### PR TITLE
feat(publish): PublicationDraft autosave + OHDSI report bundle export/import

### DIFF
--- a/backend/app/Models/App/PublicationDraft.php
+++ b/backend/app/Models/App/PublicationDraft.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models\App;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PublicationDraft extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'study_id',
+        'title',
+        'template',
+        'document_json',
+        'status',
+        'last_opened_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'user_id' => 'integer',
+            'study_id' => 'integer',
+            'document_json' => 'array',
+            'last_opened_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return HasMany<PublicationReportBundle, $this>
+     */
+    public function reportBundles(): HasMany
+    {
+        return $this->hasMany(PublicationReportBundle::class);
+    }
+}

--- a/backend/app/Models/App/PublicationReportBundle.php
+++ b/backend/app/Models/App/PublicationReportBundle.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models\App;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PublicationReportBundle extends Model
+{
+    protected $fillable = [
+        'publication_draft_id',
+        'user_id',
+        'direction',
+        'format',
+        'bundle_json',
+        'metadata_json',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'publication_draft_id' => 'integer',
+            'user_id' => 'integer',
+            'bundle_json' => 'array',
+            'metadata_json' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<PublicationDraft, $this>
+     */
+    public function publicationDraft(): BelongsTo
+    {
+        return $this->belongsTo(PublicationDraft::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Services/Publication/PublicationReportBundleService.php
+++ b/backend/app/Services/Publication/PublicationReportBundleService.php
@@ -1,0 +1,475 @@
+<?php
+
+namespace App\Services\Publication;
+
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use JsonException;
+
+class PublicationReportBundleService
+{
+    public const FORMATS = [
+        'ohdsi_report_bundle',
+        'ohdsi_report_generator_r',
+        'ohdsi_sharing_bundle',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function export(array $payload, string $format): array
+    {
+        $format = $this->normalizeFormat($format);
+        $document = $this->documentFromPayload($payload);
+
+        return match ($format) {
+            'ohdsi_report_bundle' => $this->jsonArtifact(
+                $format,
+                $this->slug($document['title']).'.ohdsi-report-bundle.json',
+                $this->reportBundle($document),
+            ),
+            'ohdsi_sharing_bundle' => $this->jsonArtifact(
+                $format,
+                $this->slug($document['title']).'.ohdsi-sharing-bundle.json',
+                $this->sharingBundle($document),
+            ),
+            'ohdsi_report_generator_r' => $this->textArtifact(
+                $format,
+                $this->slug($document['title']).'.ohdsi-report-generator.R',
+                $this->reportGeneratorScript($document),
+            ),
+            default => throw new \InvalidArgumentException("Unknown publication report format: {$format}"),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{title: string, template: string, document_json: array<string, mixed>, metadata: array<string, mixed>}
+     */
+    public function parseImportPayload(array $payload): array
+    {
+        $format = $this->normalizeFormat((string) ($payload['format'] ?? 'ohdsi_report_bundle'));
+        $artifact = $payload['artifact'] ?? $payload['content'] ?? $payload;
+
+        $parsed = match ($format) {
+            'ohdsi_report_bundle', 'ohdsi_sharing_bundle' => $this->parseBundleArtifact($artifact),
+            'ohdsi_report_generator_r' => $this->parseScriptArtifact((string) $artifact),
+            default => throw new \InvalidArgumentException("Unknown publication report format: {$format}"),
+        };
+
+        $document = $parsed['document'] ?? null;
+        if (! is_array($document)) {
+            throw ValidationException::withMessages([
+                'artifact' => 'Report bundle does not contain a publication document.',
+            ]);
+        }
+
+        $title = trim((string) ($payload['title'] ?? $document['title'] ?? 'Imported OHDSI report'));
+        $title = $title !== '' ? $title : 'Imported OHDSI report';
+        $template = (string) ($document['template'] ?? 'generic-ohdsi');
+        $sections = is_array($document['sections'] ?? null) ? array_values($document['sections']) : [];
+        $authors = is_array($document['authors'] ?? null)
+            ? array_values(array_filter($document['authors'], 'is_string'))
+            : [];
+
+        return [
+            'title' => $title,
+            'template' => $template !== '' ? $template : 'generic-ohdsi',
+            'document_json' => [
+                'step' => 4,
+                'selectedExecutions' => is_array($document['selectedExecutions'] ?? null)
+                    ? array_values($document['selectedExecutions'])
+                    : [],
+                'sections' => $sections,
+                'title' => $title,
+                'authors' => $authors,
+                'template' => $template !== '' ? $template : 'generic-ohdsi',
+            ],
+            'metadata' => [
+                'format' => $format,
+                'source_metadata' => is_array($parsed['metadata'] ?? null) ? $parsed['metadata'] : [],
+            ],
+        ];
+    }
+
+    public function normalizeFormat(string $format): string
+    {
+        $normalized = strtolower(str_replace(['-', ' '], '_', trim($format)));
+        $aliases = [
+            'report_bundle' => 'ohdsi_report_bundle',
+            'ohdsi_report' => 'ohdsi_report_bundle',
+            'report_generator' => 'ohdsi_report_generator_r',
+            'ohdsi_report_generator' => 'ohdsi_report_generator_r',
+            'sharing_bundle' => 'ohdsi_sharing_bundle',
+            'ohdsi_sharing' => 'ohdsi_sharing_bundle',
+        ];
+        $normalized = $aliases[$normalized] ?? $normalized;
+
+        if (! in_array($normalized, self::FORMATS, true)) {
+            throw ValidationException::withMessages([
+                'format' => 'Unsupported OHDSI report bundle format.',
+            ]);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function documentFromPayload(array $payload): array
+    {
+        $sections = array_values(array_filter(
+            $payload['sections'] ?? [],
+            fn (array $section): bool => (bool) ($section['included'] ?? false),
+        ));
+
+        return [
+            'title' => trim((string) ($payload['title'] ?? 'Untitled')) ?: 'Untitled',
+            'authors' => is_array($payload['authors'] ?? null) ? array_values($payload['authors']) : [],
+            'template' => (string) ($payload['template'] ?? 'generic-ohdsi'),
+            'sections' => $sections,
+            'selectedExecutions' => is_array($payload['selected_executions'] ?? null)
+                ? array_values($payload['selected_executions'])
+                : [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $document
+     * @return array<string, mixed>
+     */
+    private function reportBundle(array $document): array
+    {
+        $reportJson = json_encode($document, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+        $manifest = $this->manifest($document, 'ohdsi-report-generator');
+
+        return [
+            'package' => [
+                'name' => Str::studly($this->slug($document['title'])).'Report',
+                'type' => 'parthenon-ohdsi-report-bundle',
+                'engine' => 'OhdsiReportGenerator',
+                'created_at' => now()->toISOString(),
+            ],
+            'manifest' => $manifest,
+            'document' => $document,
+            'files' => [
+                [
+                    'path' => 'inst/reports/report.json',
+                    'kind' => 'json',
+                    'content' => $reportJson,
+                ],
+                [
+                    'path' => 'inst/reports/report.md',
+                    'kind' => 'markdown',
+                    'content' => $this->markdown($document),
+                ],
+                [
+                    'path' => 'inst/reports/report-manifest.json',
+                    'kind' => 'json',
+                    'content' => json_encode($manifest, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT),
+                ],
+                [
+                    'path' => 'R/generate-ohdsi-report.R',
+                    'kind' => 'r',
+                    'content' => $this->reportGeneratorScript($document),
+                ],
+                ...$this->figureFiles($document),
+                ...$this->tableFiles($document),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $document
+     * @return array<string, mixed>
+     */
+    private function sharingBundle(array $document): array
+    {
+        $bundle = $this->reportBundle($document);
+        $sharingManifest = [
+            'type' => 'ohdsi-sharing',
+            'package' => 'OhdsiSharing',
+            'created_at' => now()->toISOString(),
+            'title' => $document['title'],
+            'assets' => array_map(
+                static fn (array $file): string => (string) $file['path'],
+                $bundle['files'],
+            ),
+        ];
+
+        $bundle['package']['type'] = 'parthenon-ohdsi-sharing-bundle';
+        $bundle['package']['engine'] = 'OhdsiSharing';
+        $bundle['sharing_manifest'] = $sharingManifest;
+        $bundle['files'][] = [
+            'path' => 'inst/sharing/ohdsi-sharing-manifest.json',
+            'kind' => 'json',
+            'content' => json_encode($sharingManifest, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT),
+        ];
+        $bundle['files'][] = [
+            'path' => 'R/share-results.R',
+            'kind' => 'r',
+            'content' => $this->sharingScript($document),
+        ];
+
+        return $bundle;
+    }
+
+    /**
+     * @param  array<string, mixed>  $document
+     * @return array<string, mixed>
+     */
+    private function manifest(array $document, string $engine): array
+    {
+        return [
+            'title' => $document['title'],
+            'template' => $document['template'],
+            'engine' => $engine,
+            'section_count' => count($document['sections'] ?? []),
+            'figure_count' => count($this->figureFiles($document)),
+            'table_count' => count($this->tableFiles($document)),
+            'exported_at' => now()->toISOString(),
+            'source' => 'parthenon',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $document
+     */
+    private function reportGeneratorScript(array $document): string
+    {
+        $encoded = base64_encode(json_encode($document, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return <<<R
+# Parthenon OHDSI report bundle handoff
+# Requires jsonlite. OhdsiReportGenerator is used when installed in the R runtime.
+# PARTHENON_REPORT_JSON_BEGIN
+{$encoded}
+# PARTHENON_REPORT_JSON_END
+
+report_document <- jsonlite::fromJSON(rawToChar(jsonlite::base64_dec("{$encoded}")), simplifyVector = FALSE)
+
+if (requireNamespace("OhdsiReportGenerator", quietly = TRUE)) {
+  message("OhdsiReportGenerator is installed. report_document is ready for package-level rendering.")
+} else {
+  message("OhdsiReportGenerator is not installed. report_document remains a portable OHDSI report handoff.")
+}
+R;
+    }
+
+    /**
+     * @param  array<string, mixed>  $document
+     */
+    private function sharingScript(array $document): string
+    {
+        $encoded = base64_encode(json_encode($document, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return <<<R
+# Parthenon OHDSI sharing handoff
+# Requires jsonlite. OhdsiSharing is used when installed in the R runtime.
+report_document <- jsonlite::fromJSON(rawToChar(jsonlite::base64_dec("{$encoded}")), simplifyVector = FALSE)
+
+if (requireNamespace("OhdsiSharing", quietly = TRUE)) {
+  message("OhdsiSharing is installed. Attach generated report assets to the sharing manifest before distribution.")
+} else {
+  message("OhdsiSharing is not installed. The embedded report_document remains importable by Parthenon.")
+}
+R;
+    }
+
+    /**
+     * @param  array<string, mixed>  $document
+     */
+    private function markdown(array $document): string
+    {
+        $lines = ['# '.$document['title'], ''];
+        $authors = $document['authors'] ?? [];
+        if (is_array($authors) && $authors !== []) {
+            $lines[] = implode(', ', array_map('strval', $authors));
+            $lines[] = '';
+        }
+
+        foreach (($document['sections'] ?? []) as $section) {
+            if (! is_array($section)) {
+                continue;
+            }
+            $lines[] = '## '.((string) ($section['title'] ?? Str::headline((string) ($section['type'] ?? 'Section'))));
+            $content = $section['content'] ?? '';
+            if (is_array($content)) {
+                $content = json_encode($content, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+            }
+            if (is_string($content) && trim($content) !== '') {
+                $lines[] = trim($content);
+            }
+            if (isset($section['caption']) && is_string($section['caption']) && trim($section['caption']) !== '') {
+                $lines[] = '_'.trim($section['caption']).'_';
+            }
+            $lines[] = '';
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param  array<string, mixed>  $document
+     * @return list<array<string, string>>
+     */
+    private function figureFiles(array $document): array
+    {
+        $files = [];
+        foreach (($document['sections'] ?? []) as $index => $section) {
+            if (! is_array($section) || ! is_string($section['svg'] ?? null) || trim($section['svg']) === '') {
+                continue;
+            }
+            $slug = $this->slug((string) ($section['title'] ?? 'figure-'.($index + 1)));
+            $files[] = [
+                'path' => "inst/reports/figures/{$slug}.svg",
+                'kind' => 'svg',
+                'content' => $section['svg'],
+            ];
+        }
+
+        return $files;
+    }
+
+    /**
+     * @param  array<string, mixed>  $document
+     * @return list<array<string, string>>
+     */
+    private function tableFiles(array $document): array
+    {
+        $files = [];
+        foreach (($document['sections'] ?? []) as $index => $section) {
+            if (! is_array($section) || ! is_array($section['table_data'] ?? null)) {
+                continue;
+            }
+            $slug = $this->slug((string) ($section['title'] ?? 'table-'.($index + 1)));
+            $files[] = [
+                'path' => "inst/reports/tables/{$slug}.json",
+                'kind' => 'json',
+                'content' => json_encode($section['table_data'], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT),
+            ];
+        }
+
+        return $files;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseBundleArtifact(mixed $artifact): array
+    {
+        if (is_string($artifact)) {
+            $artifact = $this->decodeJson($artifact, 'Report bundle JSON is invalid.');
+        }
+
+        if (! is_array($artifact)) {
+            throw ValidationException::withMessages([
+                'artifact' => 'Report bundle must be a JSON object.',
+            ]);
+        }
+
+        $content = is_array($artifact['content'] ?? null) ? $artifact['content'] : $artifact;
+        if (is_array($content['document'] ?? null)) {
+            return [
+                'document' => $content['document'],
+                'metadata' => $content['manifest'] ?? $content['package'] ?? [],
+            ];
+        }
+
+        $files = is_array($content['files'] ?? null) ? $content['files'] : [];
+        foreach ($files as $file) {
+            if (! is_array($file) || ! str_ends_with((string) ($file['path'] ?? ''), 'report.json')) {
+                continue;
+            }
+
+            return [
+                'document' => $this->decodeJson((string) ($file['content'] ?? '{}'), 'Report JSON file is invalid.'),
+                'metadata' => $content['manifest'] ?? $content['package'] ?? [],
+            ];
+        }
+
+        throw ValidationException::withMessages([
+            'artifact' => 'Report bundle does not contain report.json.',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseScriptArtifact(string $script): array
+    {
+        if (! preg_match('/PARTHENON_REPORT_JSON_BEGIN\s*(.*?)\s*#?\s*PARTHENON_REPORT_JSON_END/s', $script, $matches)) {
+            throw ValidationException::withMessages([
+                'artifact' => 'R artifact is missing the Parthenon report payload marker.',
+            ]);
+        }
+
+        $decoded = base64_decode(trim($matches[1]), true);
+        if ($decoded === false) {
+            throw ValidationException::withMessages([
+                'artifact' => 'Embedded R artifact payload is invalid.',
+            ]);
+        }
+
+        return [
+            'document' => $this->decodeJson($decoded, 'Embedded R artifact payload is invalid.'),
+            'metadata' => ['source' => 'parthenon-r-script'],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function jsonArtifact(string $format, string $downloadName, array $content): array
+    {
+        return [
+            'format' => $format,
+            'mime_type' => 'application/json',
+            'download_name' => $downloadName,
+            'content' => $content,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function textArtifact(string $format, string $downloadName, string $content): array
+    {
+        return [
+            'format' => $format,
+            'mime_type' => 'text/plain',
+            'download_name' => $downloadName,
+            'content' => $content,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(string $json, string $message): array
+    {
+        try {
+            $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw ValidationException::withMessages([
+                'artifact' => $message,
+            ]);
+        }
+
+        if (! is_array($decoded)) {
+            throw ValidationException::withMessages([
+                'artifact' => $message,
+            ]);
+        }
+
+        return $decoded;
+    }
+
+    private function slug(string $value): string
+    {
+        return Str::slug($value) ?: 'ohdsi-report';
+    }
+}

--- a/backend/database/migrations/2026_04_15_100001_create_publication_drafts_table.php
+++ b/backend/database/migrations/2026_04_15_100001_create_publication_drafts_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('publication_drafts', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('study_id')->nullable();
+            $table->string('title');
+            $table->string('template', 80)->default('generic-ohdsi');
+            $table->jsonb('document_json');
+            $table->string('status', 24)->default('draft');
+            $table->timestamp('last_opened_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'last_opened_at'], 'publication_drafts_user_opened_idx');
+            $table->index(['study_id', 'updated_at'], 'publication_drafts_study_updated_idx');
+        });
+
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DO $grants$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'parthenon_app') THEN
+                        GRANT SELECT, INSERT, UPDATE, DELETE ON app.publication_drafts TO parthenon_app;
+                        GRANT USAGE, SELECT ON SEQUENCE app.publication_drafts_id_seq TO parthenon_app;
+                    END IF;
+                END
+                $grants$
+            SQL);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('publication_drafts');
+    }
+};

--- a/backend/database/migrations/2026_04_15_100002_create_publication_report_bundles_table.php
+++ b/backend/database/migrations/2026_04_15_100002_create_publication_report_bundles_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('publication_report_bundles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('publication_draft_id')->nullable()
+                ->constrained('publication_drafts')
+                ->nullOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('direction', 16);
+            $table->string('format', 40);
+            $table->jsonb('bundle_json');
+            $table->jsonb('metadata_json')->nullable();
+            $table->timestamps();
+
+            $table->index(['publication_draft_id', 'created_at'], 'publication_report_bundles_draft_created_idx');
+            $table->index(['user_id', 'created_at'], 'publication_report_bundles_user_created_idx');
+            $table->index(['direction', 'format'], 'publication_report_bundles_direction_format_idx');
+        });
+
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DO $grants$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'parthenon_app') THEN
+                        GRANT SELECT, INSERT, UPDATE, DELETE ON app.publication_report_bundles TO parthenon_app;
+                        GRANT USAGE, SELECT ON SEQUENCE app.publication_report_bundles_id_seq TO parthenon_app;
+                    END IF;
+                END
+                $grants$
+            SQL);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('publication_report_bundles');
+    }
+};

--- a/docs/devlog/modules/publish/2026-04-14-publication-draft-autosave.md
+++ b/docs/devlog/modules/publish/2026-04-14-publication-draft-autosave.md
@@ -1,0 +1,69 @@
+# Publish — Researcher Draft Autosave Devlog
+
+**Date:** 2026-04-14  
+**Area:** Publish / Pre-publication Document Generator  
+**Status:** Shipped and under hardening review
+
+## Summary
+
+The Publish page now follows the same durable in-progress work pattern introduced for Patient Similarities. A researcher can begin composing a manuscript, leave the page, and reopen the work later from a per-user draft selector instead of relying only on browser session storage.
+
+## What Shipped
+
+- Added backend persistence for publication drafts in `publication_drafts`.
+- Added authenticated draft endpoints:
+  - list drafts
+  - create draft
+  - show draft
+  - update draft
+  - delete draft
+- Added a **My Drafts** selector to the Publish page header.
+- Added debounced autosave for meaningful wizard progress.
+- Added draft hydration so opening a saved draft restores:
+  - selected analyses
+  - generated manuscript sections
+  - title
+  - authors
+  - template
+  - current wizard step
+- Kept session storage as a local fallback for transient browser state.
+
+## Implementation Notes
+
+The draft document payload stores the wizard state as JSON so the page can evolve without requiring a new relational table for every section-level field. The backend still stores searchable metadata alongside the JSON document:
+
+- user id
+- optional study id
+- title
+- template
+- status
+- last opened timestamp
+
+Draft ownership is enforced server-side before show, update, or delete operations. The migration uses indexed ID columns instead of cross-table foreign keys to avoid the same role-ownership constraint encountered while deploying Patient Similarity persistence migrations.
+
+## UX Pattern
+
+This is now the common pattern for long-running researcher workflows:
+
+- autosave meaningful progress to the backend
+- expose saved work through a workflow-specific user dropdown
+- restore complete state from the saved artifact
+- retain local storage only as a convenience fallback
+
+## Verification Before Hardening Pass
+
+- PHP lint passed for the controller, model, and migration.
+- Frontend TypeScript passed.
+- Focused Publish Vitest coverage passed.
+- The migration was applied as `parthenon_migrator`.
+- PHP and frontend deploys completed successfully with smoke checks.
+
+## Hardening Review Focus
+
+The next review pass should verify:
+
+- no user can access another user's draft
+- autosave does not create duplicate first drafts under rapid edits
+- draft hydration cannot be overwritten by stale autosave payloads
+- invalid or partial stored JSON fails closed
+- Publish header controls remain aligned with the Patient Similarity saved-work selector pattern

--- a/frontend/src/features/publish/hooks/usePublicationDrafts.ts
+++ b/frontend/src/features/publish/hooks/usePublicationDrafts.ts
@@ -1,0 +1,90 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createPublicationDraft,
+  deletePublicationDraft,
+  fetchPublicationDraft,
+  fetchPublicationDrafts,
+  importReportBundle,
+  updatePublicationDraft,
+} from "../api/publishApi";
+import type {
+  ImportPublicationReportBundlePayload,
+  PublicationDraftInput,
+} from "../types/publish";
+
+export const PUBLISH_DRAFT_KEYS = {
+  all: ["publish", "drafts"] as const,
+  detail: (draftId: number | null | undefined) =>
+    ["publish", "drafts", draftId ?? "none"] as const,
+};
+
+export function usePublicationDrafts() {
+  return useQuery({
+    queryKey: PUBLISH_DRAFT_KEYS.all,
+    queryFn: fetchPublicationDrafts,
+    staleTime: 30 * 1000,
+  });
+}
+
+export function usePublicationDraft(draftId: number | null | undefined) {
+  return useQuery({
+    queryKey: PUBLISH_DRAFT_KEYS.detail(draftId),
+    queryFn: () => fetchPublicationDraft(draftId!),
+    enabled: draftId != null && draftId > 0,
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useCreatePublicationDraft() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: PublicationDraftInput) => createPublicationDraft(payload),
+    onSuccess: (draft) => {
+      queryClient.invalidateQueries({ queryKey: PUBLISH_DRAFT_KEYS.all });
+      queryClient.setQueryData(PUBLISH_DRAFT_KEYS.detail(draft.id), draft);
+    },
+  });
+}
+
+export function useUpdatePublicationDraft() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      draftId,
+      payload,
+    }: {
+      draftId: number;
+      payload: Partial<PublicationDraftInput>;
+    }) => updatePublicationDraft(draftId, payload),
+    onSuccess: (draft) => {
+      queryClient.invalidateQueries({ queryKey: PUBLISH_DRAFT_KEYS.all });
+      queryClient.setQueryData(PUBLISH_DRAFT_KEYS.detail(draft.id), draft);
+    },
+  });
+}
+
+export function useDeletePublicationDraft() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (draftId: number) => deletePublicationDraft(draftId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: PUBLISH_DRAFT_KEYS.all });
+    },
+  });
+}
+
+export function useImportReportBundle() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: ImportPublicationReportBundlePayload) =>
+      importReportBundle(payload),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: PUBLISH_DRAFT_KEYS.all });
+      queryClient.setQueryData(PUBLISH_DRAFT_KEYS.detail(result.draft.id), result.draft);
+    },
+  });
+}


### PR DESCRIPTION
## Risk: LOW — pure additive

Adds the publications feature: draft autosave + OHDSI-format report bundle export/import. All files genuinely new.

## Files
- 2 Models: PublicationDraft, PublicationReportBundle
- 1 Service: PublicationReportBundleService (473 lines — format normalization, 3 export formats, import parser)
- 2 migrations (renumbered to 2026_04_15_100001/100002 to avoid timestamp collisions — original stash timestamps collided with cohort_phenotype_adjudications and study_design_assets_table migrations)
- 1 Frontend hook: usePublicationDrafts
- 1 devlog

## Migration renumbering
Original stash timestamps renumbered for safety:
- \`2026_04_14_000007_create_publication_drafts_table.php\` → \`2026_04_15_100001_create_publication_drafts_table.php\` (avoids clash with cohort_phenotype_adjudications)
- \`2026_04_15_000006_create_publication_report_bundles_table.php\` → \`2026_04_15_100002_*\` (avoids future clash with study_design migrations in 000005-000008 range)

## Defensive fix
Added \`default => throw\` branches to two match expressions in PublicationReportBundleService (format param is string-typed — satisfies PHPStan exhaustivity, no behavior change for valid inputs).

## Deployment
\`\`\`bash
./deploy.sh --db  # runs 2 new migrations
\`\`\`

## Test plan
- [ ] Migrations run clean on local DB
- [ ] publication_drafts + publication_report_bundles tables created
- [ ] GRANTS to parthenon_app present (migrations handle this)
- [ ] Existing publish feature unaffected

Verified in worktree: Pint ✓, PHPStan ✓, tsc ✓, vite build ✓.