### PR TITLE
feat(patient-similarity): saved runs + AI step interpretation

### DIFF
--- a/backend/app/Models/App/PatientSimilarityInterpretation.php
+++ b/backend/app/Models/App/PatientSimilarityInterpretation.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Models\App;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PatientSimilarityInterpretation extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'patient_similarity_run_id',
+        'patient_similarity_run_step_id',
+        'mode',
+        'step_id',
+        'source_id',
+        'target_cohort_id',
+        'comparator_cohort_id',
+        'result_hash',
+        'provider',
+        'model',
+        'status',
+        'summary',
+        'interpretation',
+        'clinical_implications',
+        'methodologic_cautions',
+        'recommended_next_steps',
+        'confidence',
+        'sanitized_result',
+        'error',
+        'raw_response',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'clinical_implications' => 'array',
+            'methodologic_cautions' => 'array',
+            'recommended_next_steps' => 'array',
+            'sanitized_result' => 'array',
+            'confidence' => 'float',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<PatientSimilarityRun, $this>
+     */
+    public function run(): BelongsTo
+    {
+        return $this->belongsTo(PatientSimilarityRun::class, 'patient_similarity_run_id');
+    }
+
+    /**
+     * @return BelongsTo<PatientSimilarityRunStep, $this>
+     */
+    public function runStep(): BelongsTo
+    {
+        return $this->belongsTo(PatientSimilarityRunStep::class, 'patient_similarity_run_step_id');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toInterpretationPayload(string $cacheStatus = 'hit'): array
+    {
+        return [
+            'id' => $this->id,
+            'run_id' => $this->patient_similarity_run_id,
+            'run_step_id' => $this->patient_similarity_run_step_id,
+            'cache_status' => $cacheStatus,
+            'result_hash' => $this->result_hash,
+            'status' => $this->status,
+            'provider' => $this->provider ?? 'analytics_llm',
+            'model' => $this->model ?? 'configured AI provider',
+            'mode' => $this->mode,
+            'step_id' => $this->step_id,
+            'summary' => $this->summary ?? '',
+            'interpretation' => $this->interpretation ?? '',
+            'clinical_implications' => $this->clinical_implications ?? [],
+            'methodologic_cautions' => $this->methodologic_cautions ?? [],
+            'recommended_next_steps' => $this->recommended_next_steps ?? [],
+            'confidence' => $this->confidence ?? 0.0,
+            'error' => $this->error,
+            'raw_response' => $this->raw_response,
+            'sanitized_result' => $this->sanitized_result ?? [],
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/backend/app/Models/App/PatientSimilarityRun.php
+++ b/backend/app/Models/App/PatientSimilarityRun.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Models\App;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PatientSimilarityRun extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'mode',
+        'name',
+        'source_id',
+        'target_cohort_id',
+        'comparator_cohort_id',
+        'similarity_mode',
+        'settings_json',
+        'status',
+        'last_opened_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'settings_json' => 'array',
+            'last_opened_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<Source, $this>
+     */
+    public function source(): BelongsTo
+    {
+        return $this->belongsTo(Source::class);
+    }
+
+    /**
+     * @return BelongsTo<CohortDefinition, $this>
+     */
+    public function targetCohort(): BelongsTo
+    {
+        return $this->belongsTo(CohortDefinition::class, 'target_cohort_id');
+    }
+
+    /**
+     * @return BelongsTo<CohortDefinition, $this>
+     */
+    public function comparatorCohort(): BelongsTo
+    {
+        return $this->belongsTo(CohortDefinition::class, 'comparator_cohort_id');
+    }
+
+    /**
+     * @return HasMany<PatientSimilarityRunStep, $this>
+     */
+    public function steps(): HasMany
+    {
+        return $this->hasMany(PatientSimilarityRunStep::class);
+    }
+
+    /**
+     * @return HasMany<PatientSimilarityInterpretation, $this>
+     */
+    public function interpretations(): HasMany
+    {
+        return $this->hasMany(PatientSimilarityInterpretation::class);
+    }
+}

--- a/backend/app/Models/App/PatientSimilarityRunStep.php
+++ b/backend/app/Models/App/PatientSimilarityRunStep.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models\App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PatientSimilarityRunStep extends Model
+{
+    protected $fillable = [
+        'patient_similarity_run_id',
+        'step_id',
+        'status',
+        'summary',
+        'result_json',
+        'result_hash',
+        'execution_time_ms',
+        'completed_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'result_json' => 'array',
+            'completed_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<PatientSimilarityRun, $this>
+     */
+    public function run(): BelongsTo
+    {
+        return $this->belongsTo(PatientSimilarityRun::class, 'patient_similarity_run_id');
+    }
+
+    /**
+     * @return HasMany<PatientSimilarityInterpretation, $this>
+     */
+    public function interpretations(): HasMany
+    {
+        return $this->hasMany(PatientSimilarityInterpretation::class);
+    }
+}

--- a/backend/app/Services/PatientSimilarity/CohortSimilarityInterpretationService.php
+++ b/backend/app/Services/PatientSimilarity/CohortSimilarityInterpretationService.php
@@ -1,0 +1,857 @@
+<?php
+
+namespace App\Services\PatientSimilarity;
+
+use App\Exceptions\AiProviderNotConfiguredException;
+use App\Models\App\AiProviderSetting;
+use App\Models\App\PatientSimilarityInterpretation;
+use App\Services\AI\AnalyticsLlmService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
+
+class CohortSimilarityInterpretationService
+{
+    /** @var array<int, string> */
+    private const STEP_IDS = [
+        'profile',
+        'balance',
+        'psm',
+        'landscape',
+        'phenotypes',
+        'snf',
+        'centroid',
+        'similar',
+    ];
+
+    public function __construct(
+        private readonly AnalyticsLlmService $llm,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @param  array<string, mixed>  $context
+     * @param  array<int, array<string, mixed>>  $priorStepSummaries
+     * @return array<string, mixed>
+     */
+    public function interpret(
+        string $mode,
+        string $stepId,
+        array $result,
+        array $context = [],
+        array $priorStepSummaries = [],
+        ?int $userId = null,
+        ?int $runId = null,
+        ?int $runStepId = null,
+        bool $forceRefresh = false,
+    ): array {
+        $provider = $this->activeProviderMetadata();
+        $sanitizedResult = $this->summarizeResultForStep($stepId, $result);
+        $sanitizedContext = $this->summarizeContext($context);
+        $sanitizedPrior = $this->summarizePriorSteps($priorStepSummaries);
+        $resultHash = $this->hashStepResult($mode, $stepId, $sanitizedResult, $sanitizedContext);
+
+        if ($userId !== null && ! $forceRefresh) {
+            $cached = $this->findCachedInterpretation($userId, $mode, $stepId, $sanitizedContext, $resultHash);
+            if ($cached) {
+                return $this->linkCachedInterpretation($cached, $runId, $runStepId)->toInterpretationPayload('hit');
+            }
+        }
+
+        $baseResponse = [
+            'id' => null,
+            'run_id' => $runId,
+            'run_step_id' => $runStepId,
+            'cache_status' => $forceRefresh ? 'refreshed' : 'miss',
+            'result_hash' => $resultHash,
+            'status' => 'not_requested',
+            'provider' => $provider['provider'] ?? 'analytics_llm',
+            'model' => $provider['model'] ?? 'configured AI provider',
+            'mode' => $mode,
+            'step_id' => $stepId,
+            'summary' => '',
+            'interpretation' => '',
+            'clinical_implications' => [],
+            'methodologic_cautions' => [],
+            'recommended_next_steps' => [],
+            'confidence' => 0.0,
+        ];
+
+        try {
+            $content = $this->llm->chat(
+                messages: [
+                    ['role' => 'user', 'content' => $this->buildPrompt(
+                        mode: $mode,
+                        stepId: $stepId,
+                        result: $sanitizedResult,
+                        context: $sanitizedContext,
+                        priorStepSummaries: $sanitizedPrior,
+                    )],
+                ],
+                options: [
+                    'system' => 'You are a senior clinical epidemiologist interpreting aggregate OHDSI/OMOP cohort similarity analyses for researchers. Return only valid JSON.',
+                    'max_tokens' => 1800,
+                    'temperature' => 0.1,
+                ],
+            );
+
+            $parsed = $this->extractJsonObject($content);
+            if ($parsed === []) {
+                $response = [
+                    ...$baseResponse,
+                    'status' => 'unparseable',
+                    'raw_response' => substr($content, 0, 2000),
+                    'sanitized_result' => $sanitizedResult,
+                ];
+
+                return $this->persistIfPossible($response, $userId, $runId, $runStepId, $sanitizedContext);
+            }
+
+            $response = [
+                ...$baseResponse,
+                'status' => 'interpreted',
+                'summary' => (string) ($parsed['summary'] ?? ''),
+                'interpretation' => (string) ($parsed['interpretation'] ?? ''),
+                'clinical_implications' => $this->stringList($parsed['clinical_implications'] ?? []),
+                'methodologic_cautions' => $this->stringList($parsed['methodologic_cautions'] ?? []),
+                'recommended_next_steps' => $this->stringList($parsed['recommended_next_steps'] ?? []),
+                'confidence' => $this->clampConfidence($parsed['confidence'] ?? 0.0),
+                'sanitized_result' => $sanitizedResult,
+            ];
+
+            return $this->persistIfPossible($response, $userId, $runId, $runStepId, $sanitizedContext);
+        } catch (AiProviderNotConfiguredException $e) {
+            $response = [
+                ...$baseResponse,
+                'status' => 'unavailable',
+                'error' => $e->getMessage(),
+                'sanitized_result' => $sanitizedResult,
+            ];
+
+            return $this->persistIfPossible($response, $userId, $runId, $runStepId, $sanitizedContext);
+        } catch (\Throwable $e) {
+            Log::warning('Cohort similarity interpretation failed', [
+                'mode' => $mode,
+                'step_id' => $stepId,
+                'provider' => $baseResponse['provider'],
+                'model' => $baseResponse['model'],
+                'error' => $e->getMessage(),
+            ]);
+
+            $response = [
+                ...$baseResponse,
+                'status' => 'unavailable',
+                'error' => $e->getMessage(),
+                'sanitized_result' => $sanitizedResult,
+            ];
+
+            return $this->persistIfPossible($response, $userId, $runId, $runStepId, $sanitizedContext);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @param  array<string, mixed>  $context
+     * @param  array<int, array<string, mixed>>  $priorStepSummaries
+     */
+    public function buildPrompt(
+        string $mode,
+        string $stepId,
+        array $result,
+        array $context = [],
+        array $priorStepSummaries = [],
+    ): string {
+        $payload = [
+            'workflow_mode' => $mode,
+            'step_id' => $stepId,
+            'step_name' => $this->stepName($stepId),
+            'research_context' => $context,
+            'prior_step_summaries' => $priorStepSummaries,
+            'aggregate_result' => $result,
+        ];
+
+        $json = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        return implode("\n\n", [
+            'Interpret this aggregate Cohort Similarities analysis step for a researcher.',
+            'Use only the supplied aggregate result. Do not infer individual patient facts, protected health information, diagnoses that are not supported by the data, or causal effects.',
+            'When the statistics are weak, unstable, capped, sparse, or imbalanced, make that uncertainty explicit. Prefer practical research guidance over generic prose.',
+            'Return only JSON with these keys: summary(string), interpretation(string), clinical_implications(array of strings), methodologic_cautions(array of strings), recommended_next_steps(array of strings), confidence(number 0-1).',
+            "Aggregate analysis payload:\n{$json}",
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    public function summarizeResultForStep(string $stepId, array $result): array
+    {
+        return match ($stepId) {
+            'profile' => $this->summarizeProfile($result),
+            'balance' => $this->summarizeBalance($result),
+            'psm' => $this->summarizePsm($result),
+            'landscape' => $this->summarizeLandscape($result),
+            'phenotypes' => $this->summarizePhenotypes($result),
+            'snf' => $this->summarizeSnf($result),
+            'centroid' => $this->summarizeCentroid($result),
+            'similar' => $this->summarizeSimilarPatients($result),
+            default => $this->redactPatientLevelData($result),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @param  array<string, mixed>  $context
+     */
+    public function hashStepResult(string $mode, string $stepId, array $result, array $context = []): string
+    {
+        return hash('sha256', json_encode([
+            'mode' => $mode,
+            'step_id' => $stepId,
+            'context' => $this->normalizeForHash($context),
+            'result' => $this->normalizeForHash($result),
+        ], JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function stepIds(): array
+    {
+        return self::STEP_IDS;
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function summarizeProfile(array $result): array
+    {
+        $divergence = [];
+        foreach (($result['divergence'] ?? []) as $dimension => $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+            $divergence[$dimension] = [
+                'score' => $row['score'] ?? null,
+                'label' => $row['label'] ?? null,
+            ];
+        }
+
+        uasort($divergence, fn (array $a, array $b): int => ((float) ($b['score'] ?? 0)) <=> ((float) ($a['score'] ?? 0)));
+
+        return [
+            'source_cohort' => $this->summarizeCohort($result['source_cohort'] ?? []),
+            'target_cohort' => $this->summarizeCohort($result['target_cohort'] ?? []),
+            'overall_divergence' => $result['overall_divergence'] ?? null,
+            'dimension_divergence' => $divergence,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function summarizeBalance(array $result): array
+    {
+        $covariates = is_array($result['covariates'] ?? null) ? $result['covariates'] : [];
+        $total = count($covariates);
+        $meanAbs = $total > 0
+            ? array_sum(array_map(fn ($row): float => abs((float) ($row['smd'] ?? 0.0)), $covariates)) / $total
+            : 0.0;
+
+        $top = $this->topRowsByAbsoluteValue($covariates, 'smd', 12);
+        $distributional = is_array($result['distributional_divergence'] ?? null)
+            ? $this->topRowsByAbsoluteValue($result['distributional_divergence'], 'value', 8)
+            : [];
+
+        return [
+            'overall_divergence' => $result['overall_divergence'] ?? null,
+            'covariate_count' => $total,
+            'imbalanced_covariates' => count(array_filter($covariates, fn ($row): bool => abs((float) ($row['smd'] ?? 0.0)) >= 0.1)),
+            'high_imbalance_covariates' => count(array_filter($covariates, fn ($row): bool => abs((float) ($row['smd'] ?? 0.0)) >= 0.2)),
+            'mean_absolute_smd' => round($meanAbs, 4),
+            'top_imbalanced_covariates' => array_map(fn (array $row): array => [
+                'covariate' => $row['covariate'] ?? null,
+                'smd' => $row['smd'] ?? null,
+                'domain' => $row['domain'] ?? null,
+                'type' => $row['type'] ?? null,
+            ], $top),
+            'distributional_divergence' => array_map(fn (array $row): array => [
+                'dimension' => $row['dimension'] ?? null,
+                'metric' => $row['metric'] ?? null,
+                'value' => $row['value'] ?? null,
+                'interpretation' => $row['interpretation'] ?? null,
+            ], $distributional),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function summarizePsm(array $result): array
+    {
+        $before = is_array($result['balance']['before'] ?? null) ? $result['balance']['before'] : [];
+        $after = is_array($result['balance']['after'] ?? null) ? $result['balance']['after'] : [];
+
+        return [
+            'model_metrics' => $result['model_metrics'] ?? [],
+            'matched_pair_count' => count(is_array($result['matched_pairs'] ?? null) ? $result['matched_pairs'] : []),
+            'unmatched_counts' => [
+                'target' => count(is_array($result['unmatched']['target_ids'] ?? null) ? $result['unmatched']['target_ids'] : []),
+                'comparator' => count(is_array($result['unmatched']['comparator_ids'] ?? null) ? $result['unmatched']['comparator_ids'] : []),
+            ],
+            'balance_before' => $this->balanceSummaryRows($before),
+            'balance_after' => $this->balanceSummaryRows($after),
+            'worst_residual_covariates' => array_map(fn (array $row): array => [
+                'covariate' => $row['covariate'] ?? null,
+                'smd' => $row['smd'] ?? null,
+                'domain' => $row['domain'] ?? null,
+                'type' => $row['type'] ?? null,
+            ], $this->topRowsByAbsoluteValue($after, 'smd', 10)),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function summarizeLandscape(array $result): array
+    {
+        $points = is_array($result['points'] ?? null) ? $result['points'] : [];
+        $clusterCounts = [];
+        $cohortCount = 0;
+        foreach ($points as $point) {
+            if (! is_array($point)) {
+                continue;
+            }
+            $cluster = (string) ($point['cluster_id'] ?? 'unknown');
+            $clusterCounts[$cluster] = ($clusterCounts[$cluster] ?? 0) + 1;
+            if ((bool) ($point['is_cohort_member'] ?? false)) {
+                $cohortCount++;
+            }
+        }
+        arsort($clusterCounts);
+
+        return [
+            'n_patients' => $result['n_patients'] ?? count($points),
+            'dimensions' => $result['dimensions'] ?? null,
+            'n_clusters' => $result['n_clusters'] ?? count($clusterCounts),
+            'cohort_member_points' => $cohortCount,
+            'non_cohort_points' => max(0, count($points) - $cohortCount),
+            'cluster_sizes' => $clusterCounts,
+            'stats' => $result['stats'] ?? [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function summarizePhenotypes(array $result): array
+    {
+        $clusters = [];
+        foreach (($result['clusters'] ?? []) as $cluster) {
+            if (! is_array($cluster)) {
+                continue;
+            }
+            $clusters[] = [
+                'cluster_id' => $cluster['cluster_id'] ?? null,
+                'size' => $cluster['size'] ?? null,
+                'demographics' => $cluster['demographics'] ?? [],
+                'top_conditions' => $this->summarizeFeatures($cluster['top_conditions'] ?? [], 8),
+                'top_drugs' => $this->summarizeFeatures($cluster['top_drugs'] ?? [], 6),
+            ];
+        }
+
+        return [
+            'quality' => $result['quality'] ?? [],
+            'feature_matrix_info' => $result['feature_matrix_info'] ?? [],
+            'capped_at' => $result['capped_at'] ?? null,
+            'original_n_patients' => $result['original_n_patients'] ?? null,
+            'clusters' => $clusters,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function summarizeSnf(array $result): array
+    {
+        $communities = is_array($result['communities'] ?? null) ? $result['communities'] : [];
+        $sizes = array_map(fn ($community): int => is_array($community) ? (int) ($community['size'] ?? 0) : 0, $communities);
+        rsort($sizes);
+
+        return [
+            'n_patients' => $result['n_patients'] ?? null,
+            'capped_at' => $result['capped_at'] ?? null,
+            'community_count' => count($communities),
+            'largest_community_sizes' => array_slice($sizes, 0, 10),
+            'modality_contributions' => $result['modality_contributions'] ?? [],
+            'convergence' => $result['convergence'] ?? [],
+            'edge_count' => count(is_array($result['edges'] ?? null) ? $result['edges'] : []),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function summarizeCentroid(array $result): array
+    {
+        return [
+            'cohort_definition_id' => $result['cohort_definition_id'] ?? null,
+            'source_id' => $result['source_id'] ?? null,
+            'member_count' => $result['member_count'] ?? null,
+            'generated' => $result['generated'] ?? null,
+            'dimensions_available' => $result['dimensions_available'] ?? [],
+            'dimensions' => $result['dimensions'] ?? [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    private function summarizeSimilarPatients(array $result): array
+    {
+        $patients = is_array($result['similar_patients'] ?? null) ? $result['similar_patients'] : [];
+        $scores = array_map(fn ($row): float => is_array($row) ? (float) ($row['overall_score'] ?? 0.0) : 0.0, $patients);
+        rsort($scores);
+
+        $dimensionSums = [];
+        $dimensionCounts = [];
+        foreach ($patients as $patient) {
+            if (! is_array($patient) || ! is_array($patient['dimension_scores'] ?? null)) {
+                continue;
+            }
+            foreach ($patient['dimension_scores'] as $dimension => $score) {
+                if ($score === null) {
+                    continue;
+                }
+                $dimensionSums[$dimension] = ($dimensionSums[$dimension] ?? 0.0) + (float) $score;
+                $dimensionCounts[$dimension] = ($dimensionCounts[$dimension] ?? 0) + 1;
+            }
+        }
+
+        $dimensionMeans = [];
+        foreach ($dimensionSums as $dimension => $sum) {
+            $dimensionMeans[$dimension] = round($sum / max(1, $dimensionCounts[$dimension] ?? 1), 4);
+        }
+        arsort($dimensionMeans);
+
+        return [
+            'mode' => $result['mode'] ?? null,
+            'returned_count' => count($patients),
+            'score_summary' => [
+                'max' => $scores[0] ?? null,
+                'median' => $this->median($scores),
+                'min' => $scores !== [] ? min($scores) : null,
+            ],
+            'mean_dimension_scores' => $dimensionMeans,
+            'metadata' => $this->redactPatientLevelData(is_array($result['metadata'] ?? null) ? $result['metadata'] : []),
+            'diagnostics' => $this->redactPatientLevelData(is_array($result['metadata']['diagnostics'] ?? null) ? $result['metadata']['diagnostics'] : []),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>|mixed  $cohort
+     * @return array<string, mixed>
+     */
+    private function summarizeCohort(mixed $cohort): array
+    {
+        if (! is_array($cohort)) {
+            return [];
+        }
+
+        return [
+            'cohort_definition_id' => $cohort['cohort_definition_id'] ?? null,
+            'name' => $cohort['name'] ?? null,
+            'member_count' => $cohort['member_count'] ?? null,
+            'dimensions' => $cohort['dimensions'] ?? [],
+        ];
+    }
+
+    /**
+     * @param  array<int, mixed>  $rows
+     * @return array<string, mixed>
+     */
+    private function balanceSummaryRows(array $rows): array
+    {
+        $total = count($rows);
+        $meanAbs = $total > 0
+            ? array_sum(array_map(fn ($row): float => is_array($row) ? abs((float) ($row['smd'] ?? 0.0)) : 0.0, $rows)) / $total
+            : 0.0;
+
+        return [
+            'covariate_count' => $total,
+            'imbalanced_covariates' => count(array_filter($rows, fn ($row): bool => is_array($row) && abs((float) ($row['smd'] ?? 0.0)) >= 0.1)),
+            'high_imbalance_covariates' => count(array_filter($rows, fn ($row): bool => is_array($row) && abs((float) ($row['smd'] ?? 0.0)) >= 0.2)),
+            'mean_absolute_smd' => round($meanAbs, 4),
+        ];
+    }
+
+    /**
+     * @param  array<int, mixed>  $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function topRowsByAbsoluteValue(array $rows, string $key, int $limit): array
+    {
+        $filtered = array_values(array_filter($rows, fn ($row): bool => is_array($row)));
+        usort($filtered, fn (array $a, array $b): int => abs((float) ($b[$key] ?? 0.0)) <=> abs((float) ($a[$key] ?? 0.0)));
+
+        return array_slice($filtered, 0, $limit);
+    }
+
+    /**
+     * @param  array<int, mixed>  $features
+     * @return array<int, array<string, mixed>>
+     */
+    private function summarizeFeatures(mixed $features, int $limit): array
+    {
+        if (! is_array($features)) {
+            return [];
+        }
+
+        $rows = array_values(array_filter($features, fn ($feature): bool => is_array($feature)));
+        usort($rows, function (array $a, array $b): int {
+            $aDelta = abs((float) ($a['prevalence'] ?? 0.0) - (float) ($a['overall_prevalence'] ?? 0.0));
+            $bDelta = abs((float) ($b['prevalence'] ?? 0.0) - (float) ($b['overall_prevalence'] ?? 0.0));
+
+            return $bDelta <=> $aDelta;
+        });
+
+        return array_map(fn (array $feature): array => [
+            'concept_id' => $feature['concept_id'] ?? null,
+            'name' => $feature['name'] ?? null,
+            'prevalence' => $feature['prevalence'] ?? null,
+            'overall_prevalence' => $feature['overall_prevalence'] ?? null,
+        ], array_slice($rows, 0, $limit));
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function summarizeContext(array $context): array
+    {
+        return $this->redactPatientLevelData($context);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $priorStepSummaries
+     * @return array<int, array<string, mixed>>
+     */
+    private function summarizePriorSteps(array $priorStepSummaries): array
+    {
+        return array_map(fn (array $step): array => [
+            'step_id' => $step['step_id'] ?? null,
+            'summary' => $step['summary'] ?? null,
+            'status' => $step['status'] ?? null,
+        ], array_slice($priorStepSummaries, 0, 8));
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     * @return array<string, mixed>
+     */
+    private function redactPatientLevelData(array $value): array
+    {
+        $blockedKeys = [
+            'person_id',
+            'person_ids',
+            'member_ids',
+            'target_ids',
+            'comparator_ids',
+            'target_id',
+            'comparator_id',
+            'matched_pairs',
+            'propensity_scores',
+            'points',
+            'edges',
+            'assignments',
+        ];
+
+        $redact = function (mixed $item) use (&$redact, $blockedKeys): mixed {
+            if (! is_array($item)) {
+                return $item;
+            }
+
+            $output = [];
+            foreach ($item as $key => $child) {
+                if (is_string($key) && in_array($key, $blockedKeys, true)) {
+                    $output[$key.'_count'] = is_array($child) ? count($child) : null;
+
+                    continue;
+                }
+                $output[$key] = $redact($child);
+            }
+
+            return $output;
+        };
+
+        $redacted = $redact($value);
+
+        return is_array($redacted) ? $redacted : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    private function findCachedInterpretation(
+        int $userId,
+        string $mode,
+        string $stepId,
+        array $context,
+        string $resultHash,
+    ): ?PatientSimilarityInterpretation {
+        $query = PatientSimilarityInterpretation::query()
+            ->where('user_id', $userId)
+            ->where('mode', $mode)
+            ->where('step_id', $stepId)
+            ->where('result_hash', $resultHash)
+            ->where('status', 'interpreted');
+
+        $this->applyInterpretationContext($query, $context);
+
+        return $query->latest('updated_at')
+            ->first();
+    }
+
+    private function linkCachedInterpretation(
+        PatientSimilarityInterpretation $cached,
+        ?int $runId,
+        ?int $runStepId,
+    ): PatientSimilarityInterpretation {
+        if ($runId === null) {
+            return $cached;
+        }
+
+        $linked = PatientSimilarityInterpretation::query()
+            ->where('user_id', $cached->user_id)
+            ->where('patient_similarity_run_id', $runId)
+            ->where('step_id', $cached->step_id)
+            ->where('result_hash', $cached->result_hash)
+            ->first();
+
+        if ($linked) {
+            if ($runStepId !== null && $linked->patient_similarity_run_step_id !== $runStepId) {
+                $linked->update(['patient_similarity_run_step_id' => $runStepId]);
+                $linked->refresh();
+            }
+
+            return $linked;
+        }
+
+        return PatientSimilarityInterpretation::query()->create([
+            'user_id' => $cached->user_id,
+            'patient_similarity_run_id' => $runId,
+            'patient_similarity_run_step_id' => $runStepId,
+            'mode' => $cached->mode,
+            'step_id' => $cached->step_id,
+            'source_id' => $cached->source_id,
+            'target_cohort_id' => $cached->target_cohort_id,
+            'comparator_cohort_id' => $cached->comparator_cohort_id,
+            'result_hash' => $cached->result_hash,
+            'provider' => $cached->provider,
+            'model' => $cached->model,
+            'status' => $cached->status,
+            'summary' => $cached->summary,
+            'interpretation' => $cached->interpretation,
+            'clinical_implications' => $cached->clinical_implications,
+            'methodologic_cautions' => $cached->methodologic_cautions,
+            'recommended_next_steps' => $cached->recommended_next_steps,
+            'confidence' => $cached->confidence,
+            'sanitized_result' => $cached->sanitized_result,
+            'error' => $cached->error,
+            'raw_response' => $cached->raw_response,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $response
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function persistIfPossible(
+        array $response,
+        ?int $userId,
+        ?int $runId,
+        ?int $runStepId,
+        array $context,
+    ): array {
+        if ($userId === null) {
+            return $response;
+        }
+
+        $interpretation = PatientSimilarityInterpretation::query()->updateOrCreate(
+            [
+                'user_id' => $userId,
+                'patient_similarity_run_id' => $runId,
+                'step_id' => (string) $response['step_id'],
+                'result_hash' => (string) $response['result_hash'],
+            ],
+            [
+                'patient_similarity_run_step_id' => $runStepId,
+                'mode' => (string) $response['mode'],
+                'source_id' => $context['source_id'] ?? null,
+                'target_cohort_id' => $context['target_cohort_id'] ?? null,
+                'comparator_cohort_id' => $context['comparator_cohort_id'] ?? null,
+                'provider' => (string) $response['provider'],
+                'model' => (string) $response['model'],
+                'status' => (string) $response['status'],
+                'summary' => (string) ($response['summary'] ?? ''),
+                'interpretation' => (string) ($response['interpretation'] ?? ''),
+                'clinical_implications' => $response['clinical_implications'] ?? [],
+                'methodologic_cautions' => $response['methodologic_cautions'] ?? [],
+                'recommended_next_steps' => $response['recommended_next_steps'] ?? [],
+                'confidence' => $response['confidence'] ?? 0.0,
+                'sanitized_result' => $response['sanitized_result'] ?? [],
+                'error' => $response['error'] ?? null,
+                'raw_response' => $response['raw_response'] ?? null,
+            ],
+        );
+
+        return $interpretation->toInterpretationPayload((string) $response['cache_status']);
+    }
+
+    /**
+     * @param  Builder<PatientSimilarityInterpretation>  $query
+     * @param  array<string, mixed>  $context
+     */
+    private function applyInterpretationContext(Builder $query, array $context): void
+    {
+        foreach (['source_id', 'target_cohort_id', 'comparator_cohort_id'] as $key) {
+            if (($context[$key] ?? null) === null) {
+                $query->whereNull($key);
+            } else {
+                $query->where($key, $context[$key]);
+            }
+        }
+    }
+
+    private function normalizeForHash(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        if (array_is_list($value)) {
+            return array_map(fn (mixed $item): mixed => $this->normalizeForHash($item), $value);
+        }
+
+        ksort($value);
+
+        foreach ($value as $key => $item) {
+            $value[$key] = $this->normalizeForHash($item);
+        }
+
+        return $value;
+    }
+
+    private function stepName(string $stepId): string
+    {
+        return match ($stepId) {
+            'profile' => 'Profile Comparison',
+            'balance' => 'Covariate Balance',
+            'psm' => 'Propensity Score Matching',
+            'landscape' => 'UMAP Landscape',
+            'phenotypes' => 'Phenotype Discovery',
+            'snf' => 'Network Fusion',
+            'centroid' => 'Centroid Profile',
+            'similar' => 'Similar Patients',
+            default => $stepId,
+        };
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_map(fn ($item): string => (string) $item, $value));
+    }
+
+    /**
+     * @param  array<int, float>  $values
+     */
+    private function median(array $values): ?float
+    {
+        if ($values === []) {
+            return null;
+        }
+
+        sort($values);
+        $count = count($values);
+        $middle = intdiv($count, 2);
+
+        if ($count % 2 === 1) {
+            return round($values[$middle], 4);
+        }
+
+        return round(($values[$middle - 1] + $values[$middle]) / 2, 4);
+    }
+
+    private function clampConfidence(mixed $confidence): float
+    {
+        $value = is_numeric($confidence) ? (float) $confidence : 0.0;
+
+        return max(0.0, min(1.0, $value));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function extractJsonObject(string $content): array
+    {
+        $cleaned = trim($content);
+        if (str_starts_with($cleaned, '```')) {
+            $cleaned = trim($cleaned, "` \n\r\t");
+            if (str_starts_with(strtolower($cleaned), 'json')) {
+                $cleaned = trim(substr($cleaned, 4));
+            }
+        }
+
+        $decoded = json_decode($cleaned, true);
+        if (is_array($decoded)) {
+            return $decoded;
+        }
+
+        $start = strpos($cleaned, '{');
+        $end = strrpos($cleaned, '}');
+        if ($start === false || $end === false || $end <= $start) {
+            return [];
+        }
+
+        $decoded = json_decode(substr($cleaned, $start, $end - $start + 1), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @return array{provider?: string, model?: string}
+     */
+    private function activeProviderMetadata(): array
+    {
+        try {
+            $provider = AiProviderSetting::where('is_active', true)->first();
+        } catch (\Throwable) {
+            return [];
+        }
+
+        if (! $provider) {
+            return [];
+        }
+
+        return [
+            'provider' => $provider->provider_type,
+            'model' => $provider->model,
+        ];
+    }
+}

--- a/backend/database/migrations/2026_04_14_000003_create_patient_similarity_runs_table.php
+++ b/backend/database/migrations/2026_04_14_000003_create_patient_similarity_runs_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('patient_similarity_runs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('mode', 16);
+            $table->string('name');
+            $table->unsignedBigInteger('source_id')->nullable();
+            $table->unsignedBigInteger('target_cohort_id')->nullable();
+            $table->unsignedBigInteger('comparator_cohort_id')->nullable();
+            $table->string('similarity_mode', 32)->default('auto');
+            $table->jsonb('settings_json')->nullable();
+            $table->string('status', 24)->default('draft');
+            $table->timestamp('last_opened_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'mode', 'last_opened_at'], 'ps_runs_user_mode_opened_idx');
+            $table->index(['source_id', 'target_cohort_id', 'comparator_cohort_id'], 'ps_runs_context_idx');
+        });
+
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DO $grants$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'parthenon_app') THEN
+                        GRANT SELECT, INSERT, UPDATE, DELETE ON app.patient_similarity_runs TO parthenon_app;
+                        GRANT USAGE, SELECT ON SEQUENCE app.patient_similarity_runs_id_seq TO parthenon_app;
+                    END IF;
+                END
+                $grants$
+            SQL);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('patient_similarity_runs');
+    }
+};

--- a/backend/database/migrations/2026_04_14_000004_create_patient_similarity_run_steps_table.php
+++ b/backend/database/migrations/2026_04_14_000004_create_patient_similarity_run_steps_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('patient_similarity_run_steps', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('patient_similarity_run_id')
+                ->constrained('patient_similarity_runs')
+                ->cascadeOnDelete();
+            $table->string('step_id', 32);
+            $table->string('status', 24)->default('completed');
+            $table->text('summary')->nullable();
+            $table->jsonb('result_json');
+            $table->string('result_hash', 64);
+            $table->unsignedInteger('execution_time_ms')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['patient_similarity_run_id', 'step_id'], 'ps_run_steps_unique');
+            $table->index(['step_id', 'result_hash'], 'ps_run_steps_step_hash_idx');
+        });
+
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DO $grants$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'parthenon_app') THEN
+                        GRANT SELECT, INSERT, UPDATE, DELETE ON app.patient_similarity_run_steps TO parthenon_app;
+                        GRANT USAGE, SELECT ON SEQUENCE app.patient_similarity_run_steps_id_seq TO parthenon_app;
+                    END IF;
+                END
+                $grants$
+            SQL);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('patient_similarity_run_steps');
+    }
+};

--- a/backend/database/migrations/2026_04_14_000005_create_patient_similarity_interpretations_table.php
+++ b/backend/database/migrations/2026_04_14_000005_create_patient_similarity_interpretations_table.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('patient_similarity_interpretations', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->foreignId('patient_similarity_run_id')
+                ->nullable()
+                ->constrained('patient_similarity_runs')
+                ->nullOnDelete();
+            $table->foreignId('patient_similarity_run_step_id')
+                ->nullable()
+                ->constrained('patient_similarity_run_steps')
+                ->nullOnDelete();
+            $table->string('mode', 16);
+            $table->string('step_id', 32);
+            $table->unsignedBigInteger('source_id')->nullable();
+            $table->unsignedBigInteger('target_cohort_id')->nullable();
+            $table->unsignedBigInteger('comparator_cohort_id')->nullable();
+            $table->string('result_hash', 64);
+            $table->string('provider')->nullable();
+            $table->string('model')->nullable();
+            $table->string('status', 24);
+            $table->text('summary')->nullable();
+            $table->text('interpretation')->nullable();
+            $table->jsonb('clinical_implications')->nullable();
+            $table->jsonb('methodologic_cautions')->nullable();
+            $table->jsonb('recommended_next_steps')->nullable();
+            $table->decimal('confidence', 4, 3)->default(0);
+            $table->jsonb('sanitized_result')->nullable();
+            $table->text('error')->nullable();
+            $table->text('raw_response')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'mode', 'step_id', 'result_hash'], 'ps_interp_user_step_hash_idx');
+            $table->index(['patient_similarity_run_id', 'step_id'], 'ps_interp_run_step_idx');
+        });
+
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DO $grants$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'parthenon_app') THEN
+                        GRANT SELECT, INSERT, UPDATE, DELETE ON app.patient_similarity_interpretations TO parthenon_app;
+                        GRANT USAGE, SELECT ON SEQUENCE app.patient_similarity_interpretations_id_seq TO parthenon_app;
+                    END IF;
+                END
+                $grants$
+            SQL);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('patient_similarity_interpretations');
+    }
+};

--- a/backend/tests/Unit/Services/PatientSimilarity/CohortSimilarityInterpretationServiceTest.php
+++ b/backend/tests/Unit/Services/PatientSimilarity/CohortSimilarityInterpretationServiceTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use App\Exceptions\AiProviderNotConfiguredException;
+use App\Services\AI\AnalyticsLlmService;
+use App\Services\PatientSimilarity\CohortSimilarityInterpretationService;
+
+function cohortSimilarityInterpretationResult(): array
+{
+    return [
+        'source_cohort' => [
+            'cohort_definition_id' => 83,
+            'name' => 'Target',
+            'member_count' => 1000,
+            'dimensions' => ['conditions' => ['coverage' => 0.92]],
+        ],
+        'target_cohort' => [
+            'cohort_definition_id' => 84,
+            'name' => 'Comparator',
+            'member_count' => 850,
+            'dimensions' => ['conditions' => ['coverage' => 0.88]],
+        ],
+        'overall_divergence' => 0.37,
+        'divergence' => [
+            'conditions' => ['score' => 0.42, 'label' => 'moderate'],
+            'drugs' => ['score' => 0.21, 'label' => 'low'],
+        ],
+        'covariates' => [
+            ['covariate' => 'Chronic kidney disease', 'smd' => 0.27, 'type' => 'binary', 'domain' => 'condition'],
+            ['covariate' => 'Age bucket', 'smd' => -0.14, 'type' => 'continuous', 'domain' => 'demographics'],
+        ],
+        'person_id' => 123,
+        'points' => [
+            ['person_id' => 123, 'x' => 1, 'y' => 1],
+        ],
+    ];
+}
+
+it('summarizes step data without patient-level fields', function () {
+    $service = new CohortSimilarityInterpretationService(Mockery::mock(AnalyticsLlmService::class));
+
+    $summary = $service->summarizeResultForStep('balance', cohortSimilarityInterpretationResult());
+
+    expect($summary['covariate_count'])->toBe(2)
+        ->and($summary['imbalanced_covariates'])->toBe(2)
+        ->and($summary['high_imbalance_covariates'])->toBe(1)
+        ->and(json_encode($summary))->not->toContain('person_id')
+        ->and(json_encode($summary))->not->toContain('points');
+});
+
+it('builds an aggregate-only interpretation prompt', function () {
+    $service = new CohortSimilarityInterpretationService(Mockery::mock(AnalyticsLlmService::class));
+
+    $prompt = $service->buildPrompt(
+        mode: 'compare',
+        stepId: 'profile',
+        result: $service->summarizeResultForStep('profile', cohortSimilarityInterpretationResult()),
+        context: ['source_id' => 47],
+        priorStepSummaries: [['step_id' => 'profile', 'summary' => 'Overall divergence 37%']],
+    );
+
+    expect($prompt)->toContain('Use only the supplied aggregate result')
+        ->and($prompt)->toContain('Profile Comparison')
+        ->and($prompt)->toContain('Return only JSON');
+});
+
+it('hashes aggregate step results deterministically for interpretation reuse', function () {
+    $service = new CohortSimilarityInterpretationService(Mockery::mock(AnalyticsLlmService::class));
+
+    $left = $service->hashStepResult(
+        mode: 'compare',
+        stepId: 'balance',
+        result: ['b' => 2, 'a' => ['z' => 9, 'y' => 8]],
+        context: ['target_cohort_id' => 1, 'source_id' => 2],
+    );
+    $right = $service->hashStepResult(
+        mode: 'compare',
+        stepId: 'balance',
+        result: ['a' => ['y' => 8, 'z' => 9], 'b' => 2],
+        context: ['source_id' => 2, 'target_cohort_id' => 1],
+    );
+
+    expect($left)->toBe($right)->and($left)->toHaveLength(64);
+});
+
+it('changes interpretation hashes when the aggregate context changes', function () {
+    $service = new CohortSimilarityInterpretationService(Mockery::mock(AnalyticsLlmService::class));
+
+    $base = $service->hashStepResult(
+        mode: 'compare',
+        stepId: 'balance',
+        result: ['mean_absolute_smd' => 0.12],
+        context: ['source_id' => 2, 'target_cohort_id' => 1],
+    );
+    $changed = $service->hashStepResult(
+        mode: 'compare',
+        stepId: 'balance',
+        result: ['mean_absolute_smd' => 0.12],
+        context: ['source_id' => 2, 'target_cohort_id' => 3],
+    );
+
+    expect($base)->not->toBe($changed);
+});
+
+it('interprets a step through the analytics llm service', function () {
+    $llm = Mockery::mock(AnalyticsLlmService::class);
+    $llm->shouldReceive('chat')
+        ->once()
+        ->withArgs(function (array $messages, array $options): bool {
+            return str_contains($messages[0]['content'], 'Aggregate analysis payload')
+                && ($options['temperature'] ?? null) === 0.1;
+        })
+        ->andReturn('```json
+{
+  "summary": "The cohorts differ most by renal comorbidity.",
+  "interpretation": "The balance step suggests residual renal and age imbalance.",
+  "clinical_implications": ["Renal disease may modify downstream outcomes."],
+  "methodologic_cautions": ["Residual imbalance remains above the SMD threshold."],
+  "recommended_next_steps": ["Run propensity score matching before reading projections."],
+  "confidence": 0.82
+}
+```');
+
+    $service = new CohortSimilarityInterpretationService($llm);
+
+    $interpretation = $service->interpret('compare', 'balance', cohortSimilarityInterpretationResult());
+
+    expect($interpretation['status'])->toBe('interpreted')
+        ->and($interpretation['summary'])->toContain('renal comorbidity')
+        ->and($interpretation['clinical_implications'])->toBe(['Renal disease may modify downstream outcomes.'])
+        ->and($interpretation['methodologic_cautions'])->toBe(['Residual imbalance remains above the SMD threshold.'])
+        ->and($interpretation['confidence'])->toBe(0.82);
+});
+
+it('returns unavailable when no analytics provider is configured', function () {
+    $llm = Mockery::mock(AnalyticsLlmService::class);
+    $llm->shouldReceive('chat')
+        ->once()
+        ->andThrow(new AiProviderNotConfiguredException('No active provider'));
+
+    $service = new CohortSimilarityInterpretationService($llm);
+
+    $interpretation = $service->interpret('compare', 'balance', cohortSimilarityInterpretationResult());
+
+    expect($interpretation['status'])->toBe('unavailable')
+        ->and($interpretation['error'])->toBe('No active provider');
+});

--- a/docs/devlog/modules/patient-similarity/2026-04-14-cohort-similarities-save-and-interpretation.md
+++ b/docs/devlog/modules/patient-similarity/2026-04-14-cohort-similarities-save-and-interpretation.md
@@ -1,0 +1,73 @@
+# Patient Similarity — Cohort Similarities Save + Interpretation Devlog
+
+**Date:** 2026-04-14  
+**Area:** Patient Similarity / Cohort Similarities  
+**Status:** Shipped and deployed
+
+## Summary
+
+The Cohort Similarities workspace moved from an ephemeral, rerun-heavy workflow to a researcher-owned workspace model. Researchers can now generate LLM interpretations for aggregate analysis steps, reopen prior comparison/similarity workflows, and avoid rerunning expensive downstream steps just to get back to the same result set.
+
+## What Shipped
+
+- Added aggregate-only LLM interpretation for Cohort Similarities steps:
+  - profile comparison
+  - covariate balance
+  - propensity score matching
+  - landscape projection
+  - phenotype discovery
+  - network fusion
+  - centroid profile
+  - similar-patient search
+- Switched interpretation UX to an immediate modal with a spinner while the configured LLM provider responds.
+- Persisted researcher-owned saved runs:
+  - `patient_similarity_runs`
+  - `patient_similarity_run_steps`
+  - `patient_similarity_interpretations`
+- Added workflow-aware saved-run selectors:
+  - **My Comparisons** for compare mode
+  - **My Similarities** for find-similar-patients mode
+- Autosaved completed step outputs and linked interpretations by run/step/result hash.
+- Removed the local data-source dropdown from the Patient Similarity setup panel. The universal topnav source selector is now the single source of truth.
+
+## Backend Notes
+
+The interpretation service summarizes and redacts patient-level payloads before prompting the LLM. Result reuse is keyed by:
+
+- user
+- workflow mode
+- step id
+- source/cohort context
+- deterministic hash of sanitized aggregate results
+
+The first database deployment exposed a useful operational constraint: the runtime/migration role can create new tables but may not be allowed to create foreign keys referencing some older app tables. New persistence migrations therefore use indexed ID columns for existing app entities and reserve foreign keys for tables created together in the same ownership context.
+
+## Frontend Notes
+
+The workspace now restores:
+
+- selected workflow
+- topnav source, when opening a saved run from a different source
+- cohort selections
+- similarity mode and settings
+- completed step outputs
+- saved LLM interpretations
+
+Changing the universal source selector intentionally clears stale in-progress analysis state unless that source change came from opening a saved run.
+
+## Verification
+
+- PHP lint passed for touched backend files and migrations.
+- Focused Pest coverage passed for deterministic interpretation hashing.
+- Frontend TypeScript passed.
+- Focused Patient Similarity Vitest coverage passed.
+- Deployed PHP and frontend assets; smoke checks passed.
+
+## Follow-On Pattern
+
+The saved-run architecture is now the pattern for other long-running researcher workflows:
+
+- persist draft/workflow state server-side by user
+- autosave meaningful progress
+- provide a per-user dropdown of saved work
+- keep local storage only as a short-lived fallback, not as the system of record

--- a/docs/superpowers/plans/2026-04-11-patient-similarity-ux-alignment.md
+++ b/docs/superpowers/plans/2026-04-11-patient-similarity-ux-alignment.md
@@ -1,0 +1,1181 @@
+# Patient Similarity UX Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the Patient Similarity feature into full alignment with Parthenon's design system — eliminating the permanent left sidebar layout, consolidating two competing pages into one, adopting standard page headers/tabs/buttons/panels, and collapsing developer diagnostics behind an accordion.
+
+**Architecture:** The current `/patient-similarity` route loads `PatientSimilarityWorkspace` (pipeline-centric). The original `PatientSimilarityPage` (search-centric) is unreachable dead code. We consolidate into one page that uses the standard `space-y-6` vertical layout with a horizontal toolbar, standard tabs, and the existing pipeline system. The `PatientComparisonPage` (/patient-similarity/compare) remains as a detail sub-route with breadcrumb added.
+
+**Tech Stack:** React 19, TypeScript strict, Tailwind 4, lucide-react icons, TanStack Query, Zustand
+
+**Design System Reference:** `frontend/src/styles/components/` defines `.panel`, `.panel-inset`, `.metric-card`, `.data-table`, `.page-title`, `.page-subtitle`, `.badge-*`, `.empty-state`, `.form-input`, `.form-select`, `.btn`, `.btn-primary`, `.btn-secondary`. All card borders use `var(--border-default)` (`#2A2A30`). Focus states use gold (`var(--border-focus)` / `var(--accent-pale)`). Tabs use teal underline indicator.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| **Rewrite** | `frontend/src/features/patient-similarity/pages/PatientSimilarityWorkspace.tsx` | Single consolidated page with standard layout |
+| **Delete** | `frontend/src/features/patient-similarity/pages/PatientSimilarityPage.tsx` | Dead code — all functionality folded into Workspace |
+| **Modify** | `frontend/src/features/patient-similarity/pages/PatientComparisonPage.tsx` | Add standard breadcrumb, fix header pattern |
+| **Rewrite** | `frontend/src/features/patient-similarity/components/CohortSelectorBar.tsx` | Standard horizontal toolbar with design system inputs |
+| **Rewrite** | `frontend/src/features/patient-similarity/components/PipelineStep.tsx` | Use `.panel` classes, design system colors |
+| **Modify** | `frontend/src/features/patient-similarity/components/AnalysisPipeline.tsx` | Wrap in `.panel` container |
+| **Modify** | `frontend/src/features/patient-similarity/components/SimilarPatientTable.tsx` | Adopt `.data-table` patterns, sticky header |
+| **Modify** | `frontend/src/features/patient-similarity/components/SearchDiagnosticsPanel.tsx` | Wrap in collapsible accordion, use `.panel` cards |
+| **Modify** | `frontend/src/features/patient-similarity/components/SimilaritySearchForm.tsx` | Gold focus states, `.form-input`/`.form-select` classes |
+| **Modify** | `frontend/src/features/patient-similarity/components/SimilarityModeToggle.tsx` | Standard badge-style toggle |
+| **Modify** | `frontend/src/features/patient-similarity/components/CohortSeedForm.tsx` | Gold focus states, standard form inputs |
+| **Modify** | `frontend/src/features/patient-similarity/components/CohortCompareForm.tsx` | Gold focus states, standard form inputs |
+| **Modify** | `frontend/src/features/patient-similarity/components/DimensionScoreBar.tsx` | No change needed (already minimal) |
+| **No change** | `frontend/src/features/patient-similarity/hooks/*` | Hooks are clean, no UI drift |
+| **No change** | `frontend/src/features/patient-similarity/types/*` | Types are clean |
+| **No change** | `frontend/src/features/patient-similarity/api/*` | API layer is clean |
+| **No change** | `frontend/src/app/router.tsx` | Routes stay the same (Workspace is already the route target) |
+
+---
+
+## Task 1: Delete Dead `PatientSimilarityPage` and Clean Up Imports
+
+**Files:**
+- Delete: `frontend/src/features/patient-similarity/pages/PatientSimilarityPage.tsx`
+
+This file is 718 lines of unreachable code. The router at `frontend/src/app/router.tsx:422-427` maps `/patient-similarity` to `PatientSimilarityWorkspace`, not this file.
+
+- [ ] **Step 1: Verify the file is truly unreachable**
+
+Run:
+```bash
+cd frontend && grep -rn "PatientSimilarityPage" src/ --include="*.tsx" --include="*.ts"
+```
+Expected: Only the file itself and possibly some dead imports. The router should NOT reference it.
+
+- [ ] **Step 2: Delete the file**
+
+```bash
+rm frontend/src/features/patient-similarity/pages/PatientSimilarityPage.tsx
+```
+
+- [ ] **Step 3: Verify no import errors**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | head -20
+```
+Expected: No new errors related to PatientSimilarityPage.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A frontend/src/features/patient-similarity/pages/PatientSimilarityPage.tsx
+git commit -m "chore: remove dead PatientSimilarityPage (unreachable, replaced by Workspace)"
+```
+
+---
+
+## Task 2: Rewrite `PipelineStep` to Use Design System
+
+**Files:**
+- Modify: `frontend/src/features/patient-similarity/components/PipelineStep.tsx`
+
+The current PipelineStep uses raw hex colors (`#333`, `#444`, `#555`, `#777`, `#888`, `#ddd`) that are completely outside the design system palette. It also uses unicode triangles (`▸`, `▾`) instead of lucide-react chevrons.
+
+- [ ] **Step 1: Rewrite PipelineStep with design system tokens**
+
+Replace the entire file content with:
+
+```tsx
+import { type ReactNode } from 'react';
+import { ChevronDown, ChevronRight, Loader2, CheckCircle2, XCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { StepStatus } from '../types/pipeline';
+
+interface PipelineStepProps {
+  stepNumber: number;
+  name: string;
+  description: string;
+  status: StepStatus;
+  isExpanded?: boolean;
+  summary?: string;
+  executionTimeMs?: number;
+  onToggle: () => void;
+  onRun?: () => void;
+  children: ReactNode;
+}
+
+export function PipelineStep({
+  stepNumber,
+  name,
+  description,
+  status,
+  isExpanded = false,
+  summary,
+  executionTimeMs,
+  onToggle,
+  onRun,
+  children,
+}: PipelineStepProps) {
+  if (status === 'future') {
+    return (
+      <div className="panel mb-3 opacity-50" style={{ borderStyle: 'dashed' }}>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <div className="flex h-6 w-6 items-center justify-center rounded-full border border-[#2A2A30]">
+              <span className="text-[10px] text-[#5A5650] tabular-nums">{stepNumber}</span>
+            </div>
+            <span className="text-sm text-[#8A857D]">{name}</span>
+            <span className="text-xs text-[#5A5650]">{description}</span>
+          </div>
+          {onRun && (
+            <button
+              onClick={onRun}
+              className="btn btn-secondary btn-sm"
+              type="button"
+            >
+              Run
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'loading') {
+    return (
+      <div className="panel mb-3">
+        <div className="flex items-center gap-2.5">
+          <Loader2 size={20} className="animate-spin text-[#2DD4BF]" />
+          <span className="text-sm font-medium text-[#F0EDE8]">{name}</span>
+          <span className="text-xs text-[#8A857D]">Running...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="panel mb-3" style={{ borderColor: 'var(--critical)' }}>
+        <div className="flex items-center gap-2.5">
+          <XCircle size={20} className="text-[#E85A6B]" />
+          <span className="text-sm font-medium text-[#F0EDE8]">{name}</span>
+          <span className="text-xs text-[#E85A6B]">Failed</span>
+        </div>
+      </div>
+    );
+  }
+
+  // status === 'completed'
+  return (
+    <div className={cn('panel mb-3 overflow-hidden', isExpanded && 'border-[#9B1B30]')}>
+      <button
+        onClick={onToggle}
+        className="flex w-full items-center justify-between text-left"
+        type="button"
+      >
+        <div className="flex items-center gap-2.5">
+          <CheckCircle2 size={20} className="text-[#2DD4BF]" />
+          <span className="text-sm font-medium text-[#F0EDE8]">{name}</span>
+          {!isExpanded && summary && (
+            <span className="ml-1 text-xs text-[#8A857D]">{summary}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {executionTimeMs !== undefined && (
+            <span className="text-xs text-[#5A5650] tabular-nums">
+              {(executionTimeMs / 1000).toFixed(1)}s
+            </span>
+          )}
+          {isExpanded ? (
+            <ChevronDown size={16} className="text-[#5A5650]" />
+          ) : (
+            <ChevronRight size={16} className="text-[#5A5650]" />
+          )}
+        </div>
+      </button>
+
+      {isExpanded && (
+        <div className="mt-4 border-t border-[#2A2A30] pt-4">{children}</div>
+      )}
+    </div>
+  );
+}
+```
+
+Key changes:
+- All hex colors now use design system palette (`#2A2A30`, `#5A5650`, `#8A857D`, `#F0EDE8`, etc.)
+- Uses `.panel` CSS class for container (gets gradient overlay, shimmer edge, gold hover)
+- Uses `.btn .btn-secondary .btn-sm` for Run button
+- Uses lucide-react `ChevronDown`/`ChevronRight` instead of unicode triangles
+- Uses lucide-react `CheckCircle2`, `XCircle`, `Loader2` for status icons
+- Step number uses `tabular-nums` and proper sizing
+- `mb-3` spacing matches design system `--space-3` (12px)
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -i pipeline
+```
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/patient-similarity/components/PipelineStep.tsx
+git commit -m "style: align PipelineStep with design system (panel, icons, colors)"
+```
+
+---
+
+## Task 3: Wrap `AnalysisPipeline` in Panel Container
+
+**Files:**
+- Modify: `frontend/src/features/patient-similarity/components/AnalysisPipeline.tsx`
+
+Currently the pipeline container uses raw padding (`px-5 py-4`). Wrap it in the standard content spacing.
+
+- [ ] **Step 1: Update the container class**
+
+In `AnalysisPipeline.tsx`, change:
+```tsx
+<div className="px-5 py-4">
+```
+to:
+```tsx
+<div className="space-y-0">
+```
+
+The PipelineStep components already have `mb-3` spacing from Task 2, so we don't need `space-y` here — just remove the arbitrary padding since the parent page will provide proper spacing.
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -i pipeline
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/patient-similarity/components/AnalysisPipeline.tsx
+git commit -m "style: remove arbitrary padding from AnalysisPipeline container"
+```
+
+---
+
+## Task 4: Rewrite `CohortSelectorBar` with Design System
+
+**Files:**
+- Modify: `frontend/src/features/patient-similarity/components/CohortSelectorBar.tsx`
+
+The current toolbar uses off-palette colors (`#1A1815`, `#2A2520`) and non-standard input styling. Align with design system form inputs and buttons.
+
+- [ ] **Step 1: Rewrite CohortSelectorBar**
+
+Replace the entire file content with:
+
+```tsx
+import { Settings } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useCohortDefinitions } from '@/features/cohort-definitions/hooks/useCohortDefinitions';
+import { useSources } from '@/features/data-sources/hooks/useSources';
+import { useCohortProfile } from '../hooks/usePatientSimilarity';
+import { GenerationStatusBanner } from './GenerationStatusBanner';
+import type { PipelineMode } from '../types/pipeline';
+
+export interface CohortSelectorBarProps {
+  mode: PipelineMode;
+  sourceId: number | null;
+  targetCohortId: number | null;
+  comparatorCohortId: number | null;
+  onModeChange: (mode: PipelineMode) => void;
+  onSourceChange: (sourceId: number) => void;
+  onTargetChange: (cohortId: number | null) => void;
+  onComparatorChange: (cohortId: number | null) => void;
+  onCompare: () => void;
+  onOpenSettings: () => void;
+  isRunning?: boolean;
+}
+
+export function CohortSelectorBar({
+  mode,
+  sourceId,
+  targetCohortId,
+  comparatorCohortId,
+  onModeChange,
+  onSourceChange,
+  onTargetChange,
+  onComparatorChange,
+  onCompare,
+  onOpenSettings,
+  isRunning = false,
+}: CohortSelectorBarProps) {
+  const { data: sourcesData } = useSources();
+  const sources = sourcesData ?? [];
+
+  const { data: cohortsData } = useCohortDefinitions({ limit: 500 });
+  const cohorts = cohortsData?.items ?? [];
+
+  const { data: targetProfile, isLoading: targetProfileLoading } =
+    useCohortProfile(
+      targetCohortId != null && targetCohortId > 0 ? targetCohortId : undefined,
+      sourceId ?? 0,
+    );
+
+  const { data: comparatorProfile, isLoading: comparatorProfileLoading } =
+    useCohortProfile(
+      comparatorCohortId != null && comparatorCohortId > 0 ? comparatorCohortId : undefined,
+      sourceId ?? 0,
+    );
+
+  const isCompareMode = mode === 'compare';
+  const actionDisabled =
+    isRunning ||
+    sourceId == null ||
+    targetCohortId == null ||
+    (isCompareMode && comparatorCohortId == null);
+
+  const handleTargetChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value;
+    onTargetChange(val ? Number(val) : null);
+  };
+
+  const handleComparatorChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value;
+    onComparatorChange(val ? Number(val) : null);
+  };
+
+  const handleSourceChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value;
+    if (val) onSourceChange(Number(val));
+  };
+
+  const showTargetBanner =
+    sourceId != null && targetCohortId != null && targetCohortId > 0;
+  const showComparatorBanner =
+    isCompareMode &&
+    sourceId != null &&
+    comparatorCohortId != null &&
+    comparatorCohortId > 0;
+
+  return (
+    <div className="panel space-y-3">
+      {/* Row 1 - controls */}
+      <div className="flex items-center gap-3 flex-wrap">
+        {/* Data source */}
+        <select
+          value={sourceId ?? ''}
+          onChange={handleSourceChange}
+          className="form-select min-w-[140px]"
+          aria-label="Data source"
+        >
+          <option value="">Source...</option>
+          {sources.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.source_name}
+            </option>
+          ))}
+        </select>
+
+        {/* Mode toggle */}
+        <div className="flex rounded-md overflow-hidden border border-[#2A2A30]">
+          <button
+            type="button"
+            onClick={() => onModeChange('compare')}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium transition-colors',
+              isCompareMode
+                ? 'bg-[#9B1B30] text-white'
+                : 'bg-[#151518] text-[#8A857D] hover:text-[#C5C0B8]',
+            )}
+          >
+            Compare Cohorts
+          </button>
+          <button
+            type="button"
+            onClick={() => onModeChange('expand')}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium transition-colors',
+              !isCompareMode
+                ? 'bg-[#2DD4BF] text-[#0E0E11]'
+                : 'bg-[#151518] text-[#8A857D] hover:text-[#C5C0B8]',
+            )}
+          >
+            Expand Cohort
+          </button>
+        </div>
+
+        {/* Target cohort */}
+        <div className="flex-1 min-w-[160px]">
+          <select
+            value={targetCohortId ?? ''}
+            onChange={handleTargetChange}
+            className="form-select w-full"
+            style={{ borderColor: 'var(--primary)' }}
+            aria-label="Target cohort"
+          >
+            <option value="">
+              {isCompareMode ? 'Target cohort...' : 'Seed cohort...'}
+            </option>
+            {cohorts.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Comparator cohort - compare mode only */}
+        {isCompareMode && (
+          <div className="flex-1 min-w-[160px]">
+            <select
+              value={comparatorCohortId ?? ''}
+              onChange={handleComparatorChange}
+              className="form-select w-full"
+              style={{ borderColor: 'var(--success)' }}
+              aria-label="Comparator cohort"
+            >
+              <option value="">Comparator cohort...</option>
+              {cohorts.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {/* Action button */}
+        <button
+          type="button"
+          onClick={onCompare}
+          disabled={actionDisabled}
+          className={cn(
+            'btn shrink-0',
+            isCompareMode ? 'btn-primary' : 'btn bg-[#2DD4BF] text-[#0E0E11] hover:bg-[#26B8A5]',
+            'disabled:opacity-40 disabled:cursor-not-allowed',
+          )}
+        >
+          {isCompareMode ? 'Compare' : 'Find Similar'}
+        </button>
+
+        {/* Settings */}
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          title="Analysis settings"
+          className="btn-icon text-[#8A857D] hover:text-[#C5C0B8] hover:bg-[#1C1C20] transition-colors"
+        >
+          <Settings size={16} />
+        </button>
+      </div>
+
+      {/* Row 2 - generation status */}
+      {(showTargetBanner || showComparatorBanner) && (
+        <div className="flex gap-6 flex-wrap">
+          {showTargetBanner && (
+            <div className="flex-1 min-w-[200px]">
+              <span className="text-xs font-medium text-[#9B1B30] mr-2">
+                {isCompareMode ? 'Target:' : 'Seed:'}
+              </span>
+              <GenerationStatusBanner
+                cohortDefinitionId={targetCohortId!}
+                sourceId={sourceId!}
+                profile={targetProfile}
+                isLoading={targetProfileLoading}
+              />
+            </div>
+          )}
+          {showComparatorBanner && (
+            <div className="flex-1 min-w-[200px]">
+              <span className="text-xs font-medium text-[#2DD4BF] mr-2">
+                Comparator:
+              </span>
+              <GenerationStatusBanner
+                cohortDefinitionId={comparatorCohortId!}
+                sourceId={sourceId!}
+                profile={comparatorProfile}
+                isLoading={comparatorProfileLoading}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+Key changes:
+- Container uses `.panel` instead of raw bg/border
+- Dropdowns use `.form-select` class (gets gold focus ring, proper sizing)
+- Action button uses `.btn .btn-primary` classes
+- Settings button uses `.btn-icon`
+- All background colors switched from `#1A1815` to `#151518` (design system `--surface-raised`)
+- All borders switched from `#2A2520` to `#2A2A30` (design system `--border-default`)
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -i selector
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/patient-similarity/components/CohortSelectorBar.tsx
+git commit -m "style: align CohortSelectorBar with design system (panel, form-select, btn)"
+```
+
+---
+
+## Task 5: Rewrite `PatientSimilarityWorkspace` with Standard Page Layout
+
+**Files:**
+- Modify: `frontend/src/features/patient-similarity/pages/PatientSimilarityWorkspace.tsx`
+
+The current page bypasses the content shell with `flex h-full flex-col overflow-hidden bg-[#0E0E11]`. Replace with the standard `space-y-6` vertical layout using `page-title`/`page-subtitle` header.
+
+- [ ] **Step 1: Rewrite the page layout**
+
+Replace the render section (from `return (` to the end of the component) with:
+
+```tsx
+  // ── Render ────────────────────────────────────────────────────────
+
+  const steps = (pipeline as unknown as { steps: import('../types/pipeline').StepDefinition[] }).steps;
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="page-title">Patient Similarity</h1>
+          <p className="page-subtitle">
+            Compare cohort profiles, find similar patients, and run propensity score matching across OMOP CDM sources
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <SimilarityModeToggle
+            mode={similarityMode}
+            onChange={setSimilarityMode}
+          />
+        </div>
+      </div>
+
+      {/* Toolbar */}
+      <CohortSelectorBar
+        mode={pipeline.mode}
+        sourceId={sourceId}
+        targetCohortId={targetCohortId}
+        comparatorCohortId={comparatorCohortId}
+        onModeChange={handleModeChange}
+        onSourceChange={handleSourceChange}
+        onTargetChange={handleTargetChange}
+        onComparatorChange={handleComparatorChange}
+        onCompare={handleCompare}
+        onOpenSettings={() => setSettingsOpen(!settingsOpen)}
+        isRunning={compareMutation.isPending || cohortSimilarityMutation.isPending}
+      />
+
+      {/* Analysis pipeline */}
+      <AnalysisPipeline
+        steps={steps}
+        expandedSteps={pipeline.expandedSteps}
+        getStepStatus={pipeline.getStepStatus}
+        getStepResult={pipeline.getStepResult}
+        onToggleStep={pipeline.toggleStep}
+        onRunStep={handleRunStep}
+        renderStepContent={renderStepContent}
+      />
+
+      {/* Drawers */}
+      <SettingsDrawer
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        weights={weights}
+        onWeightsChange={setWeights}
+        ageMin={ageMin}
+        ageMax={ageMax}
+        onAgeMinChange={setAgeMin}
+        onAgeMaxChange={setAgeMax}
+        gender={gender}
+        onGenderChange={setGender}
+        onApply={handleCompare}
+      />
+
+      <HeadToHeadDrawer
+        open={h2hOpen}
+        onClose={() => setH2hOpen(false)}
+        personAId={h2hPersonA}
+        personBId={h2hPersonB}
+        sourceId={sourceId ?? 0}
+      />
+    </div>
+  );
+```
+
+Also add the `SimilarityModeToggle` import and state at the top of the component:
+
+```tsx
+import { SimilarityModeToggle } from '../components/SimilarityModeToggle';
+```
+
+And add state:
+```tsx
+const [similarityMode, setSimilarityMode] = useState<'auto' | 'interpretable' | 'embedding'>('auto');
+```
+
+- [ ] **Step 2: Remove the `flex h-full` wrapper and overflow-hidden**
+
+The old layout:
+```tsx
+<div className="flex h-full flex-col overflow-hidden bg-[#0E0E11]">
+```
+is now replaced by:
+```tsx
+<div className="space-y-6">
+```
+
+This lets the standard `.content-main` wrapper (90% width, max 1600px, proper padding) do its job.
+
+- [ ] **Step 3: Remove the inner `<div className="flex-1 overflow-y-auto">` wrapper**
+
+The AnalysisPipeline no longer needs a scrollable container wrapper — the page itself scrolls naturally within `.content-main`.
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | head -20
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/features/patient-similarity/pages/PatientSimilarityWorkspace.tsx
+git commit -m "style: adopt standard page layout for Patient Similarity (page-title, space-y-6)"
+```
+
+---
+
+## Task 6: Align `SimilarPatientTable` with `.data-table` Patterns
+
+**Files:**
+- Modify: `frontend/src/features/patient-similarity/components/SimilarPatientTable.tsx`
+
+The table header uses `bg-[#151518]` (should be `bg-[#1C1C20]` per `.data-table th`), lacks sticky positioning, and the header text uses `text-[10px]` (should be `text-[11px]` per `var(--text-xs)`).
+
+- [ ] **Step 1: Update the thead row**
+
+In `SimilarPatientTable.tsx`, change:
+```tsx
+<tr className="bg-[#151518] border-b border-[#232328]">
+```
+to:
+```tsx
+<tr className="bg-[#1C1C20] border-b border-[#2A2A30]">
+```
+
+- [ ] **Step 2: Add sticky header to thead**
+
+Change:
+```tsx
+<thead>
+```
+to:
+```tsx
+<thead className="sticky top-0 z-20">
+```
+
+- [ ] **Step 3: Update header cell styling from text-[10px] to text-[11px]**
+
+Find all `th` class strings and change `text-[10px]` to `text-[11px]`. There are 11 `<th>` elements. Each one currently has:
+```
+text-[10px] font-semibold text-[#5A5650] uppercase tracking-wider
+```
+Change to:
+```
+text-[11px] font-semibold text-[#5A5650] uppercase tracking-[0.5px]
+```
+
+- [ ] **Step 4: Update border colors in tbody rows**
+
+Change:
+```tsx
+"border-b border-[#1C1C20] transition-colors",
+```
+to:
+```tsx
+"border-b border-[#2A2A30]/50 transition-colors",
+```
+
+- [ ] **Step 5: Update expanded row background**
+
+Change the expanded detail row:
+```tsx
+<tr className="border-b border-[#1C1C20] bg-[#131316]">
+```
+to:
+```tsx
+<tr className="border-b border-[#2A2A30]/50 bg-[#0E0E11]">
+```
+
+- [ ] **Step 6: Use `.panel-inset` for detail metric cards**
+
+Change the 4-card grid items from:
+```tsx
+className="rounded-md border border-[#232328] bg-[#151518] px-3 py-2"
+```
+to:
+```tsx
+className="panel-inset rounded-md px-3 py-2"
+```
+
+- [ ] **Step 7: Update empty state**
+
+Change:
+```tsx
+<div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-[#323238] bg-[#151518] py-16">
+  <p className="text-sm text-[#8A857D]">No similar patients found.</p>
+</div>
+```
+to:
+```tsx
+<div className="empty-state">
+  <p className="empty-message">No similar patients found for the given criteria.</p>
+</div>
+```
+
+- [ ] **Step 8: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -i similar
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/features/patient-similarity/components/SimilarPatientTable.tsx
+git commit -m "style: align SimilarPatientTable with data-table design system"
+```
+
+---
+
+## Task 7: Collapse `SearchDiagnosticsPanel` Behind Accordion
+
+**Files:**
+- Modify: `frontend/src/features/patient-similarity/components/SearchDiagnosticsPanel.tsx`
+
+The diagnostics panel shows developer-grade telemetry (candidate pool, query contract, provenance, source readiness) permanently visible. Wrap in a collapsible disclosure.
+
+- [ ] **Step 1: Add collapsible wrapper**
+
+Add `useState` and `ChevronDown`/`ChevronRight` imports:
+
+```tsx
+import { useState } from "react";
+import { Activity, ChevronDown, ChevronRight, Database, Filter, GitBranch, Timer } from "lucide-react";
+```
+
+- [ ] **Step 2: Wrap the grid in a disclosure**
+
+Replace the component's return JSX. The outer container becomes:
+
+```tsx
+export function SearchDiagnosticsPanel({
+  metadata,
+  seed,
+  computeStatus,
+}: SearchDiagnosticsPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const filters = metadata.filters_applied as SimilarityFilters | undefined;
+
+  return (
+    <div className="panel">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex w-full items-center justify-between text-left"
+      >
+        <span className="text-[11px] font-semibold text-[#5A5650] uppercase tracking-[0.5px]">
+          Search Diagnostics
+        </span>
+        {isOpen ? (
+          <ChevronDown size={14} className="text-[#5A5650]" />
+        ) : (
+          <ChevronRight size={14} className="text-[#5A5650]" />
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="mt-4 grid grid-cols-1 xl:grid-cols-4 gap-3">
+          <div className="panel-inset rounded-lg p-3">
+            <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.5px] text-[#5A5650]">
+              <Database size={12} className="text-[#2DD4BF]" />
+              Candidate Pool
+            </div>
+            <div className="mt-2 space-y-1.5 text-xs text-[#C5C0B8]">
+              <div>Total candidates: {metadata.total_candidates ?? metadata.candidates_evaluated ?? "\u2014"}</div>
+              <div>Loaded: {metadata.candidates_loaded ?? metadata.candidates_evaluated ?? "\u2014"}</div>
+              <div>Returned: {metadata.returned_count ?? "\u2014"}</div>
+              <div className="text-[#8A857D]">
+                {metadata.sql_prescored ? "SQL pre-screened before full scoring" : "Full scoring over candidate set"}
+              </div>
+            </div>
+          </div>
+
+          <div className="panel-inset rounded-lg p-3">
+            <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.5px] text-[#5A5650]">
+              <Filter size={12} className="text-[#C9A227]" />
+              Query Contract
+            </div>
+            <div className="mt-2 space-y-1.5 text-xs text-[#C5C0B8]">
+              <div>Filters: {formatFilters(filters)}</div>
+              <div>Min score: {metadata.min_score ?? "\u2014"}</div>
+              <div>Limit: {metadata.limit ?? "\u2014"}</div>
+              <div>Temporal window: {metadata.temporal_window_days ? `${metadata.temporal_window_days} days` : "\u2014"}</div>
+            </div>
+          </div>
+
+          <div className="panel-inset rounded-lg p-3">
+            <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.5px] text-[#5A5650]">
+              <GitBranch size={12} className="text-[#9B1B30]" />
+              Provenance
+            </div>
+            <div className="mt-2 space-y-1.5 text-xs text-[#C5C0B8]">
+              <div>Vector version: {seed.feature_vector_version ?? metadata.feature_vector_version ?? "\u2014"}</div>
+              <div>Seed anchor: {formatDate(seed.anchor_date ?? metadata.seed_anchor_date)}</div>
+              <div>Computed: {formatDate(metadata.computed_at)}</div>
+              <div className="text-[#8A857D]">Query hash: {typeof metadata.query_hash === "string" ? metadata.query_hash.slice(0, 12) : "\u2014"}</div>
+            </div>
+          </div>
+
+          <div className="panel-inset rounded-lg p-3">
+            <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.5px] text-[#5A5650]">
+              <Timer size={12} className="text-[#2DD4BF]" />
+              Source Readiness
+            </div>
+            <div className="mt-2 space-y-1.5 text-xs text-[#C5C0B8]">
+              <div>Latest vectors: {formatDate(computeStatus?.latest_computed_at)}</div>
+              <div>Embeddings ready: {computeStatus ? (computeStatus.embeddings_ready ? "Yes" : "No") : "\u2014"}</div>
+              <div>Recommended mode: {computeStatus?.recommended_mode ?? "\u2014"}</div>
+              <div className={computeStatus?.staleness_warning ? "text-[#E85A6B]" : "text-[#8A857D]"}>
+                {computeStatus?.staleness_warning ? "Vectors may be stale" : "No staleness warning"}
+              </div>
+            </div>
+          </div>
+
+          {metadata.weights && (
+            <div className="xl:col-span-4 panel-inset rounded-lg p-3">
+              <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.5px] text-[#5A5650]">
+                <Activity size={12} className="text-[#2DD4BF]" />
+                Dimension Weights
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {Object.entries(metadata.weights).map(([key, value]) => (
+                  <span
+                    key={key}
+                    className="badge badge-default"
+                  >
+                    {key}: {value.toFixed(1)}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+Key changes:
+- Collapsed by default (`useState(false)`)
+- Outer container uses `.panel`
+- Inner cards use `.panel-inset`
+- Header text uses `text-[11px]` with `tracking-[0.5px]`
+- Weight badges use `.badge .badge-default`
+- Chevron icons from lucide-react
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -i diagnostic
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/features/patient-similarity/components/SearchDiagnosticsPanel.tsx
+git commit -m "style: collapse SearchDiagnosticsPanel behind accordion, use panel/panel-inset"
+```
+
+---
+
+## Task 8: Fix Focus States Across All Form Components (Teal -> Gold)
+
+**Files:**
+- Modify: `frontend/src/features/patient-similarity/components/SimilaritySearchForm.tsx`
+- Modify: `frontend/src/features/patient-similarity/components/CohortSeedForm.tsx`
+- Modify: `frontend/src/features/patient-similarity/components/CohortCompareForm.tsx`
+
+The design system uses gold focus rings (`var(--border-focus)` / `var(--accent-pale)`). These forms all use teal focus: `focus:border-[#2DD4BF] focus:ring-1 focus:ring-[#2DD4BF]/40`.
+
+- [ ] **Step 1: Fix SimilaritySearchForm focus states**
+
+In `SimilaritySearchForm.tsx`, find-and-replace all occurrences:
+```
+focus:border-[#2DD4BF] focus:ring-1 focus:ring-[#2DD4BF]/40
+```
+with:
+```
+focus:border-[#C9A227] focus:ring-1 focus:ring-[#C9A227]/15
+```
+
+There are 5 occurrences in this file:
+1. Source selector (line ~117)
+2. Person ID input (line ~164)
+3. Age min input (line ~310)
+4. Age max input (line ~323)
+5. Gender select (line ~337)
+
+- [ ] **Step 2: Fix CohortSeedForm focus states**
+
+In `CohortSeedForm.tsx`, do the same find-and-replace:
+```
+focus:border-[#2DD4BF] focus:ring-1 focus:ring-[#2DD4BF]/40
+```
+with:
+```
+focus:border-[#C9A227] focus:ring-1 focus:ring-[#C9A227]/15
+```
+
+- [ ] **Step 3: Fix CohortCompareForm focus states**
+
+In `CohortCompareForm.tsx`, do the same find-and-replace.
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | head -10
+```
+
+- [ ] **Step 5: Verify no remaining teal focus in the feature**
+
+Run:
+```bash
+grep -rn "focus:border-\[#2DD4BF\]" frontend/src/features/patient-similarity/
+```
+Expected: No matches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/features/patient-similarity/components/SimilaritySearchForm.tsx \
+       frontend/src/features/patient-similarity/components/CohortSeedForm.tsx \
+       frontend/src/features/patient-similarity/components/CohortCompareForm.tsx
+git commit -m "style: switch Patient Similarity form focus states from teal to gold"
+```
+
+---
+
+## Task 9: Add Breadcrumb to `PatientComparisonPage`
+
+**Files:**
+- Modify: `frontend/src/features/patient-similarity/pages/PatientComparisonPage.tsx`
+
+The comparison sub-page uses a small inline "Back to results" link. Replace with the standard breadcrumb pattern used by all detail pages.
+
+- [ ] **Step 1: Update the header section**
+
+In `PatientComparisonPage.tsx`, find the header block (around line 520-534):
+
+```tsx
+<div className="flex items-center gap-4">
+  <Link
+    to={backUrl}
+    className="flex items-center gap-1.5 text-xs text-[#5A5650] hover:text-[#C5C0B8] transition-colors"
+  >
+    <ArrowLeft size={14} />
+    Back to results
+  </Link>
+  <h1 className="page-title">Patient Comparison</h1>
+  <span className="text-xs text-[#5A5650] tabular-nums">
+    #{personA} vs #{personB}
+  </span>
+</div>
+```
+
+Replace with:
+
+```tsx
+<div>
+  <Link
+    to={backUrl}
+    className="inline-flex items-center gap-1 text-sm text-[#8A857D] hover:text-[#F0EDE8] transition-colors mb-3"
+  >
+    <ArrowLeft size={14} />
+    Patient Similarity
+  </Link>
+  <div className="flex items-center gap-3">
+    <h1 className="page-title">Patient Comparison</h1>
+    <span className="text-sm text-[#8A857D] tabular-nums font-['IBM_Plex_Mono',monospace]">
+      #{personA} vs #{personB}
+    </span>
+  </div>
+  <p className="page-subtitle">
+    Head-to-head similarity analysis across all clinical dimensions
+  </p>
+</div>
+```
+
+Key changes:
+- Breadcrumb uses standard pattern: `text-sm text-[#8A857D] hover:text-[#F0EDE8] mb-3`
+- Breadcrumb text says "Patient Similarity" (parent section name), not "Back to results"
+- Title and patient IDs on separate line
+- Added `.page-subtitle` description
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -i comparison
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/patient-similarity/pages/PatientComparisonPage.tsx
+git commit -m "style: add standard breadcrumb and page subtitle to PatientComparisonPage"
+```
+
+---
+
+## Task 10: Align `SimilarityModeToggle` with Badge Pattern
+
+**Files:**
+- Modify: `frontend/src/features/patient-similarity/components/SimilarityModeToggle.tsx`
+
+The toggle uses raw inline styles. Align with the design system's segmented control / filter chip pattern.
+
+- [ ] **Step 1: Rewrite SimilarityModeToggle**
+
+Replace the entire file:
+
+```tsx
+import { cn } from '@/lib/utils';
+
+type SimilarityMode = 'auto' | 'interpretable' | 'embedding';
+
+interface SimilarityModeToggleProps {
+  mode: SimilarityMode;
+  onChange: (mode: SimilarityMode) => void;
+  recommendedMode?: string;
+}
+
+const modes: { value: SimilarityMode; label: string }[] = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'interpretable', label: 'Interpretable' },
+  { value: 'embedding', label: 'Embedding' },
+];
+
+export function SimilarityModeToggle({ mode, onChange, recommendedMode }: SimilarityModeToggleProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex items-center rounded-full border border-[#2A2A30] bg-[#151518] p-0.5">
+        {modes.map((m) => (
+          <button
+            key={m.value}
+            type="button"
+            onClick={() => onChange(m.value)}
+            className={cn(
+              'px-3 py-1 text-xs font-medium rounded-full transition-colors',
+              mode === m.value
+                ? 'bg-[#C9A227]/15 text-[#C9A227] border border-[#C9A227]/30'
+                : 'text-[#5A5650] hover:text-[#C5C0B8] border border-transparent',
+            )}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+      {mode === 'auto' && recommendedMode && (
+        <span className="text-[11px] text-[#5A5650]">
+          will use {recommendedMode}
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+Key changes:
+- Outer container uses pill shape (`rounded-full`) with design system border/bg
+- Active state uses gold accent (matching filter chip `.active` pattern)
+- Buttons are pill-shaped
+- No more raw `border-r` dividers between buttons
+- Hint text uses `text-[11px]` instead of `text-[10px]`
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run:
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | grep -i mode
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/features/patient-similarity/components/SimilarityModeToggle.tsx
+git commit -m "style: align SimilarityModeToggle with filter chip pattern (gold accent, pill shape)"
+```
+
+---
+
+## Task 11: Run Full Build Verification
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+Expected: Clean (0 errors).
+
+- [ ] **Step 2: Run Vite build (stricter than tsc)**
+
+```bash
+cd frontend && npx vite build 2>&1 | tail -10
+```
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run ESLint on changed files**
+
+```bash
+cd frontend && npx eslint src/features/patient-similarity/ --max-warnings=0
+```
+Expected: Clean or only pre-existing warnings.
+
+- [ ] **Step 4: Run Pint (in case any PHP was touched)**
+
+```bash
+docker compose exec -T php sh -c "cd /var/www/html && vendor/bin/pint --test" 2>&1 | tail -5
+```
+Expected: Clean.
+
+- [ ] **Step 5: Final commit if any formatting fixes needed**
+
+If ESLint auto-fixes anything:
+```bash
+git add -A frontend/src/features/patient-similarity/
+git commit -m "style: auto-fix lint issues in patient-similarity feature"
+```

--- a/docs/superpowers/plans/2026-04-14-patient-similarity-qa-punch-list-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-14-patient-similarity-qa-punch-list-implementation-plan.md
@@ -1,0 +1,460 @@
+# Patient Similarity QA Punch List — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This plan is for a focused UX/product-quality pass, not a rewrite.
+
+**Goal:** Ship a concise, high-impact quality pass on `/patient-similarity` so first-time and returning users can immediately understand the setup flow, method choice, primary action, analytical cautions, and top-line results without turning the feature into a gated wizard.
+
+**Architecture / Approach:** Keep `PatientSimilarityWorkspace` as the orchestration layer and preserve the existing pipeline model. Concentrate changes in the page header/setup area (`PatientSimilarityWorkspace`, `CohortSelectorBar`, `SimilarityModeToggle`) plus small readability improvements in the first result panels (`ProfileComparisonPanel`, `CovariateBalancePanel`). Add cohort-size imbalance heuristics close to existing cohort-profile/member-count data instead of introducing backend changes. Address the blocking “What’s New” modal at layout/help infrastructure level with a narrow route-aware suppression or defer behavior rather than changing patient-similarity feature logic to fight a global modal.
+
+**Tech Stack:** React 19, TypeScript strict, TanStack Query, Zustand, Tailwind 4, lucide-react, Vitest + Testing Library.
+
+**Primary UX outcome:** The page should read as “Comparison setup → run analysis → inspect pipeline results,” with explicit action names, visible method guidance, and hard-to-miss caution states for analytically weak cohort pairings.
+
+---
+
+## Implementation Principles
+
+- Preserve the current compare/expand pipeline and step ordering.
+- Do not convert the page into a mandatory wizard.
+- Prefer inline explanation over modals and tooltips-only guidance.
+- Reuse existing data already available via `useCohortProfile`, comparison results, and layout/help infrastructure.
+- Favor small copy, contrast, and hierarchy changes over major structural churn.
+- Keep warning logic deterministic and testable.
+
+---
+
+## Recommended Product Decisions
+
+### 1. Comparison setup hierarchy
+
+Convert the current top row into a compact setup card/section with:
+- section title: `Comparison setup`
+- short helper copy: `Choose a data source, analysis mode, and cohorts before running the pipeline.`
+- clearly labeled control groups rather than toolbar-like unlabeled controls
+- one obvious primary CTA aligned with the selected workflow mode
+
+### 2. Primary CTA copy
+
+Use explicit action labels:
+- compare mode: `Compare cohorts`
+- expand mode: `Find similar patients`
+
+Optional helper text near the CTA or setup footer:
+- compare mode: `Runs profile comparison and covariate balance first.`
+- expand mode: `Builds a cohort profile, then searches for similar patients.`
+
+### 3. Similarity method copy
+
+Keep the existing toggle but add always-visible explainer text. Recommended copy:
+- `Auto` — `Recommended. Uses the best available similarity method for this source.`
+- `Interpretable` — `Feature-based comparison with clearer explanation of what drives similarity.`
+- `Embedding` — `Representation-based comparison for more flexible similarity search.`
+
+If `recommendedMode` is available, show a compact sentence such as:
+- `Auto will use Embedding for this source.`
+- `Auto will use Interpretable for this source.`
+
+### 4. Cohort-size imbalance thresholds
+
+Use two visible caution levels derived from selected cohort profile counts:
+
+Warning thresholds:
+- show warning when smaller cohort has fewer than 100 members, or size ratio is >= 10:1
+- show severe warning when smaller cohort has fewer than 50 members, or size ratio is >= 25:1
+
+Recommended computed values:
+- `targetCount`
+- `comparatorCount`
+- `smallerCount = Math.min(targetCount, comparatorCount)`
+- `largerCount = Math.max(targetCount, comparatorCount)`
+- `sizeRatio = largerCount / Math.max(smallerCount, 1)`
+
+Recommended compare-mode copy:
+- warning: `One cohort is much smaller than the other. Similarity and matching results may be unstable.`
+- severe warning: `Comparator setup is highly imbalanced. Treat divergence, balance, and matching outputs as directional only until cohort sizes are better aligned.`
+
+Recommended detail line:
+- `Target: 17,472 patients · Comparator: 59 patients · 296x size difference`
+
+Behavior notes:
+- only show in compare mode
+- only show once both cohort profiles resolve with usable member counts
+- do not block the run action; warn prominently instead
+- keep warning near the setup controls and above the CTA/helper area
+
+### 5. Result readability improvements
+
+Preferred low-risk upgrades:
+- strengthen summary-card contrast and label hierarchy in `ProfileComparisonPanel`
+- add a short interpretation sentence directly under the overall divergence value
+- surface cohort counts near top-line comparison summary if not already visible elsewhere
+- make balance summaries in `CovariateBalancePanel` more scannable with plain-language thresholds
+- ensure critical metrics use tabular numerals and accessible contrast
+
+### 6. Blocking “What’s New” modal handling
+
+Recommended product behavior:
+- do not auto-open the modal when landing directly on `/patient-similarity`
+- preserve manual access to release notes elsewhere
+- keep existing global behavior for most routes unless product wants broader suppression
+
+Implementation options, in priority order:
+1. Add route-aware suppression in `MainLayout` or `WhatsNewModal` for `/patient-similarity`
+2. Add a non-blocking defer rule so the modal does not auto-open on first render for analysis-heavy routes
+3. Only if infrastructure forces it, add a prop such as `disableAutoOpen` or `autoOpenStrategy`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|---|---|---|
+| Modify | `frontend/src/components/layout/MainLayout.tsx` | Add route-aware suppression/defer wiring for the auto-open “What’s New” modal if implemented at layout level |
+| Modify | `frontend/src/features/help/components/WhatsNewModal.tsx` | Support route-aware auto-open suppression or explicit opt-out without breaking manual open flows |
+| Modify | `frontend/src/features/patient-similarity/pages/PatientSimilarityWorkspace.tsx` | Reorganize page header/setup composition, pass setup helper/warning props, keep pipeline orchestration intact |
+| Modify | `frontend/src/features/patient-similarity/components/CohortSelectorBar.tsx` | Convert ambiguous toolbar into setup section/card, rename CTA, render cohort imbalance warning, improve labels/helper text |
+| Modify | `frontend/src/features/patient-similarity/components/SimilarityModeToggle.tsx` | Add always-visible method explanation, stronger selected state, optional recommended-mode copy |
+| Modify | `frontend/src/features/patient-similarity/components/ProfileComparisonPanel.tsx` | Improve top-line readability and interpretation copy with minimal structural change |
+| Modify | `frontend/src/features/patient-similarity/components/CovariateBalancePanel.tsx` | Improve summary readability, plain-language balance guidance, preserve actions |
+| Maybe modify | `frontend/src/features/patient-similarity/components/GenerationStatusBanner.tsx` | Only if setup-card layout needs a smaller or denser inline status presentation |
+| Modify | `frontend/src/features/patient-similarity/components/__tests__/CohortSelectorBar.test.tsx` | Cover CTA copy, setup clarity affordances, imbalance warning states |
+| Modify | `frontend/src/features/patient-similarity/pages/__tests__/PatientSimilarityWorkspace.test.tsx` | Cover page-level composition, method explainer presence, CTA copy, modal suppression behavior if testable here |
+| Maybe add/modify | `frontend/src/features/patient-similarity/components/__tests__/SimilarityModeToggle.test.tsx` | Add focused tests for mode explainer copy and recommended-mode messaging if component logic grows |
+| Maybe add/modify | `frontend/src/components/layout/__tests__/*` or help tests | Add route-aware “What’s New” auto-open coverage if that logic lives outside patient-similarity tests |
+
+---
+
+## Current-State Notes From Code Inspection
+
+- `/patient-similarity` already renders `PatientSimilarityWorkspace`.
+- `PatientSimilarityWorkspace` owns source/cohort state, pipeline orchestration, step execution, and currently renders `SimilarityModeToggle` in the page header, separate from the setup bar.
+- `CohortSelectorBar` already fetches target/comparator cohort profiles via `useCohortProfile`, which makes it a natural place to compute size imbalance warnings without new backend calls.
+- The main compare CTA still renders `Compare`; expand renders `Find Similar`.
+- `SimilarityModeToggle` currently only renders pill buttons plus optional tiny recommended-mode text; it does not explain the modes sufficiently.
+- `ProfileComparisonPanel` already contains an interpretation sentence, but the top summary still has room for stronger hierarchy and cohort-context labeling.
+- `CovariateBalancePanel` already computes balanced/imbalanced counts and PSM recommendation logic, but it reads more like a technical panel than a quick-scanning analytical summary.
+- `WhatsNewModal` auto-opens globally from `MainLayout` based on `localStorage` version state and currently has no route-aware suppression.
+
+---
+
+## Implementation Order
+
+1. Add route-aware strategy for the “What’s New” modal so patient-similarity entry is not blocked.
+2. Rework the patient-similarity header/setup composition.
+3. Upgrade `CohortSelectorBar` to a labeled setup card with explicit CTA copy.
+4. Add imbalance heuristic + warning UI.
+5. Improve `SimilarityModeToggle` with always-visible explainer text.
+6. Make targeted readability improvements to top result panels.
+7. Update/add tests.
+8. Run targeted tests and TypeScript verification.
+
+---
+
+## Task 1: Make Entry Non-Blocking by Deferring or Suppressing “What’s New” Auto-Open
+
+**Files:**
+- `frontend/src/components/layout/MainLayout.tsx`
+- `frontend/src/features/help/components/WhatsNewModal.tsx`
+- tests near layout/help if present
+
+- [ ] Audit where route information is easiest to access (`MainLayout` via `useLocation` vs modal prop-driven strategy).
+- [ ] Implement the smallest route-aware mechanism that prevents automatic open on `/patient-similarity` while preserving manual open capability.
+- [ ] Keep the modal available from existing manual entry points.
+- [ ] Add tests for the selected strategy if the repo has layout/help test coverage nearby; otherwise document manual verification precisely.
+
+Recommended implementation shape:
+- `MainLayout` gets `location.pathname`
+- derive `disableWhatsNewAutoOpen = location.pathname.startsWith('/patient-similarity')`
+- pass prop to `WhatsNewModal`, e.g. `disableAutoOpen={disableWhatsNewAutoOpen}`
+- `WhatsNewModal` continues honoring `externalOpen`, but skips the localStorage-triggered auto-open effect when `disableAutoOpen` is true
+
+Acceptance notes:
+- direct navigation to `/patient-similarity` should not be blocked by the modal
+- opening “What’s New” manually elsewhere should still work
+
+---
+
+## Task 2: Recompose the Page Header Around a Single Setup Story
+
+**Files:**
+- `frontend/src/features/patient-similarity/pages/PatientSimilarityWorkspace.tsx`
+- `frontend/src/features/patient-similarity/components/CohortSelectorBar.tsx`
+- `frontend/src/features/patient-similarity/components/SimilarityModeToggle.tsx`
+
+- [ ] Move from “page title + detached mode toggle + toolbar” toward “page title + setup section” while keeping the overall page structure compact.
+- [ ] Decide whether the similarity-method explainer belongs inside the setup card or immediately beneath the title. Preferred: inside the setup area so all run prerequisites live together.
+- [ ] Ensure compare/expand mode still resets comparator state exactly as today.
+- [ ] Keep `AnalysisPipeline` and downstream execution behavior untouched unless a prop shape changes.
+
+Recommended layout:
+- page title + subtitle + Help button on top
+- beneath header, one setup card containing:
+  - setup title and one-line helper copy
+  - source selector
+  - workflow mode toggle (compare vs expand)
+  - target/selectors
+  - similarity method selector + explainer
+  - imbalance warning area in compare mode
+  - primary CTA + settings affordance
+
+Do not:
+- split setup into multiple disconnected panels
+- hide method choice inside settings
+- add step gating that blocks expert users
+
+---
+
+## Task 3: Upgrade `CohortSelectorBar` Into a Real Setup Card
+
+**Files:**
+- `frontend/src/features/patient-similarity/components/CohortSelectorBar.tsx`
+- maybe `GenerationStatusBanner.tsx`
+
+- [ ] Add visible section labeling (`Comparison setup` or mode-aware equivalent like `Similarity search setup` if product prefers dynamic copy).
+- [ ] Add per-control labels or compact helper captions so the user can parse source / mode / target / comparator quickly.
+- [ ] Rename the primary CTA:
+  - compare mode: `Compare cohorts`
+  - expand mode: `Find similar patients`
+- [ ] Ensure the settings affordance remains clearly secondary.
+- [ ] Keep generation-status information visible but subordinate to the main selection workflow.
+- [ ] Preserve accessibility labels and keyboard interaction.
+
+Recommended control labels:
+- `Data source`
+- `Workflow`
+- `Target cohort` or `Seed cohort`
+- `Comparator cohort`
+- `Similarity method`
+
+Recommended helper copy under selectors when useful:
+- compare mode: `Run profile comparison, covariate balance, and downstream matching analyses.`
+- expand mode: `Use a seed cohort to search for patients with a similar clinical profile.`
+
+---
+
+## Task 4: Add Cohort-Size Imbalance Heuristic and Warning UI
+
+**Files:**
+- `frontend/src/features/patient-similarity/components/CohortSelectorBar.tsx`
+- maybe `PatientSimilarityWorkspace.tsx` only if shared helper extraction makes props cleaner
+- related tests
+
+- [ ] Compute imbalance only when both compare-mode cohorts have resolved member counts.
+- [ ] Use profile `member_count` values already returned by `useCohortProfile`.
+- [ ] Add a pure helper function for warning state derivation so tests do not depend on render details.
+- [ ] Render a prominent inline warning block above or adjacent to the primary CTA, not hidden in tooltips.
+- [ ] Keep the warning informative rather than blocking.
+
+Recommended helper contract:
+```ts
+interface CohortImbalanceAssessment {
+  targetCount: number;
+  comparatorCount: number;
+  smallerCount: number;
+  largerCount: number;
+  sizeRatio: number;
+  severity: 'none' | 'warning' | 'severe';
+  headline?: string;
+  detail?: string;
+}
+```
+
+Recommended rules:
+- `none`: both cohorts >= 100 and ratio < 10
+- `warning`: smaller < 100 or ratio >= 10
+- `severe`: smaller < 50 or ratio >= 25
+
+Recommended rendering:
+- warning styling distinct from neutral status banners
+- icon + bold headline + one short detail line
+- counts formatted with locale separators
+
+Manual QA cases to cover:
+- 17,472 vs 59 => severe warning
+- 1,000 vs 150 => no warning if ratio < 10 and both >= 100
+- 800 vs 80 => warning because smaller < 100 and ratio 10
+- 500 vs 30 => severe because smaller < 50
+
+---
+
+## Task 5: Make Method Selection Self-Explanatory
+
+**Files:**
+- `frontend/src/features/patient-similarity/components/SimilarityModeToggle.tsx`
+- `frontend/src/features/patient-similarity/pages/PatientSimilarityWorkspace.tsx`
+- optional focused tests
+
+- [ ] Preserve the three current choices (`auto`, `interpretable`, `embedding`).
+- [ ] Add always-visible explainer text for all modes, not just a tiny note for auto.
+- [ ] Strengthen the selected-state styling so it reads as an analysis choice.
+- [ ] If recommended mode is available from source capabilities, surface it in plain language.
+- [ ] Ensure the component remains compact enough for the setup card.
+
+Recommended UI pattern:
+- segmented toggle or button row on top
+- beneath it, a 1–2 sentence explanation for the selected mode
+- optional small note: `Recommended default for most workflows.` when auto is selected
+
+Test expectations:
+- all three mode names visible
+- explanation text updates when selection changes
+- recommended-mode note appears only when supplied
+
+---
+
+## Task 6: Improve Result Readability Without Rewriting Panels
+
+**Files:**
+- `frontend/src/features/patient-similarity/components/ProfileComparisonPanel.tsx`
+- `frontend/src/features/patient-similarity/components/CovariateBalancePanel.tsx`
+
+- [ ] Keep current charts and step actions.
+- [ ] Improve top summary-card hierarchy, contrast, and interpretation copy.
+- [ ] Surface cohort-count context near top-line comparison results if feasible from existing result data.
+- [ ] Make covariate balance guidance easier to scan in one pass.
+
+Recommended `ProfileComparisonPanel` upgrades:
+- add a compact subtitle under `Overall divergence`, e.g. `Higher values indicate broader clinical differences between cohorts.`
+- show target and comparator counts if available from `result.source_cohort.member_count` and `result.target_cohort.member_count`
+- ensure divergence interpretation sentence is high enough contrast to read at a glance
+- consider a small badge/tag such as `Low divergence`, `Moderate divergence`, `High divergence`
+
+Recommended `CovariateBalancePanel` upgrades:
+- convert summary row into more legible metric cards/badges using existing design tokens
+- make the 0.1 SMD threshold explanation more visible
+- keep `Run Propensity Score Matching` as a clear recommended next step only when imbalance exists
+- preserve `Continue to Landscape` as a non-blocking path
+
+Non-goals:
+- no chart library changes
+- no new backend metrics
+- no broad redesign of downstream pipeline panels
+
+---
+
+## Task 7: Update Tests
+
+**Files:**
+- `frontend/src/features/patient-similarity/components/__tests__/CohortSelectorBar.test.tsx`
+- `frontend/src/features/patient-similarity/pages/__tests__/PatientSimilarityWorkspace.test.tsx`
+- optional: `frontend/src/features/patient-similarity/components/__tests__/SimilarityModeToggle.test.tsx`
+- optional: layout/help tests for modal suppression
+
+- [ ] Update old CTA assertions from `Compare` / `Find Similar` to new explicit labels.
+- [ ] Add compare-mode imbalance warning coverage using mocked cohort profiles.
+- [ ] Add severe-warning coverage for an extreme ratio example.
+- [ ] Add method explainer coverage so `Auto / Interpretable / Embedding` are not just labels.
+- [ ] Add page-level coverage that the setup area renders with expected helper text.
+- [ ] If route-aware modal suppression is testable, add coverage where direct patient-similarity rendering does not auto-show the blocking modal.
+
+Suggested test scenarios:
+1. compare mode renders `Compare cohorts`
+2. expand mode renders `Find similar patients`
+3. compare mode with both cohorts selected and 17472 vs 59 shows severe warning copy
+4. compare mode with near-balanced counts shows no imbalance warning
+5. method explainer defaults to Auto guidance
+6. clicking method options updates explainer text
+7. workspace renders setup heading and mode-aware action labels
+
+---
+
+## Task 8: Verification and Regression Pass
+
+- [ ] Verify compare mode still kicks off profile + balance pipeline stages.
+- [ ] Verify expand mode still kicks off centroid + similar-patients pipeline stages.
+- [ ] Verify no warning appears before both compare cohorts are selected and profile counts are loaded.
+- [ ] Verify warning disappears or recalculates when cohorts/mode/source change.
+- [ ] Verify settings drawer still opens from setup area.
+- [ ] Verify “What’s New” no longer blocks entry to `/patient-similarity`.
+- [ ] Verify manual release-notes access still works where expected.
+
+---
+
+## Acceptance Criteria
+
+The implementation is complete only when all of the following are true:
+
+- [ ] Entering `/patient-similarity` no longer starts with a blocking “What’s New in Parthenon” modal.
+- [ ] The page presents a clearly identifiable setup area rather than an ambiguous toolbar row.
+- [ ] The compare-mode primary CTA reads `Compare cohorts`.
+- [ ] The expand-mode primary CTA reads `Find similar patients` or approved equivalent.
+- [ ] The method selector explains `Auto`, `Interpretable`, and `Embedding` with always-visible guidance.
+- [ ] Compare mode shows an obvious imbalance warning for materially bad cohort-size pairings.
+- [ ] The extreme example of 17,472 vs 59 would trigger the strongest warning state.
+- [ ] Result summaries are easier to interpret quickly, with improved contrast and/or interpretation copy.
+- [ ] Existing compare and expand workflows still function without forced wizard gating.
+- [ ] TypeScript and relevant patient-similarity tests pass.
+- [ ] Changes stay aligned with Parthenon’s design language and do not feel bolted on.
+
+---
+
+## Test Commands
+
+From `/home/smudoshi/Github/Parthenon/frontend`:
+
+```bash
+npx vitest run src/features/patient-similarity/pages/__tests__/PatientSimilarityWorkspace.test.tsx src/features/patient-similarity/components/__tests__/CohortSelectorBar.test.tsx
+```
+
+```bash
+npm test -- --runInBand src/features/patient-similarity
+```
+
+```bash
+npx tsc --noEmit
+```
+
+If a new focused test file is added for `SimilarityModeToggle` or layout/help behavior, include it in the `vitest run` command.
+
+---
+
+## Manual Verification Checklist
+
+1. Navigate directly to `/patient-similarity` with an unseen changelog version.
+   - Expected: page is usable immediately; no blocking release-notes modal appears.
+2. Confirm the setup area reads clearly without prior training.
+   - Expected: source, workflow, cohorts, method, and primary action are visually grouped.
+3. In compare mode, select a target and comparator with extreme imbalance.
+   - Expected: visible warning with counts and cautionary copy.
+4. Switch to expand mode.
+   - Expected: comparator controls disappear, CTA copy changes, warning disappears.
+5. Run a compare flow.
+   - Expected: pipeline steps still populate as before.
+6. Inspect top result panels.
+   - Expected: overall divergence and covariate balance can be interpreted in one quick scan.
+
+---
+
+## Risks / Open Questions
+
+1. Modal suppression scope
+   - Open question: should the “What’s New” auto-open be suppressed only for `/patient-similarity`, or for all deep analytical workspaces?
+   - Risk: a route-specific fix may feel ad hoc if other pages have the same complaint.
+
+2. Method recommendation source
+   - Open question: is a reliable per-source recommended method already available in current queries/state, or does the UI only know the selected mode?
+   - Risk: if `recommendedMode` is not truly grounded, avoid overpromising dynamic recommendations.
+
+3. Warning threshold calibration
+   - Open question: do product/clinical stakeholders want 10x/25x and 100/50 thresholds, or a different standard?
+   - Risk: too-sensitive warnings may become background noise; too-weak warnings miss real analytical risk.
+
+4. Layout density
+   - Risk: putting workflow mode, cohort selectors, method selection, banners, warning copy, settings, and CTA in one compact card could get crowded on narrower widths.
+   - Mitigation: allow graceful wrapping and keep helper text concise.
+
+5. Existing tests are shallow
+   - Risk: current patient-similarity tests mostly assert static text, so implementation work may require broader mocking of hooks and route state than the current suite uses.
+
+---
+
+## Definition of Done
+
+A reviewer should be able to open `/patient-similarity` and immediately understand:
+- what to select
+- what button to press
+- what similarity method they are choosing
+- when a cohort comparison is analytically questionable
+- what the first result means
+
+Ship the smallest coherent set of changes that achieves that outcome while preserving the current pipeline workflow.

--- a/docs/superpowers/plans/2026-04-14-patient-similarity-saved-runs-todo.md
+++ b/docs/superpowers/plans/2026-04-14-patient-similarity-saved-runs-todo.md
@@ -1,0 +1,36 @@
+# Patient Similarity Saved Runs Todo
+
+## Goal
+
+Researchers should be able to return to Cohort Similarities without rerunning completed comparison, similarity, downstream analysis, or LLM interpretation steps. Saved work should be scoped to the signed-in user and presented as:
+
+- **My Comparisons** when the workflow is `Compare cohorts`
+- **My Similarities** when the workflow is `Find similar patients`
+
+## Backend
+
+- Add persistent run metadata for each user, workflow mode, selected source, selected cohorts, similarity method, settings, status, and last-opened timestamp.
+- Add persistent run step records keyed by run and step id, including status, summary, full aggregate result JSON, result hash, execution time, and completed timestamp.
+- Add persistent interpretation records keyed by user, workflow context, step id, and result hash so an LLM interpretation can be reused when the aggregate data has not changed.
+- Add owner-scoped API endpoints to list, create, show/open, update, delete, and save step outputs.
+- Extend the on-demand interpretation endpoint to accept optional run context and return cached interpretations when possible.
+- Keep all saved payloads aggregate-only for the LLM path; do not persist or send individual patient identifiers in interpretation summaries beyond the existing saved analysis result payloads.
+
+## Frontend
+
+- Add patient-similarity API types and React Query hooks for saved runs and saved steps.
+- Add a workflow-aware dropdown in the top selection panel:
+  - `My Comparisons` for compare mode.
+  - `My Similarities` for expand mode.
+- Selecting a saved run should restore source, cohort selections, similarity mode/settings, completed step payloads, and saved interpretations.
+- Starting a new analysis after changing selections should create or update the active saved run and autosave completed step outputs.
+- Interpretation requests should include run and step identifiers so returned interpretations are cached and shown on page reload.
+- Maintain visual alignment with the gold-standard form controls already used by the selector panel.
+
+## Verification
+
+- Add backend coverage for interpretation hash/cache behavior and run ownership rules where feasible.
+- Run PHP lint on touched backend files.
+- Run focused Pest tests for patient similarity interpretation/persistence.
+- Run TypeScript and focused frontend tests for the workspace and selector panel.
+- Deploy frontend with `./deploy.sh --frontend` after frontend changes pass.

--- a/docs/superpowers/specs/2026-04-14-patient-similarity-qa-punch-list-subagent-prompt.md
+++ b/docs/superpowers/specs/2026-04-14-patient-similarity-qa-punch-list-subagent-prompt.md
@@ -1,0 +1,299 @@
+# Patient Similarity QA Punch List — Subagent Prompt
+
+> For Hermes subagents: implement this as a focused frontend/product-quality pass on the Patient Similarity workspace. Treat this document as your full brief. Do not assume unstated context. Inspect the codebase, make targeted improvements, run relevant tests, and leave the branch in a reviewable state.
+
+## Mission
+
+Improve the Patient Similarity page so it behaves like a polished research workflow instead of an internal analytics console.
+
+The highest-priority goals are:
+1. Remove workflow friction on page entry.
+2. Clarify the setup/actions at the top of the page.
+3. Add stronger analytical guardrails for bad cohort comparisons.
+4. Improve method discoverability and result readability.
+5. Preserve the existing analytical pipeline and avoid unnecessary rewrites.
+
+This is not a greenfield redesign. Work with the current Patient Similarity workspace and make the most impactful UX/product improvements that can realistically ship in one implementation pass.
+
+## Scope
+
+Primary scope:
+- `frontend/src/features/patient-similarity/pages/PatientSimilarityWorkspace.tsx`
+- `frontend/src/features/patient-similarity/components/CohortSelectorBar.tsx`
+- `frontend/src/features/patient-similarity/components/SimilarityModeToggle.tsx`
+- `frontend/src/features/patient-similarity/components/ProfileComparisonPanel.tsx`
+- `frontend/src/features/patient-similarity/components/CovariateBalancePanel.tsx`
+- `frontend/src/features/patient-similarity/components/PipelineStep.tsx`
+- `frontend/src/features/patient-similarity/components/AnalysisPipeline.tsx`
+- `frontend/src/features/patient-similarity/components/GenerationStatusBanner.tsx`
+- `frontend/src/features/patient-similarity/pages/__tests__/PatientSimilarityWorkspace.test.tsx`
+- `frontend/src/features/patient-similarity/components/__tests__/CohortSelectorBar.test.tsx`
+- any nearby tests/styles/helpers needed to support the changes
+
+Secondary scope, only if needed:
+- shared page-level UI primitives already used elsewhere in the frontend
+- the release-notes / "What's New" entry behavior if the blocker can be addressed cleanly from existing app infrastructure
+
+Out of scope unless absolutely required:
+- major backend API redesign
+- new analytics algorithms
+- replacing the full Patient Similarity pipeline architecture
+- unrelated app-wide visual refactors
+
+## Known findings from QA
+
+These findings were observed during live manual inspection of the production page.
+
+### Environment observations
+- Production page is functional and renders comparison results.
+- Local environment has route issues:
+  - `/` returned 403
+  - `/patient-similarity` returned 500
+- No browser console errors were seen during production use.
+
+### UX / product issues
+1. A large "What's New in Parthenon" modal blocks the page on arrival and must be dismissed before the workflow can begin.
+2. The top control row is ambiguous. The current labels and arrangement make the workflow hard to parse quickly.
+3. The method toggle (`Auto`, `Interpretable`, `Embedding`) is not self-explanatory enough.
+4. The page allows analytically weak comparisons, such as very large cohort-size imbalance, without strong warning copy.
+5. Visualizations are useful but some chart/summary content feels low-contrast or less legible than it should be.
+6. The page should feel more like a guided analysis workflow with a clear primary action and better setup hierarchy.
+
+### Concrete example observed
+A successful production comparison was run with:
+- Target cohort size: 17,472
+- Comparator cohort size: 59
+- Overall divergence displayed: 33%
+
+This is exactly the kind of comparison that should surface an analytical caution in the UI.
+
+## Existing architecture context
+
+Current route:
+- `/patient-similarity` renders `PatientSimilarityWorkspace`
+
+Current page structure already includes:
+- page title + subtitle
+- top controls for source / mode / target / comparator / compare
+- a pipeline of analysis steps
+- compare mode and expand mode
+- settings drawer
+- profile comparison / covariate balance / PSM / landscape / phenotype discovery / network fusion modules
+
+Important implementation notes from current code:
+- `PatientSimilarityWorkspace.tsx` owns pipeline state and orchestration.
+- `CohortSelectorBar.tsx` currently renders source select, mode toggle, cohort dropdowns, generation banners, and the main action button.
+- `PatientSimilarityWorkspace.tsx` currently stores the method mode separately as `similarityMode`, while the page workflow mode (`compare` vs `expand`) is part of `usePipeline()`.
+- There is already a `SimilarityModeToggle` component imported into the workspace.
+- The compare-mode primary action label currently appears as a generic `Compare` in `CohortSelectorBar.tsx`.
+
+## Product direction
+
+Implement the following product direction with pragmatic, codebase-native changes.
+
+### 1. Make setup feel like a single coherent "Comparison setup" area
+Target outcome:
+- A user should immediately understand what must be selected before running analysis.
+- The top section should feel like a setup card/form, not a toolbar.
+
+Preferred approach:
+- Group top controls visually as one setup region.
+- Preserve compactness, but add hierarchy.
+- Make the primary CTA visually and semantically obvious.
+
+### 2. Clarify action naming
+Target outcome:
+- A first-time user should know the next action in under 3 seconds.
+
+Preferred copy direction:
+- Compare-mode primary CTA should say `Compare cohorts` instead of `Compare`.
+- Expand-mode CTA should say something explicit like `Find similar patients` or equivalent if that already matches the mode intent.
+- If secondary controls remain, they should read as helper actions, not competing primaries.
+
+### 3. Explain method selection
+Target outcome:
+- Users should understand what `Auto`, `Interpretable`, and `Embedding` mean.
+
+Preferred approach:
+- Add short helper text and/or tooltips.
+- Strengthen selected-state styling.
+- Make it obvious that this is a similarity method choice, not a cosmetic display toggle.
+
+Suggested conceptual copy:
+- `Auto`: Recommended default; choose the best available method
+- `Interpretable`: Feature-based comparison optimized for explainability
+- `Embedding`: Representation-based comparison optimized for flexible similarity search
+
+You do not have to use this exact wording, but the end result should teach users what they are choosing.
+
+### 4. Add analytical guardrails for cohort-size imbalance
+Target outcome:
+- The UI should warn users when the cohort pairing is likely unstable or misleading.
+
+Required behavior:
+- When both cohorts are selected in compare mode, compute a simple size-imbalance heuristic.
+- Show a visible warning when the comparison is extreme enough to merit caution.
+
+Suggested minimum heuristic:
+- warn when one cohort is much smaller than the other (for example ratio > 10x or similarly sensible threshold)
+- warn when the smaller cohort falls below a low sample-size threshold
+
+Suggested warning copy direction:
+- `Comparator cohort is much smaller than target cohort. Similarity and matching results may be unstable.`
+
+The exact thresholds and wording can be improved if the codebase already has conventions, but the warning must be hard to miss.
+
+### 5. Improve summary/result readability
+Target outcome:
+- After comparison, the top results should be easier to interpret quickly.
+
+Preferred approach:
+- Strengthen contrast where needed.
+- Add concise interpretation copy near key summary metrics where appropriate.
+- Avoid large structural rewrites if smaller improvements achieve the goal.
+
+### 6. Keep the page pipeline-oriented, not wizard-gated
+Target outcome:
+- The UI should suggest a sequence without hard-forcing one.
+
+Preferred approach:
+- Preserve the pipeline model.
+- Emphasize recommended next steps where already supported.
+- Do not convert the experience into a mandatory wizard.
+
+## Deliverables
+
+### Required deliverable A: shipped code changes
+Make the UI/product improvements in code.
+
+### Required deliverable B: automated test coverage
+Add or update tests for at least:
+- top CTA copy / behavior
+- cohort-size imbalance warning behavior
+- method explainer / method toggle presence and clarity
+- any changed component behavior with meaningful logic
+
+### Required deliverable C: concise implementation note
+At the end of your work, prepare a short summary containing:
+- files changed
+- what user-visible behavior changed
+- what thresholds/rules were chosen for warnings
+- what tests were run
+- any unresolved follow-up items
+
+## Acceptance criteria
+
+The task is complete only when all of the following are true:
+
+1. The Patient Similarity page has a clearly identifiable primary setup area.
+2. The compare CTA no longer reads as a vague generic action.
+3. The method selection is meaningfully explained in the UI.
+4. An obvious imbalance warning appears for materially bad cohort-size pairings.
+5. Existing compare/expand workflow still functions.
+6. TypeScript and relevant tests pass.
+7. Changes remain aligned with the existing Parthenon design language and do not feel bolted on.
+
+## Implementation guidance
+
+### Recommended file-level approach
+
+#### `PatientSimilarityWorkspace.tsx`
+- Audit current page layout and determine whether the similarity method explainer belongs near the page title or within the setup region.
+- Pass any new warning/helper props into `CohortSelectorBar`.
+- Avoid duplicating logic between workspace and selector bar.
+- Prefer computing warning inputs from already-available cohort profile/member count data.
+
+#### `CohortSelectorBar.tsx`
+- This is likely the primary place to:
+  - rename CTA labels
+  - add setup grouping
+  - add imbalance warning UI
+  - improve help text / labels
+- Preserve accessibility semantics.
+- Keep compare mode and expand mode clearly differentiated.
+
+#### `SimilarityModeToggle.tsx`
+- Improve active-state clarity.
+- Add concise explanatory UI.
+- Make sure the semantics are understandable without needing outside documentation.
+
+#### result panels
+- Touch only as much as needed to improve readability / interpretation.
+- Favor small, high-value copy and contrast changes over major layout churn.
+
+### Design / UX constraints
+- Respect the existing Parthenon design system and token usage.
+- Avoid introducing a second visual language.
+- Avoid giant blocks of explanatory copy; aim for crisp, research-friendly language.
+- Prefer inline guidance over modal guidance.
+- The page should still feel powerful for experienced users.
+
+### Accessibility expectations
+- New warnings should be readable and visually distinct.
+- Helper text should not rely only on color.
+- Button labels and control labels must remain accessible.
+- Tooltips alone are not enough; there should be at least some always-visible explanation for method choice.
+
+## Suggested execution plan
+
+1. Inspect current Patient Similarity workspace and top controls.
+2. Implement setup-area hierarchy and rename the primary CTA.
+3. Add method explanation and stronger toggle states.
+4. Implement cohort-size imbalance warning logic + UI.
+5. Make targeted readability improvements to summary/results if needed.
+6. Update and add tests.
+7. Run typecheck and targeted test suite.
+8. Summarize changes and call out any follow-up work.
+
+## Commands to run
+
+From `./Parthenon/frontend`:
+
+```bash
+npm test -- --runInBand src/features/patient-similarity
+```
+
+```bash
+npx vitest run src/features/patient-similarity/pages/__tests__/PatientSimilarityWorkspace.test.tsx src/features/patient-similarity/components/__tests__/CohortSelectorBar.test.tsx
+```
+
+```bash
+npx tsc --noEmit
+```
+
+If there is an existing narrower test command already used in this repo for the feature, use it.
+
+## References inside the repo
+
+Useful context documents:
+- `docs/superpowers/plans/2026-04-11-patient-similarity-ux-alignment.md`
+- `docs/superpowers/plans/2026-04-10-patient-similarity-ux-redesign.md`
+- `docs/blog/2026-04-10-patient-similarity-workspace-redesign.md`
+
+Useful source files:
+- `frontend/src/features/patient-similarity/pages/PatientSimilarityWorkspace.tsx`
+- `frontend/src/features/patient-similarity/components/CohortSelectorBar.tsx`
+- `frontend/src/features/patient-similarity/components/SimilarityModeToggle.tsx`
+- `frontend/src/features/patient-similarity/components/ProfileComparisonPanel.tsx`
+- `frontend/src/features/patient-similarity/components/CovariateBalancePanel.tsx`
+
+## Non-goals / anti-patterns
+
+Do not:
+- rewrite the whole page from scratch just to improve the setup bar
+- add hidden magical behavior without user feedback
+- introduce a wizard that blocks experienced users
+- bury the imbalance warning in tooltips or developer diagnostics
+- change backend contracts unless absolutely necessary
+- broaden into unrelated product cleanup
+
+## Definition of done
+
+Your implementation is done when a reviewer can open the page and immediately understand:
+- what to select
+- what button to press
+- what method they are using
+- when a cohort comparison is statistically questionable
+- what the first result means
+
+Ship the smallest coherent set of changes that achieves that outcome.

--- a/frontend/src/features/patient-similarity/components/AiStepInterpretationPanel.tsx
+++ b/frontend/src/features/patient-similarity/components/AiStepInterpretationPanel.tsx
@@ -1,0 +1,164 @@
+import { useState } from "react";
+import { AlertTriangle, Loader2, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Modal } from "@/components/ui";
+import type { CohortSimilarityStepInterpretation } from "../types/patientSimilarity";
+
+interface AiStepInterpretationPanelProps {
+  interpretation?: CohortSimilarityStepInterpretation;
+  isLoading?: boolean;
+  onInterpret: (forceRefresh?: boolean) => void;
+}
+
+export function AiStepInterpretationPanel({
+  interpretation,
+  isLoading = false,
+  onInterpret,
+}: AiStepInterpretationPanelProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const isInterpreted = interpretation?.status === "interpreted";
+  const hasError = interpretation?.status === "unavailable" || interpretation?.status === "unparseable";
+
+  const handleInterpret = () => {
+    setModalOpen(true);
+    onInterpret(isInterpreted);
+  };
+
+  return (
+    <div className="mt-5 border-t border-border-subtle pt-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Sparkles size={16} className="text-primary" />
+            <h4 className="text-sm font-semibold text-text-primary">Researcher Interpretation</h4>
+          </div>
+          <p className="text-xs text-text-muted">
+            Generate a complete aggregate-only reading of this step using the configured LLM provider.
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleInterpret}
+          disabled={isLoading}
+          className={cn(
+            "inline-flex items-center justify-center gap-2 rounded-md border border-border-default px-3 py-2 text-sm font-medium transition-colors",
+            "text-text-secondary hover:border-border-hover hover:bg-surface-overlay hover:text-text-primary",
+            "disabled:cursor-not-allowed disabled:opacity-60",
+          )}
+        >
+          {isLoading ? <Loader2 size={15} className="animate-spin" /> : <Sparkles size={15} />}
+          {isInterpreted ? "Regenerate" : "Interpret this step"}
+        </button>
+      </div>
+
+      {isInterpreted && interpretation ? (
+        <button
+          type="button"
+          onClick={() => setModalOpen(true)}
+          className="mt-3 text-xs font-medium text-primary transition-colors hover:text-primary-light"
+        >
+          View latest interpretation
+        </button>
+      ) : null}
+
+      <Modal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        title="Researcher Interpretation"
+        size="lg"
+      >
+        {isLoading ? (
+          <div className="flex min-h-[260px] flex-col items-center justify-center gap-4 text-center">
+            <Loader2 size={36} className="animate-spin text-primary" />
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-text-primary">Interpreting this step...</p>
+              <p className="max-w-md text-sm text-text-muted">
+                The configured LLM service is reviewing aggregate results and preparing clinical implications, cautions, and next steps.
+              </p>
+            </div>
+          </div>
+        ) : isInterpreted && interpretation ? (
+          <InterpretationContent interpretation={interpretation} />
+        ) : hasError && interpretation ? (
+          <div className="flex min-h-[220px] items-start gap-3 rounded-md border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-text-secondary">
+            <AlertTriangle size={18} className="mt-0.5 shrink-0 text-warning" />
+            <div className="space-y-1">
+              <p className="font-semibold text-text-primary">Interpretation unavailable</p>
+              <p>{interpretation.error || "The model response could not be parsed."}</p>
+            </div>
+          </div>
+        ) : (
+          <div className="flex min-h-[220px] flex-col items-center justify-center gap-3 text-center">
+            <Sparkles size={28} className="text-primary" />
+            <p className="text-sm text-text-muted">Start an interpretation to review this step.</p>
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+}
+
+function InterpretationContent({
+  interpretation,
+}: {
+  interpretation: CohortSimilarityStepInterpretation;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2 text-xs text-text-muted">
+        <span className="rounded bg-surface-overlay px-2 py-1">
+          {interpretation.provider} · {interpretation.model}
+        </span>
+        <span className="rounded bg-info/10 px-2 py-1 text-info">
+          {Math.round(interpretation.confidence * 100)}% confidence
+        </span>
+      </div>
+
+      <div className="space-y-2">
+        {interpretation.summary ? (
+          <p className="text-sm font-medium text-text-primary">{interpretation.summary}</p>
+        ) : null}
+        <p className="whitespace-pre-line text-sm leading-6 text-text-secondary">
+          {interpretation.interpretation}
+        </p>
+      </div>
+
+      <InterpretationList title="Clinical Implications" items={interpretation.clinical_implications} />
+      <InterpretationList title="Methodologic Cautions" items={interpretation.methodologic_cautions} tone="warning" />
+      <InterpretationList title="Recommended Next Steps" items={interpretation.recommended_next_steps} />
+    </div>
+  );
+}
+
+function InterpretationList({
+  title,
+  items,
+  tone = "default",
+}: {
+  title: string;
+  items: string[];
+  tone?: "default" | "warning";
+}) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <p
+        className={cn(
+          "text-xs font-semibold uppercase tracking-[0.08em]",
+          tone === "warning" ? "text-warning" : "text-text-ghost",
+        )}
+      >
+        {title}
+      </p>
+      <ul className="list-disc space-y-1 pl-5 text-sm leading-6 text-text-secondary">
+        {items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Risk: LOW — pure additive schema + service

Adds persistence + AI interpretation layer for Patient Similarity runs. 14 files, all genuinely new (no existing files modified).

## Files
- 3 Models: PatientSimilarityRun, PatientSimilarityRunStep, PatientSimilarityInterpretation
- 1 Service: CohortSimilarityInterpretationService (wraps LLM step-by-step analysis)
- 3 migrations: patient_similarity_runs, _run_steps, _interpretations (2026_04_14_000003-000005)
- 1 unit test
- 1 frontend component: AiStepInterpretationPanel
- 4 planning/spec docs + 1 devlog

## Known limitation
**Does NOT include the existing PatientSimilarityController.php edits** (those are in the stash's DIFFERS set — 360+ lines of edits still need per-file reconciliation against main's version).

That means after merge:
- The 3 new tables exist
- The new models can be used programmatically
- BUT the controller won't actually call into them until the DIFFERS edits are reconciled separately

This is a known-safe half-step that doesn't break anything currently live.

## Deployment
\`\`\`bash
./deploy.sh --db  # runs 3 new migrations (they use --path guard)
\`\`\`

## Test plan
- [ ] Migrations run clean
- [ ] \`\\d app.patient_similarity_runs\` shows expected columns
- [ ] Existing Patient Similarity UMAP workflow still works (unchanged)
- [ ] python tests still green

Verified in worktree: Pint ✓, PHPStan ✓, tsc ✓, vite build ✓.