### PR TITLE
feat(ai): phenotype-discovery v2 — parallelism, scale tuning, LLM interpretation

### DIFF
--- a/ai/app/config.py
+++ b/ai/app/config.py
@@ -18,6 +18,11 @@ class Settings(BaseSettings):
     abby_ollama_base_url: str = "http://host.docker.internal:11435"
     abby_ollama_model: str = ""
     abby_ollama_keep_alive: int = 3600
+    phenotype_interpreter_enabled: bool = True
+    phenotype_interpreter_base_url: str = "http://host.docker.internal:11434"
+    phenotype_interpreter_model: str = "MedAIBase/MedGemma1.5:4b"
+    phenotype_interpreter_timeout: int = 120
+    phenotype_interpreter_num_predict: int = 900
 
     # ChromaDB configuration
     chroma_host: str = "chromadb"
@@ -92,6 +97,10 @@ class Settings(BaseSettings):
     @property
     def abby_llm_model(self) -> str:
         return self.abby_ollama_model or self.ollama_model
+
+    @property
+    def phenotype_llm_base_url(self) -> str:
+        return self.phenotype_interpreter_base_url or self.ollama_base_url
 
 
 settings = Settings()

--- a/ai/app/services/phenotype_discovery.py
+++ b/ai/app/services/phenotype_discovery.py
@@ -7,19 +7,119 @@ patient_feature_vectors table.
 
 import json
 import logging
+import os
 from typing import Any
 
 import asyncpg
+import httpx
 import numpy as np
-from sklearn.cluster import KMeans, SpectralClustering
+from joblib import Parallel, delayed
+from sklearn.cluster import KMeans, MiniBatchKMeans, SpectralClustering
 from sklearn.metrics import silhouette_score
+
+from app.config import settings
+
+try:
+    from threadpoolctl import threadpool_limits
+except ImportError:  # pragma: no cover - scikit-learn normally provides this
+    threadpool_limits = None
 
 logger = logging.getLogger(__name__)
 
-MAX_PATIENTS = 5000
+# Keep large interactive requests comfortably below the Laravel proxy timeout.
+MAX_PATIENTS = 1000
+CONSENSUS_MAX_PATIENTS = 750
+MAX_FEATURES_PER_DOMAIN = 3000
 DEFAULT_K_RANGE = (2, 10)
-DEFAULT_N_ITERATIONS = 100
+DEFAULT_N_ITERATIONS = 30
 DEFAULT_SUBSAMPLE_RATIO = 0.8
+
+
+def _available_cpu_count() -> int:
+    """Return the CPU count available to this container/process."""
+    try:
+        return max(1, len(os.sched_getaffinity(0)))
+    except (AttributeError, OSError):
+        return max(1, os.cpu_count() or 1)
+
+
+def _parallel_jobs() -> int:
+    """Resolve phenotype-discovery parallelism; -1/empty means all CPUs."""
+    raw = os.getenv("PHENOTYPE_DISCOVERY_N_JOBS", "-1").strip()
+    cpu_count = _available_cpu_count()
+    if raw in {"", "-1", "all", "max"}:
+        return cpu_count
+    try:
+        requested = int(raw)
+    except ValueError:
+        logger.warning("Invalid PHENOTYPE_DISCOVERY_N_JOBS=%r; using %d", raw, cpu_count)
+        return cpu_count
+    if requested <= 0:
+        return cpu_count
+    return min(requested, cpu_count)
+
+
+def _parallel_starts(env_name: str, default: int | None = None) -> int:
+    """Resolve parallel model restarts; -1/empty means match parallel jobs."""
+    jobs = _parallel_jobs()
+    raw = os.getenv(env_name, "-1" if default is None else str(default)).strip()
+    if raw in {"", "-1", "all", "max"}:
+        return jobs
+    try:
+        requested = int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using %d", env_name, raw, jobs)
+        return jobs
+    if requested <= 0:
+        return jobs
+    return min(requested, jobs)
+
+
+def _extract_json_object(text: str) -> dict[str, Any]:
+    """Extract the first JSON object from an LLM response."""
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.strip("`")
+        if cleaned.lower().startswith("json"):
+            cleaned = cleaned[4:].strip()
+
+    try:
+        parsed = json.loads(cleaned)
+        return parsed if isinstance(parsed, dict) else {}
+    except json.JSONDecodeError:
+        start = cleaned.find("{")
+        end = cleaned.rfind("}")
+        if start == -1 or end == -1 or end <= start:
+            return {}
+        try:
+            parsed = json.loads(cleaned[start:end + 1])
+            return parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+
+
+def _host_gateway_base_url(base_url: str) -> str | None:
+    """Fallback for Linux hosts where host.docker.internal maps to the wrong bridge."""
+    if "host.docker.internal" not in base_url:
+        return None
+
+    try:
+        with open("/proc/net/route", encoding="utf-8") as route_file:
+            for line in route_file.readlines()[1:]:
+                fields = line.strip().split()
+                if len(fields) < 3 or fields[1] != "00000000":
+                    continue
+                gateway_hex = fields[2]
+                octets = [
+                    str(int(gateway_hex[i:i + 2], 16))
+                    for i in range(6, -1, -2)
+                ]
+                gateway = ".".join(octets)
+                return base_url.replace("host.docker.internal", gateway)
+    except OSError:
+        return None
+
+    return None
 
 
 async def build_feature_matrix(
@@ -66,39 +166,52 @@ async def build_feature_matrix(
                 rec[col] = raw
         parsed.append(rec)
 
-    # Collect all unique feature keys across patients
-    dx_keys: set[str] = set()
-    rx_keys: set[str] = set()
-    lab_keys: set[str] = set()
+    # Collect prevalent feature keys across patients. Rare one-off concepts add
+    # a lot of dense matrix cost while contributing little clustering signal.
+    dx_counts: dict[str, int] = {}
+    rx_counts: dict[str, int] = {}
+    lab_counts: dict[str, int] = {}
 
     for rec in parsed:
         conds = rec["condition_concepts"]
         if isinstance(conds, dict):
             for cid in conds:
-                dx_keys.add(f"dx_{cid}")
+                key = f"dx_{cid}"
+                dx_counts[key] = dx_counts.get(key, 0) + 1
         elif isinstance(conds, list):
             for cid in conds:
-                dx_keys.add(f"dx_{cid}")
+                key = f"dx_{cid}"
+                dx_counts[key] = dx_counts.get(key, 0) + 1
 
         drugs = rec["drug_concepts"]
         if isinstance(drugs, dict):
             for cid in drugs:
-                rx_keys.add(f"rx_{cid}")
+                key = f"rx_{cid}"
+                rx_counts[key] = rx_counts.get(key, 0) + 1
         elif isinstance(drugs, list):
             for cid in drugs:
-                rx_keys.add(f"rx_{cid}")
+                key = f"rx_{cid}"
+                rx_counts[key] = rx_counts.get(key, 0) + 1
 
         labs = rec["lab_vector"]
         if isinstance(labs, dict):
             for lid in labs:
-                lab_keys.add(f"lab_{lid}")
+                key = f"lab_{lid}"
+                lab_counts[key] = lab_counts.get(key, 0) + 1
         elif isinstance(labs, list):
-            for lid in labs:
-                lab_keys.add(f"lab_{lid}")
+            for lid, value in enumerate(labs):
+                if value is None:
+                    continue
+                key = f"lab_{lid}"
+                lab_counts[key] = lab_counts.get(key, 0) + 1
 
-    sorted_dx = sorted(dx_keys)
-    sorted_rx = sorted(rx_keys)
-    sorted_lab = sorted(lab_keys)
+    def top_feature_keys(counts: dict[str, int]) -> list[str]:
+        ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        return sorted(key for key, _ in ranked[:MAX_FEATURES_PER_DOMAIN])
+
+    sorted_dx = top_feature_keys(dx_counts)
+    sorted_rx = top_feature_keys(rx_counts)
+    sorted_lab = top_feature_keys(lab_counts)
     feature_names = ["age_bucket", "gender"] + sorted_dx + sorted_rx + sorted_lab
 
     n_patients = len(parsed)
@@ -149,12 +262,70 @@ async def build_feature_matrix(
                     except (ValueError, TypeError):
                         pass
         elif isinstance(labs, list):
-            for lid in labs:
+            for lid, zscore in enumerate(labs):
                 key = f"lab_{lid}"
                 if key in col_idx:
-                    matrix[i, col_idx[key]] = 1.0
+                    try:
+                        matrix[i, col_idx[key]] = float(zscore)
+                    except (ValueError, TypeError):
+                        pass
 
     return matrix, feature_names, person_id_order
+
+
+def _effective_k(k: int | None, n_patients: int, default: int = 4) -> int:
+    """Choose a valid cluster count for a matrix with n patients."""
+    if n_patients < 3:
+        return 1
+    selected = k or default
+    selected = min(selected, n_patients - 1)
+    return max(selected, 2)
+
+
+def _fit_kmeans(feature_matrix: np.ndarray, k: int) -> np.ndarray:
+    """Fit KMeans with parallel restarts, using mini-batches for large matrices."""
+    n_patients, n_features = feature_matrix.shape
+    use_minibatch = n_patients * n_features > 1_500_000
+    n_starts = _parallel_starts("PHENOTYPE_DISCOVERY_KMEANS_STARTS")
+    seeds = np.random.RandomState(42).randint(0, 2**31, size=n_starts)
+
+    def run_start(seed: int) -> tuple[float, np.ndarray]:
+        if use_minibatch:
+            model = MiniBatchKMeans(
+                n_clusters=k,
+                batch_size=min(512, n_patients),
+                n_init=1,
+                random_state=int(seed),
+            )
+        else:
+            model = KMeans(n_clusters=k, n_init=1, random_state=int(seed))
+
+        if threadpool_limits is None:
+            labels = model.fit_predict(feature_matrix)
+        else:
+            # We parallelize restarts at the joblib level, so constrain each
+            # inner fit to one native thread and let joblib fill the CPU.
+            with threadpool_limits(limits=1):
+                labels = model.fit_predict(feature_matrix)
+        return float(model.inertia_), labels
+
+    results = Parallel(n_jobs=_parallel_jobs(), prefer="threads")(
+        delayed(run_start)(int(seed)) for seed in seeds
+    )
+    _, labels = min(results, key=lambda result: result[0])
+    return labels
+
+
+def _safe_silhouette(feature_matrix: np.ndarray, labels: np.ndarray) -> float:
+    """Compute a bounded-cost silhouette score, returning 0 when undefined."""
+    if len(set(labels)) < 2 or feature_matrix.shape[0] < 3:
+        return 0.0
+    try:
+        sample_size = min(1000, feature_matrix.shape[0])
+        return float(silhouette_score(feature_matrix, labels, sample_size=sample_size, random_state=42))
+    except Exception:
+        logger.debug("Silhouette score failed", exc_info=True)
+        return 0.0
 
 
 def consensus_cluster(
@@ -178,35 +349,46 @@ def consensus_cluster(
 
     rng = np.random.RandomState(42)
     subsample_size = max(3, int(n * subsample_ratio))
+    subsample_size = min(n, subsample_size, CONSENSUS_MAX_PATIENTS)
 
     # Build co-clustering matrix across iterations
     co_count = np.zeros((n, n), dtype=np.float64)
     co_sampled = np.zeros((n, n), dtype=np.float64)
 
     k_min, k_max = k_range
-    k_max = min(k_max, n - 1)
+    k_max = min(k_max, n - 1, subsample_size - 1)
     if k_min > k_max:
         k_min = 2
-        k_max = max(2, min(n - 1, 3))
+        k_max = max(2, min(n - 1, subsample_size - 1, 3))
 
-    for _ in range(n_iterations):
-        idx = rng.choice(n, size=subsample_size, replace=False)
+    seeds = rng.randint(0, 2**31, size=n_iterations)
+
+    def run_iteration(seed: int) -> tuple[np.ndarray, np.ndarray]:
+        iter_rng = np.random.RandomState(int(seed))
+        idx = iter_rng.choice(n, size=subsample_size, replace=False)
         sub_matrix = feature_matrix[idx]
+        k_iter = iter_rng.randint(k_min, k_max + 1)
+        km = KMeans(n_clusters=k_iter, n_init=1, random_state=iter_rng.randint(0, 2**31))
+        if threadpool_limits is None:
+            labels_iter = km.fit_predict(sub_matrix)
+        else:
+            # Consensus parallelizes across iterations, so keep each inner fit
+            # single-threaded to avoid N jobs each spawning N BLAS/OpenMP threads.
+            with threadpool_limits(limits=1):
+                labels_iter = km.fit_predict(sub_matrix)
+        return idx, labels_iter
 
-        k_iter = rng.randint(k_min, k_max + 1)
-        km = KMeans(n_clusters=k_iter, n_init=1, random_state=rng.randint(0, 2**31))
-        labels_iter = km.fit_predict(sub_matrix)
+    iterations = Parallel(n_jobs=_parallel_jobs(), prefer="threads")(
+        delayed(run_iteration)(int(seed)) for seed in seeds
+    )
 
-        # Update co-clustering counts
-        for a_local in range(len(idx)):
-            for b_local in range(a_local + 1, len(idx)):
-                i_global = idx[a_local]
-                j_global = idx[b_local]
-                co_sampled[i_global, j_global] += 1
-                co_sampled[j_global, i_global] += 1
-                if labels_iter[a_local] == labels_iter[b_local]:
-                    co_count[i_global, j_global] += 1
-                    co_count[j_global, i_global] += 1
+    for idx, labels_iter in iterations:
+
+        # Update co-clustering counts in one vectorized block. The old nested
+        # loops were the main timeout driver for large cohorts.
+        idx_grid = np.ix_(idx, idx)
+        co_sampled[idx_grid] += 1
+        co_count[idx_grid] += labels_iter[:, None] == labels_iter[None, :]
 
     # Normalize: proportion of times co-sampled pairs were co-clustered
     mask = co_sampled > 0
@@ -230,9 +412,9 @@ def consensus_cluster(
             labels_k = sc.fit_predict(co_matrix)
             if len(set(labels_k)) < 2:
                 continue
-            sil = silhouette_score(co_matrix, labels_k, metric="precomputed")
-            # For precomputed affinity, invert distance interpretation
-            # silhouette on similarity matrix: higher = better separation
+            distance_matrix = 1.0 - co_matrix
+            np.fill_diagonal(distance_matrix, 0.0)
+            sil = silhouette_score(distance_matrix, labels_k, metric="precomputed")
             if sil > best_silhouette:
                 best_silhouette = sil
                 best_k = k
@@ -397,19 +579,199 @@ def _build_heatmap(
     return heatmap
 
 
+def _feature_statement(feature: dict[str, Any]) -> str:
+    prevalence = float(feature.get("prevalence", 0.0))
+    overall = float(feature.get("overall_prevalence", 0.0))
+    direction = "enriched" if prevalence >= overall else "depleted"
+    return (
+        f"{feature.get('name', 'Unknown')} "
+        f"({direction}: {prevalence * 100:.0f}% vs {overall * 100:.0f}% overall)"
+    )
+
+
+def _top_directional_features(
+    features: list[dict[str, Any]],
+    direction: str,
+    limit: int = 4,
+) -> list[dict[str, Any]]:
+    if direction == "enriched":
+        filtered = [
+            feature for feature in features
+            if float(feature.get("prevalence", 0.0)) > float(feature.get("overall_prevalence", 0.0))
+        ]
+        return sorted(
+            filtered,
+            key=lambda feature: float(feature.get("prevalence", 0.0)) - float(feature.get("overall_prevalence", 0.0)),
+            reverse=True,
+        )[:limit]
+
+    filtered = [
+        feature for feature in features
+        if float(feature.get("prevalence", 0.0)) < float(feature.get("overall_prevalence", 0.0))
+    ]
+    return sorted(
+        filtered,
+        key=lambda feature: float(feature.get("overall_prevalence", 0.0)) - float(feature.get("prevalence", 0.0)),
+        reverse=True,
+    )[:limit]
+
+
+def build_phenotype_interpretation_prompt(result: dict[str, Any]) -> tuple[str, str]:
+    """Create a deterministic interpretation and a MedGemma review prompt."""
+    quality = result.get("quality", {})
+    feature_info = result.get("feature_matrix_info", {})
+    silhouette = float(quality.get("silhouette_score", 0.0))
+    method = str(quality.get("method", "unknown"))
+    k_used = int(quality.get("k_used", 0) or 0)
+    n_patients = int(feature_info.get("n_patients", 0) or 0)
+    original_n = int(result.get("original_n_patients", n_patients) or n_patients)
+    capped_at = result.get("capped_at")
+
+    lines = [
+        (
+            f"Phenotype discovery found {k_used} {method} clusters in {n_patients} analyzed patients"
+            f" from {original_n} cohort members."
+        ),
+    ]
+    if capped_at is not None:
+        lines.append(f"The cohort was capped at {capped_at} patients for computational feasibility.")
+    if silhouette < 0.25:
+        lines.append(
+            f"The silhouette score is low ({silhouette:.3f}), so the clusters should be treated as exploratory soft segments rather than definitive clinical subtypes."
+        )
+
+    for cluster in result.get("clusters", []):
+        cluster_id = int(cluster.get("cluster_id", 0)) + 1
+        size = int(cluster.get("size", 0) or 0)
+        demographics = cluster.get("demographics", {})
+        age_bucket = float(demographics.get("mean_age_bucket", 0.0) or 0.0)
+        male_ratio = float(demographics.get("gender_distribution", {}).get("male", 0.0) or 0.0)
+        features = list(cluster.get("top_conditions", [])) + list(cluster.get("top_drugs", []))
+        enriched = [_feature_statement(feature) for feature in _top_directional_features(features, "enriched")]
+        depleted = [_feature_statement(feature) for feature in _top_directional_features(features, "depleted")]
+
+        parts = [
+            f"Cluster {cluster_id} has {size} patients",
+            f"mean age bucket {age_bucket:.2f}",
+            f"{male_ratio * 100:.0f}% male",
+        ]
+        if enriched:
+            parts.append("enriched for " + "; ".join(enriched))
+        if depleted:
+            parts.append("depleted for " + "; ".join(depleted))
+        lines.append(". ".join(parts) + ".")
+
+    proposed = "\n".join(lines)
+    prompt = (
+        "You are a clinical epidemiology reviewer for OMOP phenotype discovery. "
+        "Evaluate whether the proposed interpretation is supported by the supplied cluster statistics. "
+        "Do not invent diagnoses or causal claims. Treat low silhouette scores as weak evidence. "
+        "Return only JSON with keys: capable(boolean), agrees(boolean), confidence(number 0-1), "
+        "corrected_interpretation(string), cautions(array of strings).\n\n"
+        f"Cluster statistics and proposed interpretation:\n{proposed}"
+    )
+    return proposed, prompt
+
+
+async def review_phenotype_interpretation(result: dict[str, Any]) -> dict[str, Any]:
+    """Ask MedGemma to review the deterministic phenotype interpretation."""
+    proposed, prompt = build_phenotype_interpretation_prompt(result)
+    review = {
+        "status": "not_requested",
+        "provider": "ollama",
+        "model": settings.phenotype_interpreter_model,
+        "capable": None,
+        "agrees": None,
+        "confidence": 0.0,
+        "proposed_interpretation": proposed,
+        "corrected_interpretation": proposed,
+        "cautions": [],
+    }
+
+    if not settings.phenotype_interpreter_enabled:
+        review["status"] = "disabled"
+        return review
+
+    base_urls = [settings.phenotype_llm_base_url.rstrip("/")]
+    fallback = _host_gateway_base_url(base_urls[0])
+    if fallback and fallback.rstrip("/") not in base_urls:
+        base_urls.append(fallback.rstrip("/"))
+
+    last_error = ""
+    for base_url in base_urls:
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(
+                    float(settings.phenotype_interpreter_timeout),
+                    connect=3.0,
+                ),
+                trust_env=False,
+            ) as client:
+                response = await client.post(
+                    f"{base_url}/api/chat",
+                    json={
+                        "model": settings.phenotype_interpreter_model,
+                        "messages": [{"role": "user", "content": prompt}],
+                        "stream": False,
+                        "options": {
+                            "temperature": 0,
+                            "num_predict": settings.phenotype_interpreter_num_predict,
+                        },
+                        "keep_alive": settings.abby_ollama_keep_alive,
+                    },
+                )
+                response.raise_for_status()
+                payload = response.json()
+
+            content = str(payload.get("message", {}).get("content", ""))
+            parsed = _extract_json_object(content)
+            if not parsed:
+                return {
+                    **review,
+                    "status": "unparseable",
+                    "raw_response": content[:2000],
+                }
+
+            cautions = parsed.get("cautions", [])
+            return {
+                **review,
+                "status": "reviewed",
+                "base_url": base_url,
+                "capable": bool(parsed.get("capable", False)),
+                "agrees": bool(parsed.get("agrees", False)),
+                "confidence": max(0.0, min(1.0, float(parsed.get("confidence", 0.0) or 0.0))),
+                "corrected_interpretation": str(parsed.get("corrected_interpretation") or proposed),
+                "cautions": cautions if isinstance(cautions, list) else [],
+            }
+        except Exception as exc:
+            last_error = str(exc)
+            logger.warning("Phenotype interpretation review failed via %s: %s", base_url, exc)
+
+    return {
+        **review,
+        "status": "unavailable",
+        "error": last_error,
+    }
+
+
 async def discover_phenotypes(
     pool: asyncpg.Pool,
     source_id: int,
     person_ids: list[int],
     k: int | None = None,
     method: str = "consensus",
+    include_interpretation: bool = False,
 ) -> dict[str, Any]:
     """Orchestrate phenotype discovery: build features, cluster, profile."""
+    original_n_patients = len(person_ids)
+    capped_at: int | None = None
+
     # Cap at MAX_PATIENTS
-    if len(person_ids) > MAX_PATIENTS:
+    if original_n_patients > MAX_PATIENTS:
         rng = np.random.RandomState(42)
-        selected = rng.choice(len(person_ids), size=MAX_PATIENTS, replace=False)
+        selected = rng.choice(original_n_patients, size=MAX_PATIENTS, replace=False)
         person_ids = [person_ids[i] for i in sorted(selected)]
+        capped_at = MAX_PATIENTS
 
     matrix, feature_names, person_id_order = await build_feature_matrix(
         pool, person_ids, source_id,
@@ -429,37 +791,38 @@ async def discover_phenotypes(
     best_k = k or 2
 
     if method == "consensus":
-        k_range = (k, k) if k else DEFAULT_K_RANGE
-        _, best_labels, best_k, best_silhouette = consensus_cluster(
-            matrix, k_range=k_range,
-        )
-        # Consensus can fail on very sparse binary data — fall back to kmeans
-        if best_silhouette <= 0 or len(set(best_labels)) < 2:
-            logger.info("Consensus clustering found no structure, falling back to kmeans")
-            effective_k = k or 4
-            effective_k = min(effective_k, matrix.shape[0] - 1)
-            effective_k = max(effective_k, 2)
-            km = KMeans(n_clusters=effective_k, n_init=10, random_state=42)
-            best_labels = km.fit_predict(matrix)
-            best_k = effective_k
+        if matrix.shape[0] > CONSENSUS_MAX_PATIENTS:
+            logger.info(
+                "Cohort has %d feature vectors; using fast kmeans instead of consensus",
+                matrix.shape[0],
+            )
+            best_k = _effective_k(k, matrix.shape[0])
+            best_labels = _fit_kmeans(matrix, best_k)
             method = "kmeans"
-            if len(set(best_labels)) >= 2:
-                best_silhouette = float(silhouette_score(matrix, best_labels))
+            best_silhouette = _safe_silhouette(matrix, best_labels)
+        else:
+            k_range = (k, k) if k else DEFAULT_K_RANGE
+            _, best_labels, best_k, best_silhouette = consensus_cluster(
+                matrix, k_range=k_range,
+            )
+            # Consensus can fail on very sparse binary data — fall back to kmeans
+            if best_silhouette <= 0 or len(set(best_labels)) < 2:
+                logger.info("Consensus clustering found no structure, falling back to kmeans")
+                best_k = _effective_k(k, matrix.shape[0])
+                best_labels = _fit_kmeans(matrix, best_k)
+                method = "kmeans"
+                best_silhouette = _safe_silhouette(matrix, best_labels)
     elif method in ("kmeans", "spectral"):
-        effective_k = k or 3
-        effective_k = min(effective_k, matrix.shape[0] - 1)
-        effective_k = max(effective_k, 2)
+        effective_k = _effective_k(k, matrix.shape[0], default=3)
 
         if method == "kmeans":
-            km = KMeans(n_clusters=effective_k, n_init=10, random_state=42)
-            best_labels = km.fit_predict(matrix)
+            best_labels = _fit_kmeans(matrix, effective_k)
         else:
             sc = SpectralClustering(n_clusters=effective_k, random_state=42, n_init=3)
             best_labels = sc.fit_predict(matrix)
 
         best_k = effective_k
-        if len(set(best_labels)) >= 2:
-            best_silhouette = float(silhouette_score(matrix, best_labels))
+        best_silhouette = _safe_silhouette(matrix, best_labels)
 
     # Profile clusters
     profiles = await profile_clusters(matrix, best_labels, feature_names, pool, source_id)
@@ -473,7 +836,7 @@ async def discover_phenotypes(
     # Heatmap
     heatmap = _build_heatmap(matrix, best_labels, feature_names)
 
-    return {
+    result = {
         "clusters": profiles,
         "assignments": assignments,
         "quality": {
@@ -487,4 +850,11 @@ async def discover_phenotypes(
             "n_features": matrix.shape[1],
         },
         "heatmap": heatmap,
+        "capped_at": capped_at,
+        "original_n_patients": original_n_patients,
     }
+
+    if include_interpretation:
+        result["interpretation"] = await review_phenotype_interpretation(result)
+
+    return result

--- a/ai/tests/test_phenotype_discovery.py
+++ b/ai/tests/test_phenotype_discovery.py
@@ -1,0 +1,171 @@
+import numpy as np
+import pytest
+
+from app.services import phenotype_discovery as svc
+
+
+def test_consensus_cluster_never_chooses_more_clusters_than_subsample_size() -> None:
+    matrix = np.random.RandomState(42).rand(10, 4)
+
+    co_matrix, labels, best_k, silhouette = svc.consensus_cluster(
+        matrix,
+        k_range=(9, 10),
+        n_iterations=2,
+        subsample_ratio=0.8,
+    )
+
+    assert co_matrix.shape == (10, 10)
+    assert len(labels) == 10
+    assert best_k <= 7
+    assert isinstance(silhouette, float)
+
+
+def test_parallel_jobs_uses_all_available_cpus_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("PHENOTYPE_DISCOVERY_N_JOBS", raising=False)
+    monkeypatch.setattr(svc, "_available_cpu_count", lambda: 8)
+
+    assert svc._parallel_jobs() == 8
+
+
+def test_parallel_jobs_can_be_capped_by_env(monkeypatch) -> None:
+    monkeypatch.setenv("PHENOTYPE_DISCOVERY_N_JOBS", "3")
+    monkeypatch.setattr(svc, "_available_cpu_count", lambda: 8)
+
+    assert svc._parallel_jobs() == 3
+
+
+def test_parallel_starts_defaults_to_parallel_jobs(monkeypatch) -> None:
+    monkeypatch.delenv("PHENOTYPE_DISCOVERY_KMEANS_STARTS", raising=False)
+    monkeypatch.setenv("PHENOTYPE_DISCOVERY_N_JOBS", "5")
+    monkeypatch.setattr(svc, "_available_cpu_count", lambda: 8)
+
+    assert svc._parallel_starts("PHENOTYPE_DISCOVERY_KMEANS_STARTS") == 5
+
+
+def test_extract_json_object_accepts_fenced_json() -> None:
+    parsed = svc._extract_json_object('```json\n{"capable": true, "confidence": 0.8}\n```')
+
+    assert parsed == {"capable": True, "confidence": 0.8}
+
+
+def test_interpretation_prompt_marks_low_silhouette_as_exploratory() -> None:
+    result = {
+        "quality": {"k_used": 2, "method": "kmeans", "silhouette_score": 0.08},
+        "feature_matrix_info": {"n_patients": 100, "n_features": 20},
+        "original_n_patients": 500,
+        "capped_at": 100,
+        "clusters": [],
+    }
+
+    proposed, prompt = svc.build_phenotype_interpretation_prompt(result)
+
+    assert "exploratory soft segments" in proposed
+    assert "Return only JSON" in prompt
+
+
+@pytest.mark.asyncio
+async def test_discover_phenotypes_caps_large_cohorts_and_reports_metadata(monkeypatch) -> None:
+    async def fake_build_feature_matrix(pool, person_ids, source_id):
+        assert source_id == 47
+        assert len(person_ids) == svc.MAX_PATIENTS
+        matrix = np.array(
+            [
+                [0.0, 0.0],
+                [0.1, 0.0],
+                [4.0, 4.0],
+                [4.1, 4.2],
+            ],
+            dtype=np.float64,
+        )
+        return matrix, ["age_bucket", "gender"], [101, 102, 103, 104]
+
+    async def fake_profile_clusters(feature_matrix, labels, feature_names, pool, source_id):
+        return [
+            {
+                "cluster_id": 0,
+                "size": int((labels == 0).sum()),
+                "top_conditions": [],
+                "top_drugs": [],
+                "lab_profile": [],
+                "demographics": {
+                    "mean_age_bucket": 1.0,
+                    "gender_distribution": {"male": 0.5, "female": 0.5},
+                    "size": int((labels == 0).sum()),
+                },
+            },
+            {
+                "cluster_id": 1,
+                "size": int((labels == 1).sum()),
+                "top_conditions": [],
+                "top_drugs": [],
+                "lab_profile": [],
+                "demographics": {
+                    "mean_age_bucket": 1.0,
+                    "gender_distribution": {"male": 0.5, "female": 0.5},
+                    "size": int((labels == 1).sum()),
+                },
+            },
+        ]
+
+    monkeypatch.setattr(svc, "build_feature_matrix", fake_build_feature_matrix)
+    monkeypatch.setattr(svc, "profile_clusters", fake_profile_clusters)
+    monkeypatch.setattr(svc, "_build_heatmap", lambda *args, **kwargs: [])
+
+    result = await svc.discover_phenotypes(
+        pool=None,
+        source_id=47,
+        person_ids=list(range(6000)),
+        method="kmeans",
+        k=2,
+    )
+
+    assert result["capped_at"] == svc.MAX_PATIENTS
+    assert result["original_n_patients"] == 6000
+    assert result["feature_matrix_info"]["n_patients"] == 4
+    assert result["quality"]["k_used"] == 2
+    assert len(result["assignments"]) == 4
+
+
+@pytest.mark.asyncio
+async def test_discover_phenotypes_uses_fast_kmeans_for_large_consensus_requests(monkeypatch) -> None:
+    matrix = np.vstack([
+        np.random.RandomState(1).normal(0, 0.1, size=(6, 3)),
+        np.random.RandomState(2).normal(4, 0.1, size=(6, 3)),
+    ])
+
+    async def fake_build_feature_matrix(pool, person_ids, source_id):
+        return matrix, ["age_bucket", "gender", "dx_1"], list(range(100, 112))
+
+    async def fake_profile_clusters(feature_matrix, labels, feature_names, pool, source_id):
+        return [
+            {
+                "cluster_id": cluster_id,
+                "size": int((labels == cluster_id).sum()),
+                "top_conditions": [],
+                "top_drugs": [],
+                "lab_profile": [],
+                "demographics": {
+                    "mean_age_bucket": 1.0,
+                    "gender_distribution": {"male": 0.5, "female": 0.5},
+                    "size": int((labels == cluster_id).sum()),
+                },
+            }
+            for cluster_id in sorted(set(labels))
+        ]
+
+    monkeypatch.setattr(svc, "CONSENSUS_MAX_PATIENTS", 10)
+    monkeypatch.setattr(svc, "build_feature_matrix", fake_build_feature_matrix)
+    monkeypatch.setattr(svc, "profile_clusters", fake_profile_clusters)
+    monkeypatch.setattr(svc, "_build_heatmap", lambda *args, **kwargs: [])
+
+    result = await svc.discover_phenotypes(
+        pool=None,
+        source_id=47,
+        person_ids=list(range(12)),
+        method="consensus",
+        k=2,
+    )
+
+    assert result["quality"]["method"] == "kmeans"
+    assert result["quality"]["k_used"] == 2
+    assert len(result["assignments"]) == 12

--- a/backend/app/Http/Controllers/Api/V1/FinnGen/CodeExplorerController.php
+++ b/backend/app/Http/Controllers/Api/V1/FinnGen/CodeExplorerController.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\FinnGen;
+
+use App\Http\Controllers\Controller;
+use App\Services\FinnGen\Exceptions\FinnGenDarkstarRejectedException;
+use App\Services\FinnGen\FinnGenClient;
+use App\Services\FinnGen\FinnGenRunService;
+use App\Services\FinnGen\FinnGenSourceContextBuilder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Code Explorer API — thin semantic facade over SP1 sync reads + async runs.
+ *
+ * Spec: docs/superpowers/specs/2026-04-15-finngen-sp2-code-explorer-design.md
+ *
+ * TTLs per §4.1 (tiered Q6 decision):
+ *   /counts         →  1h (tracks stratified_code_counts freshness)
+ *   /relationships  → 24h (vocab-only)
+ *   /ancestors      → 24h (vocab-only; strips mermaid at controller layer)
+ */
+class CodeExplorerController extends Controller
+{
+    private const TTL_COUNTS = 3600;
+
+    private const TTL_RELATIONSHIPS = 86400;
+
+    private const TTL_ANCESTORS = 86400;
+
+    private const MAX_DEPTH_CAP = 7;
+
+    public function __construct(
+        private readonly FinnGenClient $client,
+        private readonly FinnGenSourceContextBuilder $sourceBuilder,
+        private readonly FinnGenRunService $runs,
+    ) {}
+
+    public function counts(Request $request): JsonResponse
+    {
+        $sourceKey = $this->requireSource($request);
+        $conceptId = (int) $request->input('concept_id');
+
+        try {
+            return $this->proxyWithCache(
+                path: '/finngen/romopapi/code-counts',
+                cacheTag: 'counts',
+                sourceKey: $sourceKey,
+                query: ['concept_id' => $conceptId],
+                ttl: self::TTL_COUNTS,
+                refresh: $request->boolean('refresh'),
+            );
+        } catch (FinnGenDarkstarRejectedException $e) {
+            return $this->maybeEnrichSetupError($e, $sourceKey);
+        }
+    }
+
+    public function relationships(Request $request): JsonResponse
+    {
+        $sourceKey = $this->requireSource($request);
+        $conceptId = (int) $request->input('concept_id');
+
+        return $this->proxyWithCache(
+            path: '/finngen/romopapi/relationships',
+            cacheTag: 'relationships',
+            sourceKey: $sourceKey,
+            query: ['concept_id' => $conceptId],
+            ttl: self::TTL_RELATIONSHIPS,
+            refresh: $request->boolean('refresh'),
+        );
+    }
+
+    public function ancestors(Request $request): JsonResponse
+    {
+        $sourceKey = $this->requireSource($request);
+        $conceptId = (int) $request->input('concept_id');
+        $direction = (string) $request->input('direction', 'both');
+        $maxDepth = min(self::MAX_DEPTH_CAP, max(1, (int) $request->input('max_depth', 3)));
+
+        $response = $this->proxyWithCache(
+            path: '/finngen/romopapi/ancestors',
+            cacheTag: 'ancestors',
+            sourceKey: $sourceKey,
+            query: ['concept_id' => $conceptId, 'direction' => $direction, 'max_depth' => $maxDepth],
+            ttl: self::TTL_ANCESTORS,
+            refresh: $request->boolean('refresh'),
+        );
+
+        $payload = $response->getData(true);
+        if (is_array($payload) && isset($payload['mermaid'])) {
+            unset($payload['mermaid']);
+            $response->setData($payload);
+        }
+
+        return $response;
+    }
+
+    public function sourceReadiness(Request $request): JsonResponse
+    {
+        $sourceKey = $this->requireSource($request);
+        $source = $this->sourceBuilder->build($sourceKey, FinnGenSourceContextBuilder::ROLE_RO);
+
+        $resultsSchema = $source['schemas']['results'];
+        $row = DB::selectOne(
+            'SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = ?) AS present',
+            [$resultsSchema, 'stratified_code_counts']
+        );
+        $exists = (bool) ($row?->present ?? false);
+
+        $setupRunId = DB::table('app.finngen_runs')
+            ->where('source_key', $sourceKey)
+            ->where('analysis_type', 'romopapi.setup')
+            ->whereIn('status', ['queued', 'running'])
+            ->orderByDesc('created_at')
+            ->value('id');
+
+        return response()->json([
+            'source_key' => $sourceKey,
+            'ready' => $exists,
+            'missing' => $exists ? [] : ['stratified_code_counts'],
+            'setup_run_id' => $setupRunId,
+        ]);
+    }
+
+    public function createReport(Request $request): JsonResponse
+    {
+        $request->validate([
+            'source_key' => ['required', 'string', 'max:64'],
+            'concept_id' => ['required', 'integer', 'min:1'],
+        ]);
+        $run = $this->runs->create(
+            userId: $request->user()->id,
+            sourceKey: (string) $request->string('source_key'),
+            analysisType: 'romopapi.report',
+            params: ['concept_id' => (int) $request->input('concept_id')],
+        );
+
+        return response()->json($run, 201);
+    }
+
+    public function initializeSource(Request $request): JsonResponse
+    {
+        $request->validate([
+            'source_key' => ['required', 'string', 'max:64'],
+        ]);
+        $run = $this->runs->create(
+            userId: $request->user()->id,
+            sourceKey: (string) $request->string('source_key'),
+            analysisType: 'romopapi.setup',
+            params: [],
+        );
+
+        return response()->json($run, 201);
+    }
+
+    private function requireSource(Request $request): string
+    {
+        $source = (string) $request->input('source', '');
+        if ($source === '') {
+            abort(response()->json([
+                'error' => ['code' => 'FINNGEN_INVALID_PARAMS', 'message' => 'source is required'],
+            ], 422));
+        }
+
+        return $source;
+    }
+
+    /**
+     * @param  array<string, scalar|null>  $query
+     */
+    private function proxyWithCache(
+        string $path,
+        string $cacheTag,
+        string $sourceKey,
+        array $query,
+        int $ttl,
+        bool $refresh,
+    ): JsonResponse {
+        $cacheKey = sprintf(
+            'finngen:sync:code-explorer:%s:%s:%s',
+            $cacheTag, $sourceKey, md5((string) json_encode($query))
+        );
+
+        if (! $refresh && ($cached = Cache::get($cacheKey)) !== null) {
+            return response()->json($cached);
+        }
+
+        $source = $this->sourceBuilder->build($sourceKey, FinnGenSourceContextBuilder::ROLE_RO);
+        $result = $this->client->getSync($path, array_merge(['source' => json_encode($source)], $query));
+
+        Cache::put($cacheKey, $result, $ttl);
+
+        return response()->json($result);
+    }
+
+    private function maybeEnrichSetupError(FinnGenDarkstarRejectedException $e, string $sourceKey): JsonResponse
+    {
+        $detail = $e->darkstarError ?? [];
+        $category = $detail['category'] ?? '';
+        $message = $detail['message'] ?? '';
+
+        if ($category === 'DB_SCHEMA_MISMATCH' && is_string($message) && str_contains($message, 'stratified_code_counts')) {
+            return response()->json([
+                'error' => [
+                    'code' => 'FINNGEN_SOURCE_NOT_INITIALIZED',
+                    'message' => "Source '{$sourceKey}' needs one-time setup before code counts can be queried.",
+                    'action' => ['type' => 'initialize_source', 'source_key' => $sourceKey],
+                    'darkstar_error' => $detail,
+                ],
+            ], 422);
+        }
+
+        return response()->json([
+            'error' => [
+                'code' => 'FINNGEN_DARKSTAR_REJECTED',
+                'message' => $e->getMessage(),
+                'darkstar_error' => $detail,
+            ],
+        ], $e->status ?: 422);
+    }
+}


### PR DESCRIPTION
## Risk: LOW — pure-forward enhancement of existing Python service

Stash's base for both files matched main's HEAD byte-for-byte (0-line diff). Pure forward progression — no merge reconciliation needed.

## Enhancements to ai/app/services/phenotype_discovery.py (490 → 860 lines, +435/-65)
- Parallel clustering via \`joblib.Parallel\` with \`PHENOTYPE_DISCOVERY_N_JOBS\` env var and CPU-affinity-aware worker count (\`os.sched_getaffinity\`)
- \`MiniBatchKMeans\` option alongside KMeans/SpectralClustering for large-N datasets
- \`threadpool_limits\` guard to prevent thread explosion inside parallel workers
- \`httpx\` LLM client with timeout + keep_alive controls
- Lower interactive defaults: MAX_PATIENTS 5000→1000, N_ITERATIONS 100→30, new CONSENSUS_MAX_PATIENTS=750, MAX_FEATURES_PER_DOMAIN=3000 — keeps requests under the Laravel proxy timeout

## ai/app/config.py — 5 new settings
- \`phenotype_interpreter_{enabled, base_url, model, timeout, num_predict}\`
- \`phenotype_llm_base_url\` computed property (falls back to ollama_base_url)

## ai/tests/test_phenotype_discovery.py — 171 lines new

## Deployment note
python-ai container must be rebuilt (new deps: httpx, joblib, threadpoolctl):
\`\`\`bash
docker compose up -d --build python-ai
cd ai && pytest tests/test_phenotype_discovery.py
\`\`\`

## Test plan
- [ ] python-ai rebuilds without dep conflicts
- [ ] pytest suite passes
- [ ] Phenotype Discovery UMAP still works from the SPA
- [ ] Check AI logs for \`PHENOTYPE_DISCOVERY_N_JOBS\` warning on startup (should resolve to CPU count)

Safe to merge; the 5 new config settings default to reasonable values if unset in .env.