### PR TITLE
feat(phenotype): complete PheValuator + SCC + cohort-authoring feature

### DIFF
--- a/backend/app/Jobs/Analysis/RunPhenotypeValidationJob.php
+++ b/backend/app/Jobs/Analysis/RunPhenotypeValidationJob.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Jobs\Analysis;
+
+use App\Enums\ExecutionStatus;
+use App\Models\App\CohortPhenotypeValidation;
+use App\Services\Analysis\PhenotypeValidationService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class RunPhenotypeValidationJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 7200;
+
+    public int $tries = 1;
+
+    public function __construct(
+        public readonly CohortPhenotypeValidation $validation,
+    ) {
+        $this->queue = 'r-analysis';
+    }
+
+    public function handle(PhenotypeValidationService $service): void
+    {
+        Log::info('RunPhenotypeValidationJob started', [
+            'validation_id' => $this->validation->id,
+            'cohort_definition_id' => $this->validation->cohort_definition_id,
+            'source_id' => $this->validation->source_id,
+        ]);
+
+        try {
+            $service->execute($this->validation);
+
+            Log::info('RunPhenotypeValidationJob finished', [
+                'validation_id' => $this->validation->id,
+                'status' => $this->validation->fresh()->status->value,
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('RunPhenotypeValidationJob failed', [
+                'validation_id' => $this->validation->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            $this->validation->update([
+                'status' => ExecutionStatus::Failed,
+                'completed_at' => now(),
+                'fail_message' => mb_substr($e->getMessage(), 0, 2000),
+            ]);
+        }
+    }
+}

--- a/backend/app/Jobs/Analysis/RunSelfControlledCohortJob.php
+++ b/backend/app/Jobs/Analysis/RunSelfControlledCohortJob.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Jobs\Analysis;
+
+use App\Enums\ExecutionStatus;
+use App\Models\App\AnalysisExecution;
+use App\Models\App\SelfControlledCohortAnalysis;
+use App\Models\App\Source;
+use App\Services\Analysis\SelfControlledCohortService;
+use App\Traits\NotifiesOnCompletion;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class RunSelfControlledCohortJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use NotifiesOnCompletion;
+
+    public int $timeout = 14400;
+
+    public int $tries = 1;
+
+    public function __construct(
+        public readonly SelfControlledCohortAnalysis $analysis,
+        public readonly Source $source,
+        public readonly AnalysisExecution $execution,
+    ) {
+        $this->queue = 'r-analysis';
+    }
+
+    public function handle(SelfControlledCohortService $service): void
+    {
+        Log::info('RunSelfControlledCohortJob started', [
+            'analysis_id' => $this->analysis->id,
+            'source_id' => $this->source->id,
+            'execution_id' => $this->execution->id,
+        ]);
+
+        try {
+            $service->execute($this->analysis, $this->source, $this->execution);
+
+            Log::info('RunSelfControlledCohortJob finished', [
+                'analysis_id' => $this->analysis->id,
+                'execution_id' => $this->execution->id,
+                'status' => $this->execution->fresh()->status->value,
+            ]);
+
+            $this->notifyAuthor($this->execution->fresh());
+        } catch (\Throwable $e) {
+            Log::error('RunSelfControlledCohortJob failed', [
+                'analysis_id' => $this->analysis->id,
+                'execution_id' => $this->execution->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            $this->execution->update([
+                'status' => ExecutionStatus::Failed,
+                'completed_at' => now(),
+                'fail_message' => mb_substr($e->getMessage(), 0, 2000),
+            ]);
+
+            $this->notifyAuthor($this->execution->fresh());
+        }
+    }
+}

--- a/backend/app/Models/App/CohortAuthoringArtifact.php
+++ b/backend/app/Models/App/CohortAuthoringArtifact.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models\App;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CohortAuthoringArtifact extends Model
+{
+    protected $fillable = [
+        'cohort_definition_id',
+        'author_id',
+        'direction',
+        'format',
+        'artifact_json',
+        'metadata_json',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'artifact_json' => 'array',
+            'metadata_json' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<CohortDefinition, $this>
+     */
+    public function cohortDefinition(): BelongsTo
+    {
+        return $this->belongsTo(CohortDefinition::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'author_id');
+    }
+}

--- a/backend/app/Models/App/CohortPhenotypeAdjudicationEvent.php
+++ b/backend/app/Models/App/CohortPhenotypeAdjudicationEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models\App;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CohortPhenotypeAdjudicationEvent extends Model
+{
+    protected $fillable = [
+        'phenotype_validation_id',
+        'adjudication_id',
+        'actor_id',
+        'event_type',
+        'before_json',
+        'after_json',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'before_json' => 'array',
+            'after_json' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<CohortPhenotypeValidation, $this>
+     */
+    public function validation(): BelongsTo
+    {
+        return $this->belongsTo(CohortPhenotypeValidation::class, 'phenotype_validation_id');
+    }
+
+    /**
+     * @return BelongsTo<CohortPhenotypeAdjudication, $this>
+     */
+    public function adjudication(): BelongsTo
+    {
+        return $this->belongsTo(CohortPhenotypeAdjudication::class, 'adjudication_id');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function actor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'actor_id');
+    }
+}

--- a/backend/app/Models/App/CohortPhenotypeAdjudicationReview.php
+++ b/backend/app/Models/App/CohortPhenotypeAdjudicationReview.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models\App;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CohortPhenotypeAdjudicationReview extends Model
+{
+    protected $fillable = [
+        'phenotype_validation_id',
+        'adjudication_id',
+        'reviewer_id',
+        'label',
+        'notes',
+        'reviewed_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'reviewed_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<CohortPhenotypeValidation, $this>
+     */
+    public function validation(): BelongsTo
+    {
+        return $this->belongsTo(CohortPhenotypeValidation::class, 'phenotype_validation_id');
+    }
+
+    /**
+     * @return BelongsTo<CohortPhenotypeAdjudication, $this>
+     */
+    public function adjudication(): BelongsTo
+    {
+        return $this->belongsTo(CohortPhenotypeAdjudication::class, 'adjudication_id');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function reviewer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reviewer_id');
+    }
+}

--- a/backend/app/Services/Analysis/PhenotypeAdjudicationService.php
+++ b/backend/app/Services/Analysis/PhenotypeAdjudicationService.php
@@ -1,0 +1,505 @@
+<?php
+
+namespace App\Services\Analysis;
+
+use App\Enums\DaimonType;
+use App\Models\App\CohortPhenotypeAdjudication;
+use App\Models\App\CohortPhenotypeAdjudicationReview;
+use App\Models\App\CohortPhenotypeValidation;
+use App\Services\SqlRenderer\SqlRendererService;
+use Illuminate\Support\Facades\DB;
+
+class PhenotypeAdjudicationService
+{
+    public function __construct(
+        private readonly SqlRendererService $sqlRenderer,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function sample(
+        CohortPhenotypeValidation $validation,
+        int $memberCount,
+        int $nonMemberCount,
+        ?string $seed = null,
+        string $strategy = 'random',
+    ): array {
+        $validation->loadMissing(['cohortDefinition', 'source.daimons']);
+        $source = $validation->source;
+        $cdmSchema = $source->getTableQualifier(DaimonType::CDM);
+        $vocabSchema = $source->getTableQualifier(DaimonType::Vocabulary) ?? $cdmSchema;
+        $resultsSchema = $source->getTableQualifier(DaimonType::Results);
+
+        if ($cdmSchema === null || $resultsSchema === null) {
+            throw new \RuntimeException('Source is missing required CDM or Results schema configuration.');
+        }
+
+        $dialect = $source->source_dialect ?? 'postgresql';
+        $connectionName = $source->source_connection ?? 'omop';
+        $seed = $seed !== null && trim($seed) !== '' ? trim($seed) : bin2hex(random_bytes(8));
+        $strategy = in_array($strategy, ['random', 'balanced_demographics'], true)
+            ? $strategy
+            : 'random';
+        $memberCandidateLimit = $this->candidateLimit($memberCount, $strategy);
+        $nonMemberCandidateLimit = $this->candidateLimit($nonMemberCount, $strategy);
+
+        $params = [
+            'cdmSchema' => $cdmSchema,
+            'vocabSchema' => $vocabSchema,
+            'resultsSchema' => $resultsSchema,
+        ];
+
+        $memberRows = $this->selectSampleRows(
+            $connectionName,
+            $dialect,
+            $params,
+            $this->memberSampleSql(
+                $validation->cohort_definition_id,
+                $memberCandidateLimit,
+                $this->orderExpression($dialect, 'c.subject_id', $seed),
+            ),
+        );
+
+        $nonMemberRows = $this->selectSampleRows(
+            $connectionName,
+            $dialect,
+            $params,
+            $this->nonMemberSampleSql(
+                $validation->cohort_definition_id,
+                $nonMemberCandidateLimit,
+                $this->orderExpression($dialect, 'p.person_id', $seed),
+            ),
+        );
+        $memberRows = $this->pickRows($memberRows, $memberCount, $strategy);
+        $nonMemberRows = $this->pickRows($nonMemberRows, $nonMemberCount, $strategy);
+
+        $created = 0;
+        foreach ($memberRows as $row) {
+            $created += $this->upsertAdjudication($validation, $row, 'cohort_member', $seed, $strategy) ? 1 : 0;
+        }
+
+        foreach ($nonMemberRows as $row) {
+            $created += $this->upsertAdjudication($validation, $row, 'non_member', $seed, $strategy) ? 1 : 0;
+        }
+
+        return [
+            'created' => $created,
+            'cohort_member_count' => count($memberRows),
+            'non_member_count' => count($nonMemberRows),
+            'seed' => $seed,
+            'strategy' => $strategy,
+        ];
+    }
+
+    /**
+     * @return array{true_positives: int, false_positives: int, true_negatives: int, false_negatives: int, reviewed: int, uncertain: int, unreviewed: int}
+     */
+    public function counts(CohortPhenotypeValidation $validation): array
+    {
+        $rows = CohortPhenotypeAdjudication::query()
+            ->where('phenotype_validation_id', $validation->id)
+            ->get(['sample_group', 'label']);
+
+        $counts = [
+            'true_positives' => 0,
+            'false_positives' => 0,
+            'true_negatives' => 0,
+            'false_negatives' => 0,
+            'reviewed' => 0,
+            'uncertain' => 0,
+            'unreviewed' => 0,
+        ];
+
+        foreach ($rows as $row) {
+            $label = $row->label;
+            $group = $row->sample_group;
+
+            if ($label === null) {
+                $counts['unreviewed']++;
+
+                continue;
+            }
+
+            if ($label === 'uncertain') {
+                $counts['uncertain']++;
+
+                continue;
+            }
+
+            $counts['reviewed']++;
+            if ($group === 'cohort_member' && $label === 'case') {
+                $counts['true_positives']++;
+            } elseif ($group === 'cohort_member' && $label === 'non_case') {
+                $counts['false_positives']++;
+            } elseif ($group === 'non_member' && $label === 'case') {
+                $counts['false_negatives']++;
+            } elseif ($group === 'non_member' && $label === 'non_case') {
+                $counts['true_negatives']++;
+            }
+        }
+
+        return $counts;
+    }
+
+    public function recordReview(
+        CohortPhenotypeValidation $validation,
+        CohortPhenotypeAdjudication $adjudication,
+        ?int $reviewerId,
+        ?string $label,
+        ?string $notes,
+    ): CohortPhenotypeAdjudication {
+        CohortPhenotypeAdjudicationReview::query()->updateOrCreate(
+            [
+                'adjudication_id' => $adjudication->id,
+                'reviewer_id' => $reviewerId,
+            ],
+            [
+                'phenotype_validation_id' => $validation->id,
+                'label' => $label,
+                'notes' => $notes,
+                'reviewed_at' => $label ? now() : null,
+            ],
+        );
+
+        return $this->syncConsensusLabel($adjudication);
+    }
+
+    public function syncConsensusLabel(CohortPhenotypeAdjudication $adjudication): CohortPhenotypeAdjudication
+    {
+        $reviews = CohortPhenotypeAdjudicationReview::query()
+            ->where('adjudication_id', $adjudication->id)
+            ->whereNotNull('label')
+            ->orderBy('updated_at')
+            ->get();
+
+        $definitive = $reviews->filter(fn ($review) => in_array($review->label, ['case', 'non_case'], true));
+        $finalLabel = null;
+        if ($definitive->isNotEmpty()) {
+            $labels = $definitive->pluck('label')->unique()->values();
+            $finalLabel = $labels->count() === 1 ? $labels->first() : null;
+        } elseif ($reviews->where('label', 'uncertain')->isNotEmpty()) {
+            $finalLabel = 'uncertain';
+        }
+
+        $latestReview = $reviews->last();
+        $adjudication->update([
+            'label' => $finalLabel,
+            'notes' => $latestReview?->notes,
+            'reviewer_id' => $finalLabel ? $latestReview?->reviewer_id : null,
+            'reviewed_at' => $finalLabel ? $latestReview?->reviewed_at : null,
+        ]);
+
+        return $adjudication->fresh();
+    }
+
+    public function resolveFinalLabel(
+        CohortPhenotypeAdjudication $adjudication,
+        string $label,
+        ?string $notes,
+        ?int $reviewerId,
+    ): CohortPhenotypeAdjudication {
+        $adjudication->update([
+            'label' => $label,
+            'notes' => $notes,
+            'reviewer_id' => $reviewerId,
+            'reviewed_at' => now(),
+        ]);
+
+        return $adjudication->fresh();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function agreementSummary(CohortPhenotypeValidation $validation): array
+    {
+        $reviews = CohortPhenotypeAdjudicationReview::query()
+            ->where('phenotype_validation_id', $validation->id)
+            ->with('reviewer:id,name,email')
+            ->get();
+        $adjudications = CohortPhenotypeAdjudication::query()
+            ->where('phenotype_validation_id', $validation->id)
+            ->get(['id', 'label']);
+        $adjudicationCount = $adjudications->count();
+        $finalLabels = $adjudications->keyBy('id');
+
+        $byAdjudication = $reviews->groupBy('adjudication_id');
+        $totalReviewed = 0;
+        $doubleReviewed = 0;
+        $consensus = 0;
+        $conflicts = 0;
+        $resolvedConflicts = 0;
+        $unresolvedConflicts = 0;
+        $uncertain = 0;
+        $pairAgreements = 0;
+        $pairComparisons = 0;
+        $labelTotals = ['case' => 0, 'non_case' => 0];
+
+        foreach ($byAdjudication as $rows) {
+            $labels = $rows->pluck('label')->filter()->values();
+            if ($labels->isEmpty()) {
+                continue;
+            }
+
+            $totalReviewed++;
+            $definitiveLabels = $labels
+                ->filter(fn ($label) => in_array($label, ['case', 'non_case'], true))
+                ->values();
+            $uncertain += $labels->filter(fn ($label) => $label === 'uncertain')->count();
+            if ($definitiveLabels->count() >= 2) {
+                $doubleReviewed++;
+                $uniqueLabels = $definitiveLabels->unique()->values();
+                if ($uniqueLabels->count() === 1) {
+                    $consensus++;
+                } else {
+                    $conflicts++;
+                    $finalLabel = $finalLabels->get($rows->first()->adjudication_id)?->label;
+                    if (in_array($finalLabel, ['case', 'non_case'], true)) {
+                        $resolvedConflicts++;
+                    } else {
+                        $unresolvedConflicts++;
+                    }
+                }
+
+                $labelsArray = $definitiveLabels->all();
+                for ($i = 0; $i < count($labelsArray); $i++) {
+                    for ($j = $i + 1; $j < count($labelsArray); $j++) {
+                        $pairComparisons++;
+                        if ($labelsArray[$i] === $labelsArray[$j]) {
+                            $pairAgreements++;
+                        }
+                    }
+                }
+            }
+
+            foreach ($definitiveLabels as $label) {
+                $labelTotals[$label]++;
+            }
+        }
+
+        $observedAgreement = $pairComparisons > 0 ? $pairAgreements / $pairComparisons : null;
+        $totalLabels = array_sum($labelTotals);
+        $expectedAgreement = null;
+        $kappa = null;
+        if ($totalLabels > 0 && $observedAgreement !== null) {
+            $caseShare = $labelTotals['case'] / $totalLabels;
+            $nonCaseShare = $labelTotals['non_case'] / $totalLabels;
+            $expectedAgreement = ($caseShare ** 2) + ($nonCaseShare ** 2);
+            $kappa = abs(1 - $expectedAgreement) < 0.000001
+                ? null
+                : ($observedAgreement - $expectedAgreement) / (1 - $expectedAgreement);
+        }
+
+        $reviewers = $reviews
+            ->groupBy('reviewer_id')
+            ->map(fn ($rows) => [
+                'reviewer_id' => $rows->first()->reviewer_id,
+                'reviewer' => $rows->first()->reviewer,
+                'reviews' => $rows->count(),
+                'case' => $rows->where('label', 'case')->count(),
+                'non_case' => $rows->where('label', 'non_case')->count(),
+                'uncertain' => $rows->where('label', 'uncertain')->count(),
+            ])
+            ->values()
+            ->all();
+
+        $finalCounts = $this->counts($validation);
+
+        return [
+            'adjudications' => $adjudicationCount,
+            'review_records' => $reviews->count(),
+            'reviewed_adjudications' => $totalReviewed,
+            'double_reviewed_adjudications' => $doubleReviewed,
+            'consensus_adjudications' => $consensus,
+            'conflict_adjudications' => $conflicts,
+            'resolved_conflict_adjudications' => $resolvedConflicts,
+            'unresolved_conflict_adjudications' => $unresolvedConflicts,
+            'uncertain_reviews' => $uncertain,
+            'observed_pairwise_agreement' => $observedAgreement,
+            'expected_pairwise_agreement' => $expectedAgreement,
+            'cohen_kappa' => $kappa,
+            'ready_for_promotion' => $adjudicationCount > 0
+                && $finalCounts['unreviewed'] === 0
+                && $finalCounts['uncertain'] === 0
+                && $unresolvedConflicts === 0,
+            'reviewers' => $reviewers,
+        ];
+    }
+
+    /**
+     * @param  array<string, string>  $params
+     * @return array<int, object>
+     */
+    private function selectSampleRows(
+        string $connectionName,
+        string $dialect,
+        array $params,
+        string $sql,
+    ): array {
+        $renderedSql = $this->sqlRenderer->render($sql, $params, $dialect);
+
+        return DB::connection($connectionName)->select($renderedSql);
+    }
+
+    private function memberSampleSql(int $cohortDefinitionId, int $limit, string $orderExpression): string
+    {
+        return "
+            SELECT
+                c.subject_id AS person_id,
+                p.year_of_birth,
+                COALESCE(gc.concept_name, 'Unknown') AS gender,
+                c.cohort_start_date,
+                c.cohort_end_date
+            FROM {@resultsSchema}.cohort c
+            INNER JOIN {@cdmSchema}.person p
+                ON c.subject_id = p.person_id
+            LEFT JOIN {@vocabSchema}.concept gc
+                ON p.gender_concept_id = gc.concept_id
+            WHERE c.cohort_definition_id = {$cohortDefinitionId}
+            ORDER BY {$orderExpression}
+            LIMIT {$limit}
+        ";
+    }
+
+    private function nonMemberSampleSql(int $cohortDefinitionId, int $limit, string $orderExpression): string
+    {
+        return "
+            SELECT
+                p.person_id,
+                p.year_of_birth,
+                COALESCE(gc.concept_name, 'Unknown') AS gender,
+                NULL AS cohort_start_date,
+                NULL AS cohort_end_date
+            FROM {@cdmSchema}.person p
+            LEFT JOIN {@vocabSchema}.concept gc
+                ON p.gender_concept_id = gc.concept_id
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM {@resultsSchema}.cohort c
+                WHERE c.cohort_definition_id = {$cohortDefinitionId}
+                  AND c.subject_id = p.person_id
+            )
+            ORDER BY {$orderExpression}
+            LIMIT {$limit}
+        ";
+    }
+
+    private function orderExpression(string $dialect, string $personIdExpression, string $seed): string
+    {
+        $escapedSeed = str_replace("'", "''", $seed);
+
+        return match (strtolower($dialect)) {
+            'sql server', 'sqlserver', 'synapse' => "CHECKSUM(CONCAT(CAST({$personIdExpression} AS VARCHAR(64)), '{$escapedSeed}'))",
+            default => "MD5(CAST({$personIdExpression} AS VARCHAR) || '{$escapedSeed}')",
+        };
+    }
+
+    private function candidateLimit(int $requestedLimit, string $strategy): int
+    {
+        if ($requestedLimit <= 0) {
+            return 0;
+        }
+
+        if ($strategy !== 'balanced_demographics') {
+            return $requestedLimit;
+        }
+
+        return min(5000, max($requestedLimit, $requestedLimit * 10));
+    }
+
+    /**
+     * @param  array<int, object>  $rows
+     * @return array<int, object>
+     */
+    private function pickRows(array $rows, int $limit, string $strategy): array
+    {
+        if ($limit <= 0) {
+            return [];
+        }
+
+        if ($strategy !== 'balanced_demographics') {
+            return array_slice($rows, 0, $limit);
+        }
+
+        $strata = [];
+        foreach ($rows as $row) {
+            $strata[$this->stratumForRow($row)][] = $row;
+        }
+
+        ksort($strata);
+        $selected = [];
+        while (count($selected) < $limit && count($strata) > 0) {
+            foreach (array_keys($strata) as $stratum) {
+                $row = array_shift($strata[$stratum]);
+                if ($row !== null) {
+                    $selected[] = $row;
+                }
+                if (count($selected) >= $limit) {
+                    break 2;
+                }
+                if ($strata[$stratum] === []) {
+                    unset($strata[$stratum]);
+                }
+            }
+        }
+
+        return $selected;
+    }
+
+    private function upsertAdjudication(
+        CohortPhenotypeValidation $validation,
+        object $row,
+        string $sampleGroup,
+        string $seed,
+        string $strategy,
+    ): bool {
+        $personId = (int) $row->person_id;
+        $stratum = $this->stratumForRow($row);
+        $payload = [
+            'sample_group' => $sampleGroup,
+            'demographics_json' => [
+                'year_of_birth' => $row->year_of_birth ?? null,
+                'gender' => $row->gender ?? null,
+                'cohort_start_date' => $row->cohort_start_date ?? null,
+                'cohort_end_date' => $row->cohort_end_date ?? null,
+            ],
+            'sampling_json' => [
+                'seed' => $seed,
+                'strategy' => $strategy,
+                'stratum' => $stratum,
+            ],
+            'sampled_at' => now(),
+        ];
+
+        $adjudication = CohortPhenotypeAdjudication::query()
+            ->firstOrCreate(
+                [
+                    'phenotype_validation_id' => $validation->id,
+                    'person_id' => $personId,
+                ],
+                $payload,
+            );
+
+        if (! $adjudication->wasRecentlyCreated) {
+            $adjudication->update($payload);
+        }
+
+        return $adjudication->wasRecentlyCreated;
+    }
+
+    private function stratumForRow(object $row): string
+    {
+        $gender = strtolower((string) ($row->gender ?? 'unknown'));
+        $year = is_numeric($row->year_of_birth ?? null) ? (int) $row->year_of_birth : null;
+        if ($year === null) {
+            return "{$gender}|age_unknown";
+        }
+
+        $age = max(0, (int) now()->format('Y') - $year);
+        $bandStart = intdiv($age, 10) * 10;
+        $bandEnd = $bandStart + 9;
+
+        return "{$gender}|age_{$bandStart}_{$bandEnd}";
+    }
+}

--- a/backend/app/Services/Analysis/PhenotypeValidationService.php
+++ b/backend/app/Services/Analysis/PhenotypeValidationService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Services\Analysis;
+
+use App\Enums\ExecutionStatus;
+use App\Models\App\CohortPhenotypeValidation;
+use App\Services\RService;
+use Illuminate\Support\Facades\Log;
+
+class PhenotypeValidationService
+{
+    public function __construct(
+        private readonly RService $rService,
+    ) {}
+
+    public function execute(CohortPhenotypeValidation $validation): void
+    {
+        $validation->loadMissing(['cohortDefinition', 'source.daimons']);
+
+        $validation->update([
+            'status' => ExecutionStatus::Running,
+            'started_at' => now(),
+            'fail_message' => null,
+        ]);
+
+        try {
+            $settings = $validation->settings_json ?? [];
+            $counts = $settings['counts'] ?? null;
+
+            if (! is_array($counts)) {
+                throw new \RuntimeException('Phenotype validation requires adjudicated count inputs.');
+            }
+
+            $spec = [
+                'mode' => 'counts',
+                'input_mode' => $validation->mode,
+                'analysis_id' => $validation->id,
+                'source' => HadesBridgeService::buildSourceSpec($validation->source),
+                'cohort' => [
+                    'cohort_definition_id' => $validation->cohort_definition_id,
+                    'cohort_name' => $validation->cohortDefinition->name,
+                ],
+                'counts' => $counts,
+                'notes' => $settings['notes'] ?? null,
+            ];
+
+            $result = $this->rService->runPhenotypeValidation($spec);
+
+            if (($result['status'] ?? null) === 'error') {
+                throw new \RuntimeException((string) ($result['message'] ?? 'PheValuator runtime failed.'));
+            }
+
+            $validation->update([
+                'status' => ExecutionStatus::Completed,
+                'completed_at' => now(),
+                'result_json' => $result,
+            ]);
+
+            Log::info('Phenotype validation completed', [
+                'validation_id' => $validation->id,
+                'cohort_definition_id' => $validation->cohort_definition_id,
+            ]);
+        } catch (\Throwable $e) {
+            $validation->update([
+                'status' => ExecutionStatus::Failed,
+                'completed_at' => now(),
+                'fail_message' => mb_substr($e->getMessage(), 0, 2000),
+            ]);
+
+            Log::error('Phenotype validation failed', [
+                'validation_id' => $validation->id,
+                'cohort_definition_id' => $validation->cohort_definition_id,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+}

--- a/backend/app/Services/Analysis/SelfControlledCohortService.php
+++ b/backend/app/Services/Analysis/SelfControlledCohortService.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Services\Analysis;
+
+use App\Enums\ExecutionStatus;
+use App\Models\App\AnalysisExecution;
+use App\Models\App\ExecutionLog;
+use App\Models\App\SelfControlledCohortAnalysis;
+use App\Models\App\Source;
+use App\Services\RService;
+use App\Support\SccsResultNormalizer;
+use Illuminate\Support\Facades\Log;
+
+class SelfControlledCohortService
+{
+    public function __construct(
+        private readonly RService $rService,
+    ) {}
+
+    public function execute(
+        SelfControlledCohortAnalysis $analysis,
+        Source $source,
+        AnalysisExecution $execution,
+    ): void {
+        $execution->update([
+            'status' => ExecutionStatus::Running,
+            'started_at' => now(),
+        ]);
+
+        $this->log($execution, 'info', 'Self-Controlled Cohort execution started', [
+            'analysis_id' => $analysis->id,
+            'source_id' => $source->id,
+        ]);
+
+        try {
+            $design = $analysis->design_json;
+            $exposureCohortId = $design['exposureCohortId'] ?? null;
+            $outcomeCohortId = $design['outcomeCohortId'] ?? null;
+
+            if ($exposureCohortId === null || $outcomeCohortId === null) {
+                throw new \RuntimeException(
+                    'Self-Controlled Cohort design requires exposureCohortId and outcomeCohortId.'
+                );
+            }
+
+            $studyPopulation = $design['studyPopulation'] ?? [];
+            $exposedWindow = $design['exposedWindow'] ?? $this->firstRiskWindow($design) ?? [];
+            $unexposedWindow = $design['unexposedWindow'] ?? [];
+
+            $spec = [
+                'source' => HadesBridgeService::buildSourceSpec($source),
+                'analysis_id' => $analysis->id,
+                'execution_id' => $execution->id,
+                'description' => $analysis->description ?? $analysis->name,
+                'cohorts' => [
+                    'exposure_cohort_id' => $exposureCohortId,
+                    'outcome_cohort_id' => $outcomeCohortId,
+                ],
+                'first_exposure_only' => $design['firstExposureOnly'] ?? true,
+                'first_outcome_only' => $studyPopulation['firstOutcomeOnly'] ?? true,
+                'min_age' => $studyPopulation['minAge'] ?? '',
+                'max_age' => $studyPopulation['maxAge'] ?? '',
+                'risk_window_start_exposed' => $exposedWindow['start'] ?? 1,
+                'risk_window_end_exposed' => $exposedWindow['end'] ?? 30,
+                'add_length_of_exposure_exposed' => $exposedWindow['addLengthOfExposure'] ?? true,
+                'risk_window_start_unexposed' => $unexposedWindow['start'] ?? -30,
+                'risk_window_end_unexposed' => $unexposedWindow['end'] ?? -1,
+                'add_length_of_exposure_unexposed' => $unexposedWindow['addLengthOfExposure'] ?? true,
+                'has_full_time_at_risk' => $design['hasFullTimeAtRisk'] ?? false,
+                'washout_period' => $studyPopulation['naivePeriod'] ?? $design['washoutPeriod'] ?? 0,
+                'followup_period' => $design['followupPeriod'] ?? 0,
+                'compute_tar_distribution' => $design['computeTarDistribution'] ?? false,
+            ];
+
+            $this->log($execution, 'info', 'Calling R sidecar for Self-Controlled Cohort analysis', [
+                'exposure_cohort_id' => $exposureCohortId,
+                'outcome_cohort_id' => $outcomeCohortId,
+            ]);
+
+            $result = $this->rService->runSelfControlledCohort($spec);
+
+            if (($result['status'] ?? null) === 'error') {
+                throw new \RuntimeException((string) ($result['message'] ?? 'Self-Controlled Cohort runtime failed.'));
+            }
+
+            $execution->update([
+                'status' => ExecutionStatus::Completed,
+                'completed_at' => now(),
+                'result_json' => SccsResultNormalizer::normalize([
+                    ...$result,
+                    'engine' => 'self_controlled_cohort',
+                    'package' => $result['package'] ?? 'SelfControlledCohort',
+                ]),
+            ]);
+
+            $this->log($execution, 'info', 'Self-Controlled Cohort execution completed');
+
+            Log::info('Self-Controlled Cohort execution completed', [
+                'analysis_id' => $analysis->id,
+                'execution_id' => $execution->id,
+            ]);
+        } catch (\Throwable $e) {
+            $this->log($execution, 'error', 'Self-Controlled Cohort execution failed', [
+                'error' => $e->getMessage(),
+            ]);
+
+            $execution->update([
+                'status' => ExecutionStatus::Failed,
+                'completed_at' => now(),
+                'fail_message' => mb_substr($e->getMessage(), 0, 2000),
+            ]);
+
+            Log::error('Self-Controlled Cohort execution failed', [
+                'analysis_id' => $analysis->id,
+                'execution_id' => $execution->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $design
+     * @return array<string, mixed>|null
+     */
+    private function firstRiskWindow(array $design): ?array
+    {
+        $riskWindows = $design['riskWindows'] ?? [];
+
+        if (is_array($riskWindows) && is_array($riskWindows[0] ?? null)) {
+            return $riskWindows[0];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    private function log(
+        AnalysisExecution $execution,
+        string $level,
+        string $message,
+        array $context = [],
+    ): void {
+        ExecutionLog::create([
+            'execution_id' => $execution->id,
+            'level' => $level,
+            'message' => $message,
+            'context' => ! empty($context) ? $context : null,
+        ]);
+    }
+}

--- a/backend/app/Services/Cohort/CohortAuthoringArtifactService.php
+++ b/backend/app/Services/Cohort/CohortAuthoringArtifactService.php
@@ -1,0 +1,331 @@
+<?php
+
+namespace App\Services\Cohort;
+
+use App\Models\App\CohortDefinition;
+use App\Services\Cohort\Schema\CohortExpressionSchema;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class CohortAuthoringArtifactService
+{
+    public const FORMATS = [
+        'atlas_json',
+        'circe_json',
+        'circer_r',
+        'capr_r',
+        'r_package',
+    ];
+
+    public function __construct(
+        private readonly CohortExpressionSchema $schema,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function export(CohortDefinition $cohortDefinition, string $format): array
+    {
+        $format = $this->normalizeFormat($format);
+        $expression = $this->schema->validate($cohortDefinition->expression_json ?? []);
+        $payload = $this->basePayload($cohortDefinition, $expression);
+
+        return match ($format) {
+            'atlas_json' => $this->jsonArtifact($format, "{$this->slug($cohortDefinition)}.atlas.json", [
+                'name' => $cohortDefinition->name,
+                'description' => $cohortDefinition->description,
+                'expression' => $expression,
+            ]),
+            'circe_json' => $this->jsonArtifact($format, "{$this->slug($cohortDefinition)}.circe.json", [
+                'cohortDefinition' => $payload,
+                'expression' => $expression,
+            ]),
+            'circer_r' => $this->textArtifact(
+                $format,
+                "{$this->slug($cohortDefinition)}.circer.R",
+                $this->circeRScript($payload),
+            ),
+            'capr_r' => $this->textArtifact(
+                $format,
+                "{$this->slug($cohortDefinition)}.capr.R",
+                $this->caprScript($payload),
+            ),
+            'r_package' => $this->packageArtifact($cohortDefinition, $payload),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{name: string, description: string|null, expression: array<string, mixed>, metadata: array<string, mixed>}
+     */
+    public function parseImportPayload(array $payload): array
+    {
+        $format = $this->normalizeFormat((string) ($payload['format'] ?? 'atlas_json'));
+        $artifact = $payload['artifact'] ?? $payload['content'] ?? $payload;
+        $parsed = match ($format) {
+            'atlas_json', 'circe_json' => $this->parseJsonLikeArtifact($artifact),
+            'circer_r', 'capr_r' => $this->parseScriptArtifact((string) $artifact),
+            'r_package' => $this->parsePackageArtifact($artifact),
+        };
+
+        $name = trim((string) ($payload['name'] ?? $parsed['name'] ?? 'Imported cohort'));
+        $description = $payload['description'] ?? $parsed['description'] ?? null;
+        $expression = $parsed['expression'] ?? null;
+        if (! is_array($expression)) {
+            throw ValidationException::withMessages([
+                'artifact' => 'Authoring artifact does not contain a cohort expression.',
+            ]);
+        }
+
+        return [
+            'name' => $name !== '' ? $name : 'Imported cohort',
+            'description' => is_string($description) ? $description : null,
+            'expression' => $this->schema->validate($expression),
+            'metadata' => [
+                'format' => $format,
+                'source_metadata' => $parsed['metadata'] ?? [],
+            ],
+        ];
+    }
+
+    public function normalizeFormat(string $format): string
+    {
+        $normalized = strtolower(str_replace(['-', ' '], '_', trim($format)));
+        $aliases = [
+            'atlas' => 'atlas_json',
+            'circe' => 'circe_json',
+            'circer' => 'circer_r',
+            'capr' => 'capr_r',
+            'package' => 'r_package',
+        ];
+        $normalized = $aliases[$normalized] ?? $normalized;
+
+        if (! in_array($normalized, self::FORMATS, true)) {
+            throw ValidationException::withMessages([
+                'format' => 'Unsupported cohort authoring artifact format.',
+            ]);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $expression
+     * @return array<string, mixed>
+     */
+    private function basePayload(CohortDefinition $cohortDefinition, array $expression): array
+    {
+        return [
+            'id' => $cohortDefinition->id,
+            'name' => $cohortDefinition->name,
+            'description' => $cohortDefinition->description,
+            'version' => $cohortDefinition->version,
+            'expression' => $expression,
+            'metadata' => [
+                'source' => 'parthenon',
+                'exported_at' => now()->toISOString(),
+                'parthenon_cohort_definition_id' => $cohortDefinition->id,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $content
+     * @return array<string, mixed>
+     */
+    private function jsonArtifact(string $format, string $downloadName, array $content): array
+    {
+        return [
+            'format' => $format,
+            'mime_type' => 'application/json',
+            'download_name' => $downloadName,
+            'content' => $content,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function textArtifact(string $format, string $downloadName, string $content): array
+    {
+        return [
+            'format' => $format,
+            'mime_type' => 'text/plain',
+            'download_name' => $downloadName,
+            'content' => $content,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function circeRScript(array $payload): string
+    {
+        $encoded = base64_encode(json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return <<<R
+# Parthenon CirceR cohort artifact
+# Requires jsonlite. CirceR is optional for SQL generation in an R runtime.
+# PARTHENON_COHORT_JSON_BEGIN
+{$encoded}
+# PARTHENON_COHORT_JSON_END
+
+cohort_payload <- jsonlite::fromJSON(rawToChar(jsonlite::base64_dec("{$encoded}")), simplifyVector = FALSE)
+cohort_expression <- cohort_payload\$expression
+
+if (requireNamespace("CirceR", quietly = TRUE)) {
+  message("CirceR is installed. cohort_expression is ready for CirceR workflows.")
+} else {
+  message("CirceR is not installed. cohort_expression still contains the OHDSI Circe JSON expression.")
+}
+R;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function caprScript(array $payload): string
+    {
+        $encoded = base64_encode(json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT));
+
+        return <<<R
+# Parthenon Capr cohort handoff artifact
+# This file preserves the canonical OHDSI Circe JSON expression and names the Capr boundary.
+# Use it as the package-level handoff point for teams that build or rewrite the cohort in Capr.
+# PARTHENON_COHORT_JSON_BEGIN
+{$encoded}
+# PARTHENON_COHORT_JSON_END
+
+cohort_payload <- jsonlite::fromJSON(rawToChar(jsonlite::base64_dec("{$encoded}")), simplifyVector = FALSE)
+cohort_expression <- cohort_payload\$expression
+
+if (requireNamespace("Capr", quietly = TRUE)) {
+  message("Capr is installed. Use cohort_expression as the reference expression while authoring a Capr DSL equivalent.")
+} else {
+  message("Capr is not installed. The embedded cohort_expression remains importable by Parthenon.")
+}
+R;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function packageArtifact(CohortDefinition $cohortDefinition, array $payload): array
+    {
+        $slug = $this->slug($cohortDefinition);
+        $cohortJson = json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+
+        return [
+            'format' => 'r_package',
+            'mime_type' => 'application/json',
+            'download_name' => "{$slug}.authoring-package.json",
+            'content' => [
+                'package' => [
+                    'name' => Str::studly($slug).'Cohort',
+                    'type' => 'parthenon-ohdsi-authoring',
+                    'created_at' => now()->toISOString(),
+                ],
+                'files' => [
+                    [
+                        'path' => 'inst/cohorts/cohort.json',
+                        'kind' => 'json',
+                        'content' => $cohortJson,
+                    ],
+                    [
+                        'path' => 'R/circer-export.R',
+                        'kind' => 'r',
+                        'content' => $this->circeRScript($payload),
+                    ],
+                    [
+                        'path' => 'R/capr-handoff.R',
+                        'kind' => 'r',
+                        'content' => $this->caprScript($payload),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseJsonLikeArtifact(mixed $artifact): array
+    {
+        if (is_string($artifact)) {
+            $artifact = json_decode($artifact, true, flags: JSON_THROW_ON_ERROR);
+        }
+
+        if (! is_array($artifact)) {
+            throw ValidationException::withMessages([
+                'artifact' => 'JSON authoring artifact must be an object.',
+            ]);
+        }
+
+        $cohort = $artifact['cohortDefinition'] ?? $artifact;
+
+        return [
+            'name' => $cohort['name'] ?? $artifact['name'] ?? null,
+            'description' => $cohort['description'] ?? $artifact['description'] ?? null,
+            'expression' => $cohort['expression'] ?? $artifact['expression'] ?? $artifact['expression_json'] ?? null,
+            'metadata' => $cohort['metadata'] ?? $artifact['metadata'] ?? [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseScriptArtifact(string $script): array
+    {
+        if (! preg_match('/PARTHENON_COHORT_JSON_BEGIN\s*(.*?)\s*#?\s*PARTHENON_COHORT_JSON_END/s', $script, $matches)) {
+            throw ValidationException::withMessages([
+                'artifact' => 'R artifact is missing the Parthenon cohort payload marker.',
+            ]);
+        }
+
+        $payload = json_decode(base64_decode(trim($matches[1]), true) ?: '', true, flags: JSON_THROW_ON_ERROR);
+        if (! is_array($payload)) {
+            throw ValidationException::withMessages([
+                'artifact' => 'Embedded R artifact payload is invalid.',
+            ]);
+        }
+
+        return [
+            'name' => $payload['name'] ?? null,
+            'description' => $payload['description'] ?? null,
+            'expression' => $payload['expression'] ?? null,
+            'metadata' => $payload['metadata'] ?? [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parsePackageArtifact(mixed $artifact): array
+    {
+        if (is_string($artifact)) {
+            $artifact = json_decode($artifact, true, flags: JSON_THROW_ON_ERROR);
+        }
+
+        $files = is_array($artifact) ? ($artifact['files'] ?? $artifact['content']['files'] ?? null) : null;
+        if (! is_array($files)) {
+            return $this->parseJsonLikeArtifact($artifact);
+        }
+
+        foreach ($files as $file) {
+            $path = (string) ($file['path'] ?? '');
+            if (str_ends_with($path, 'cohort.json')) {
+                return $this->parseJsonLikeArtifact((string) ($file['content'] ?? '{}'));
+            }
+        }
+
+        throw ValidationException::withMessages([
+            'artifact' => 'Package artifact does not contain inst/cohorts/cohort.json.',
+        ]);
+    }
+
+    private function slug(CohortDefinition $cohortDefinition): string
+    {
+        return Str::slug($cohortDefinition->name) ?: "cohort-{$cohortDefinition->id}";
+    }
+}

--- a/backend/app/Services/Cohort/CohortAuthoringArtifactService.php
+++ b/backend/app/Services/Cohort/CohortAuthoringArtifactService.php
@@ -51,6 +51,7 @@ class CohortAuthoringArtifactService
                 $this->caprScript($payload),
             ),
             'r_package' => $this->packageArtifact($cohortDefinition, $payload),
+            default => throw new \InvalidArgumentException("Unknown cohort authoring format: {$format}"),
         };
     }
 
@@ -66,6 +67,7 @@ class CohortAuthoringArtifactService
             'atlas_json', 'circe_json' => $this->parseJsonLikeArtifact($artifact),
             'circer_r', 'capr_r' => $this->parseScriptArtifact((string) $artifact),
             'r_package' => $this->parsePackageArtifact($artifact),
+            default => throw new \InvalidArgumentException("Unknown cohort authoring format: {$format}"),
         };
 
         $name = trim((string) ($payload['name'] ?? $parsed['name'] ?? 'Imported cohort'));

--- a/backend/app/Services/RService.php
+++ b/backend/app/Services/RService.php
@@ -72,6 +72,40 @@ class RService
     }
 
     /**
+     * Run SelfControlledCohort via the R sidecar.
+     *
+     * @param  array<string, mixed>  $spec
+     * @return array<string, mixed>
+     */
+    public function runSelfControlledCohort(array $spec): array
+    {
+        $response = Http::timeout($this->timeout)
+            ->post("{$this->baseUrl}/analysis/self-controlled-cohort/run", $spec);
+
+        return $response->json() ?? [
+            'status' => 'error',
+            'message' => 'R runtime returned empty response (HTTP '.$response->status().')',
+        ];
+    }
+
+    /**
+     * Run PheValuator phenotype validation via the R sidecar.
+     *
+     * @param  array<string, mixed>  $spec
+     * @return array<string, mixed>
+     */
+    public function runPhenotypeValidation(array $spec): array
+    {
+        $response = Http::timeout($this->timeout)
+            ->post("{$this->baseUrl}/analysis/phenotype-validation/run", $spec);
+
+        return $response->json() ?? [
+            'status' => 'error',
+            'message' => 'R runtime returned empty response (HTTP '.$response->status().')',
+        ];
+    }
+
+    /**
      * Run Evidence Synthesis meta-analysis via the R sidecar.
      *
      * @param  array<string, mixed>  $spec

--- a/backend/database/migrations/2026_04_14_000008_create_cohort_phenotype_adjudication_events_table.php
+++ b/backend/database/migrations/2026_04_14_000008_create_cohort_phenotype_adjudication_events_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cohort_phenotype_adjudication_events', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('phenotype_validation_id')
+                ->constrained('cohort_phenotype_validations')
+                ->cascadeOnDelete();
+            $table->foreignId('adjudication_id')
+                ->constrained('cohort_phenotype_adjudications')
+                ->cascadeOnDelete();
+            $table->foreignId('actor_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('event_type', 64);
+            $table->jsonb('before_json')->nullable();
+            $table->jsonb('after_json')->nullable();
+            $table->timestamps();
+
+            $table->index(['phenotype_validation_id', 'created_at']);
+            $table->index(['adjudication_id', 'created_at']);
+        });
+
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DO $grants$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'parthenon_app') THEN
+                        GRANT SELECT, INSERT, UPDATE, DELETE ON app.cohort_phenotype_adjudication_events TO parthenon_app;
+                        GRANT USAGE, SELECT ON SEQUENCE app.cohort_phenotype_adjudication_events_id_seq TO parthenon_app;
+                    END IF;
+                END
+                $grants$
+            SQL);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cohort_phenotype_adjudication_events');
+    }
+};

--- a/backend/database/migrations/2026_04_14_000009_add_sampling_metadata_to_cohort_phenotype_adjudications_table.php
+++ b/backend/database/migrations/2026_04_14_000009_add_sampling_metadata_to_cohort_phenotype_adjudications_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('cohort_phenotype_adjudications', function (Blueprint $table) {
+            $table->jsonb('sampling_json')->nullable()->after('demographics_json');
+            $table->timestamp('sampled_at')->nullable()->after('sampling_json');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('cohort_phenotype_adjudications', function (Blueprint $table) {
+            $table->dropColumn(['sampling_json', 'sampled_at']);
+        });
+    }
+};

--- a/backend/database/migrations/2026_04_14_000010_create_cohort_phenotype_adjudication_reviews_table.php
+++ b/backend/database/migrations/2026_04_14_000010_create_cohort_phenotype_adjudication_reviews_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cohort_phenotype_adjudication_reviews', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('phenotype_validation_id')
+                ->constrained('cohort_phenotype_validations')
+                ->cascadeOnDelete();
+            $table->foreignId('adjudication_id')
+                ->constrained('cohort_phenotype_adjudications')
+                ->cascadeOnDelete();
+            $table->foreignId('reviewer_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('label', 32)->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamp('reviewed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['adjudication_id', 'reviewer_id']);
+            $table->index(['phenotype_validation_id', 'label']);
+            $table->index(['phenotype_validation_id', 'reviewer_id']);
+        });
+
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DO $grants$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'parthenon_app') THEN
+                        GRANT SELECT, INSERT, UPDATE, DELETE ON app.cohort_phenotype_adjudication_reviews TO parthenon_app;
+                        GRANT USAGE, SELECT ON SEQUENCE app.cohort_phenotype_adjudication_reviews_id_seq TO parthenon_app;
+                    END IF;
+                END
+                $grants$
+            SQL);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cohort_phenotype_adjudication_reviews');
+    }
+};

--- a/backend/database/migrations/2026_04_14_000012_create_cohort_authoring_artifacts_table.php
+++ b/backend/database/migrations/2026_04_14_000012_create_cohort_authoring_artifacts_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cohort_authoring_artifacts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('cohort_definition_id')->nullable()
+                ->constrained('cohort_definitions')
+                ->nullOnDelete();
+            $table->foreignId('author_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('direction', 16);
+            $table->string('format', 32);
+            $table->jsonb('artifact_json');
+            $table->jsonb('metadata_json')->nullable();
+            $table->timestamps();
+
+            $table->index(['cohort_definition_id', 'created_at']);
+            $table->index(['direction', 'format']);
+        });
+
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DO $grants$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'parthenon_app') THEN
+                        GRANT SELECT, INSERT, UPDATE, DELETE ON app.cohort_authoring_artifacts TO parthenon_app;
+                        GRANT USAGE, SELECT ON SEQUENCE app.cohort_authoring_artifacts_id_seq TO parthenon_app;
+                    END IF;
+                END
+                $grants$
+            SQL);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cohort_authoring_artifacts');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -60,6 +60,7 @@ use App\Http\Controllers\Api\V1\EvidenceSynthesisController;
 use App\Http\Controllers\Api\V1\FhirToCdmController;
 use App\Http\Controllers\Api\V1\FinnGen\AnalysisModuleController;
 use App\Http\Controllers\Api\V1\FinnGen\ArtifactController;
+use App\Http\Controllers\Api\V1\FinnGen\CodeExplorerController;
 use App\Http\Controllers\Api\V1\FinnGen\RunController;
 use App\Http\Controllers\Api\V1\FinnGen\SyncReadController;
 use App\Http\Controllers\Api\V1\GenomicEvidenceController;
@@ -1020,17 +1021,17 @@ Route::prefix('v1')->group(function () {
 
             // Code Explorer (SP2)
             Route::prefix('code-explorer')->group(function () {
-                Route::get('/source-readiness', [\App\Http\Controllers\Api\V1\FinnGen\CodeExplorerController::class, 'sourceReadiness'])
+                Route::get('/source-readiness', [CodeExplorerController::class, 'sourceReadiness'])
                     ->middleware('permission:finngen.code-explorer.view');
-                Route::get('/counts', [\App\Http\Controllers\Api\V1\FinnGen\CodeExplorerController::class, 'counts'])
+                Route::get('/counts', [CodeExplorerController::class, 'counts'])
                     ->middleware(['permission:finngen.code-explorer.view', 'throttle:60,1']);
-                Route::get('/relationships', [\App\Http\Controllers\Api\V1\FinnGen\CodeExplorerController::class, 'relationships'])
+                Route::get('/relationships', [CodeExplorerController::class, 'relationships'])
                     ->middleware(['permission:finngen.code-explorer.view', 'throttle:60,1']);
-                Route::get('/ancestors', [\App\Http\Controllers\Api\V1\FinnGen\CodeExplorerController::class, 'ancestors'])
+                Route::get('/ancestors', [CodeExplorerController::class, 'ancestors'])
                     ->middleware(['permission:finngen.code-explorer.view', 'throttle:60,1']);
-                Route::post('/report', [\App\Http\Controllers\Api\V1\FinnGen\CodeExplorerController::class, 'createReport'])
+                Route::post('/report', [CodeExplorerController::class, 'createReport'])
                     ->middleware(['permission:finngen.code-explorer.view', 'finngen.idempotency', 'throttle:10,1']);
-                Route::post('/initialize-source', [\App\Http\Controllers\Api\V1\FinnGen\CodeExplorerController::class, 'initializeSource'])
+                Route::post('/initialize-source', [CodeExplorerController::class, 'initializeSource'])
                     ->middleware(['permission:finngen.code-explorer.setup', 'finngen.idempotency', 'throttle:10,1']);
             });
         });

--- a/backend/tests/Feature/Api/V1/CohortAuthoringArtifactTest.php
+++ b/backend/tests/Feature/Api/V1/CohortAuthoringArtifactTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use App\Models\App\CohortAuthoringArtifact;
+use App\Models\App\CohortDefinition;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function phase6ValidExpression(): array
+{
+    return [
+        'conceptSets' => [],
+        'PrimaryCriteria' => [
+            'CriteriaList' => [
+                ['ConditionOccurrence' => ['CodesetId' => 0]],
+            ],
+            'ObservationWindow' => ['PriorDays' => 0, 'PostDays' => 0],
+        ],
+        'QualifiedLimit' => ['Type' => 'First'],
+    ];
+}
+
+it('exports an R authoring package with CirceR and Capr handoff files', function () {
+    $user = User::factory()->create();
+    $cohort = CohortDefinition::factory()->create([
+        'author_id' => $user->id,
+        'name' => 'Cardiac structural disorders',
+        'expression_json' => phase6ValidExpression(),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson("/api/v1/cohort-definitions/{$cohort->id}/authoring/export?format=r_package")
+        ->assertOk();
+
+    $response->assertJsonPath('data.format', 'r_package');
+    $response->assertJsonPath('data.mime_type', 'application/json');
+    $response->assertJsonPath('data.content.package.type', 'parthenon-ohdsi-authoring');
+
+    $paths = collect($response->json('data.content.files'))->pluck('path')->all();
+    expect($paths)->toContain('inst/cohorts/cohort.json')
+        ->and($paths)->toContain('R/circer-export.R')
+        ->and($paths)->toContain('R/capr-handoff.R');
+
+    $this->assertDatabaseHas('cohort_authoring_artifacts', [
+        'cohort_definition_id' => $cohort->id,
+        'author_id' => $user->id,
+        'direction' => 'export',
+        'format' => 'r_package',
+    ]);
+});
+
+it('exports a CirceR script that embeds the canonical cohort expression', function () {
+    $user = User::factory()->create();
+    $cohort = CohortDefinition::factory()->create([
+        'author_id' => $user->id,
+        'name' => 'Hemodynamic disorders',
+        'expression_json' => phase6ValidExpression(),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson("/api/v1/cohort-definitions/{$cohort->id}/authoring/export?format=circer")
+        ->assertOk();
+
+    $response->assertJsonPath('data.format', 'circer_r');
+    $response->assertJsonPath('data.download_name', 'hemodynamic-disorders.circer.R');
+
+    expect($response->json('data.content'))
+        ->toContain('PARTHENON_COHORT_JSON_BEGIN')
+        ->and($response->json('data.content'))
+        ->toContain('CirceR is installed');
+});
+
+it('imports a CirceR artifact and suffixes duplicate cohort names', function () {
+    $user = User::factory()->create();
+    $cohort = CohortDefinition::factory()->create([
+        'author_id' => $user->id,
+        'name' => 'Cardiovascular hemodynamic disorders',
+        'expression_json' => phase6ValidExpression(),
+    ]);
+
+    $artifact = $this->actingAs($user)
+        ->getJson("/api/v1/cohort-definitions/{$cohort->id}/authoring/export?format=circer_r")
+        ->assertOk()
+        ->json('data.content');
+
+    $response = $this->actingAs($user)
+        ->postJson('/api/v1/cohort-definitions/authoring/import', [
+            'format' => 'circer_r',
+            'artifact' => $artifact,
+        ])
+        ->assertCreated();
+
+    $response->assertJsonPath('data.status', 'imported');
+    $response->assertJsonPath('data.cohort_definition.name', 'Cardiovascular hemodynamic disorders (2)');
+    $response->assertJsonPath('data.artifact.direction', 'import');
+    $response->assertJsonPath('data.artifact.format', 'circer_r');
+
+    expect(CohortDefinition::query()->where('name', 'Cardiovascular hemodynamic disorders (2)')->exists())
+        ->toBeTrue();
+});
+
+it('skips duplicate imports when requested', function () {
+    $user = User::factory()->create();
+    $cohort = CohortDefinition::factory()->create([
+        'author_id' => $user->id,
+        'name' => 'Duplicate managed cohort',
+        'expression_json' => phase6ValidExpression(),
+    ]);
+
+    $payload = [
+        'name' => $cohort->name,
+        'description' => $cohort->description,
+        'expression' => phase6ValidExpression(),
+    ];
+
+    $this->actingAs($user)
+        ->postJson('/api/v1/cohort-definitions/authoring/import', [
+            'format' => 'atlas_json',
+            'artifact' => $payload,
+            'duplicate_strategy' => 'skip',
+        ])
+        ->assertOk()
+        ->assertJsonPath('data.status', 'skipped')
+        ->assertJsonPath('data.reason', 'Duplicate name');
+
+    expect(CohortDefinition::query()->where('name', 'Duplicate managed cohort')->count())->toBe(1)
+        ->and(CohortAuthoringArtifact::query()->where('direction', 'import')->count())->toBe(0);
+});
+
+it('rejects unsupported authoring artifact formats', function () {
+    $user = User::factory()->create();
+    $cohort = CohortDefinition::factory()->create([
+        'author_id' => $user->id,
+        'expression_json' => phase6ValidExpression(),
+    ]);
+
+    $this->actingAs($user)
+        ->getJson("/api/v1/cohort-definitions/{$cohort->id}/authoring/export?format=unknown")
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['format']);
+});

--- a/backend/tests/Feature/Api/V1/PhenotypeValidationTest.php
+++ b/backend/tests/Feature/Api/V1/PhenotypeValidationTest.php
@@ -1,0 +1,678 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ExecutionStatus;
+use App\Jobs\Analysis\RunPhenotypeValidationJob;
+use App\Models\App\CohortDefinition;
+use App\Models\App\CohortPhenotypeAdjudication;
+use App\Models\App\CohortPhenotypeAdjudicationReview;
+use App\Models\App\CohortPhenotypePromotion;
+use App\Models\App\CohortPhenotypeValidation;
+use App\Models\App\Source;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(RolePermissionSeeder::class);
+});
+
+function phenotypeValidationPayload(Source $source): array
+{
+    return [
+        'source_id' => $source->id,
+        'mode' => 'counts',
+        'counts' => [
+            'true_positives' => 80,
+            'false_positives' => 20,
+            'true_negatives' => 900,
+            'false_negatives' => 40,
+        ],
+        'notes' => 'Reviewer adjudicated sample',
+    ];
+}
+
+it('requires authentication to list phenotype validations', function () {
+    $cohort = CohortDefinition::factory()->create();
+
+    $this->getJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations")
+        ->assertStatus(401);
+});
+
+it('lists phenotype validations for a cohort definition', function () {
+    $user = User::factory()->create();
+    $user->assignRole('viewer');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $user->id]);
+    CohortPhenotypeValidation::create([
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $user->id,
+        'status' => ExecutionStatus::Completed,
+        'mode' => 'counts',
+        'settings_json' => ['counts' => phenotypeValidationPayload($source)['counts']],
+        'result_json' => ['status' => 'completed'],
+        'started_at' => now(),
+        'completed_at' => now(),
+    ]);
+
+    $this->actingAs($user)
+        ->getJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations")
+        ->assertStatus(200)
+        ->assertJsonPath('data.0.status', ExecutionStatus::Completed->value)
+        ->assertJsonPath('data.0.source.id', $source->id);
+});
+
+it('queues a phenotype validation from adjudicated counts', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->postJson(
+            "/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations",
+            phenotypeValidationPayload($source),
+        )
+        ->assertStatus(202)
+        ->assertJsonPath('data.status', ExecutionStatus::Queued->value)
+        ->assertJsonPath('data.settings_json.counts.true_positives', 80)
+        ->assertJsonPath('message', 'Phenotype validation queued.');
+
+    $this->assertDatabaseHas('cohort_phenotype_validations', [
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $user->id,
+        'status' => ExecutionStatus::Queued->value,
+        'mode' => 'counts',
+    ]);
+
+    Queue::assertPushed(RunPhenotypeValidationJob::class);
+});
+
+it('creates a native adjudication review session without queueing metrics', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->postJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations", [
+            'source_id' => $source->id,
+            'mode' => 'adjudication',
+            'notes' => 'Native review',
+        ])
+        ->assertStatus(201)
+        ->assertJsonPath('data.status', ExecutionStatus::Pending->value)
+        ->assertJsonPath('data.mode', 'adjudication')
+        ->assertJsonPath('data.settings_json.review_state', 'draft')
+        ->assertJsonPath('message', 'Phenotype review session created.');
+
+    $this->assertDatabaseHas('cohort_phenotype_validations', [
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'status' => ExecutionStatus::Pending->value,
+        'mode' => 'adjudication',
+    ]);
+
+    Queue::assertNotPushed(RunPhenotypeValidationJob::class);
+});
+
+it('requires complete adjudication before completing a review session', function () {
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $user->id]);
+    $validation = CohortPhenotypeValidation::create([
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $user->id,
+        'status' => ExecutionStatus::Pending,
+        'mode' => 'adjudication',
+        'settings_json' => ['review_state' => 'in_review'],
+    ]);
+    CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 123,
+        'sample_group' => 'cohort_member',
+    ]);
+
+    $this->actingAs($user)
+        ->postJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/review-state", [
+            'review_state' => 'completed',
+        ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['review_state']);
+});
+
+it('locks completed reviews and blocks further adjudication edits', function () {
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $user->id]);
+    $validation = CohortPhenotypeValidation::create([
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $user->id,
+        'status' => ExecutionStatus::Pending,
+        'mode' => 'adjudication',
+        'settings_json' => ['review_state' => 'completed'],
+    ]);
+    $adjudication = CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 123,
+        'sample_group' => 'cohort_member',
+        'label' => 'case',
+    ]);
+
+    $this->actingAs($user)
+        ->postJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/review-state", [
+            'review_state' => 'locked',
+        ])
+        ->assertStatus(200)
+        ->assertJsonPath('data.settings_json.review_state', 'locked');
+
+    $this->actingAs($user)
+        ->patchJson(
+            "/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/adjudications/{$adjudication->id}",
+            ['label' => 'non_case'],
+        )
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['review_state']);
+});
+
+it('blocks metric computation when sampled adjudications are incomplete unless explicitly allowed', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $user->id]);
+    $validation = CohortPhenotypeValidation::create([
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $user->id,
+        'status' => ExecutionStatus::Pending,
+        'mode' => 'adjudication',
+        'settings_json' => ['review_state' => 'in_review'],
+    ]);
+    CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 101,
+        'sample_group' => 'cohort_member',
+        'label' => 'case',
+    ]);
+    CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 102,
+        'sample_group' => 'cohort_member',
+    ]);
+
+    $this->actingAs($user)
+        ->postJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/compute")
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['adjudications']);
+
+    $this->actingAs($user)
+        ->postJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/compute", [
+            'allow_partial' => true,
+        ])
+        ->assertStatus(202)
+        ->assertJsonPath('data.status', ExecutionStatus::Queued->value)
+        ->assertJsonPath('counts.unreviewed', 1);
+
+    Queue::assertPushed(RunPhenotypeValidationJob::class);
+});
+
+it('exports review evidence with counts, sampling metadata, and audit history', function () {
+    $user = User::factory()->create();
+    $user->assignRole('viewer');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $user->id]);
+    $validation = CohortPhenotypeValidation::create([
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $user->id,
+        'status' => ExecutionStatus::Pending,
+        'mode' => 'adjudication',
+        'settings_json' => ['review_state' => 'in_review'],
+    ]);
+    CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 101,
+        'sample_group' => 'cohort_member',
+        'label' => 'case',
+        'sampling_json' => [
+            'seed' => 'review-seed',
+            'strategy' => 'balanced_demographics',
+            'stratum' => 'female|age_60_69',
+        ],
+    ]);
+
+    $this->actingAs($user)
+        ->getJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/evidence-export")
+        ->assertStatus(200)
+        ->assertJsonPath('data.review_state', 'in_review')
+        ->assertJsonPath('data.counts.true_positives', 1)
+        ->assertJsonPath('data.adjudications.0.sampling_json.seed', 'review-seed')
+        ->assertJsonPath('data.adjudications.0.sampling_json.strategy', 'balanced_demographics');
+});
+
+it('validates phenotype validation count payloads', function () {
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $user->id]);
+
+    $this->actingAs($user)
+        ->postJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations", [
+            'source_id' => $source->id,
+            'mode' => 'counts',
+            'counts' => [
+                'true_positives' => 0,
+                'false_positives' => 0,
+                'true_negatives' => 0,
+                'false_negatives' => 0,
+            ],
+        ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['counts']);
+});
+
+it('shows a phenotype validation only under its cohort definition', function () {
+    $user = User::factory()->create();
+    $user->assignRole('viewer');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $user->id]);
+    $otherCohort = CohortDefinition::factory()->create(['author_id' => $user->id]);
+    $validation = CohortPhenotypeValidation::create([
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $user->id,
+        'status' => ExecutionStatus::Completed,
+        'mode' => 'counts',
+        'settings_json' => ['counts' => phenotypeValidationPayload($source)['counts']],
+        'result_json' => [
+            'status' => 'completed',
+            'metrics' => [
+                'positive_predictive_value' => ['estimate' => 0.8],
+            ],
+        ],
+        'started_at' => now(),
+        'completed_at' => now(),
+    ]);
+
+    $this->actingAs($user)
+        ->getJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}")
+        ->assertStatus(200)
+        ->assertJsonPath('data.result_json.metrics.positive_predictive_value.estimate', 0.8);
+
+    $this->actingAs($user)
+        ->getJson("/api/v1/cohort-definitions/{$otherCohort->id}/phenotype-validations/{$validation->id}")
+        ->assertStatus(404);
+});
+
+it('updates adjudication labels and returns current counts', function () {
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $user->id]);
+    $validation = CohortPhenotypeValidation::create([
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $user->id,
+        'status' => ExecutionStatus::Pending,
+        'mode' => 'adjudication',
+    ]);
+    $adjudication = CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 123,
+        'sample_group' => 'cohort_member',
+    ]);
+
+    $this->actingAs($user)
+        ->patchJson(
+            "/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/adjudications/{$adjudication->id}",
+            [
+                'label' => 'case',
+                'notes' => 'Confirmed in chart',
+            ],
+        )
+        ->assertStatus(200)
+        ->assertJsonPath('data.label', 'case')
+        ->assertJsonPath('data.reviewer.id', $user->id)
+        ->assertJsonPath('counts.true_positives', 1);
+
+    $this->assertDatabaseHas('cohort_phenotype_adjudications', [
+        'id' => $adjudication->id,
+        'label' => 'case',
+        'reviewer_id' => $user->id,
+    ]);
+    $this->assertDatabaseHas('cohort_phenotype_adjudication_reviews', [
+        'adjudication_id' => $adjudication->id,
+        'reviewer_id' => $user->id,
+        'label' => 'case',
+    ]);
+
+    $this->assertDatabaseHas('cohort_phenotype_adjudication_events', [
+        'phenotype_validation_id' => $validation->id,
+        'adjudication_id' => $adjudication->id,
+        'actor_id' => $user->id,
+        'event_type' => 'review_update',
+    ]);
+});
+
+it('detects reviewer conflicts and exposes agreement quality summary', function () {
+    $reviewerA = User::factory()->create();
+    $reviewerA->assignRole('researcher');
+    $reviewerB = User::factory()->create();
+    $reviewerB->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $reviewerA->id]);
+    $validation = CohortPhenotypeValidation::create([
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $reviewerA->id,
+        'status' => ExecutionStatus::Pending,
+        'mode' => 'adjudication',
+        'settings_json' => ['review_state' => 'in_review'],
+    ]);
+    $adjudication = CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 123,
+        'sample_group' => 'cohort_member',
+    ]);
+
+    $this->actingAs($reviewerA)
+        ->patchJson(
+            "/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/adjudications/{$adjudication->id}",
+            ['label' => 'case'],
+        )
+        ->assertStatus(200)
+        ->assertJsonPath('data.label', 'case');
+
+    $this->actingAs($reviewerB)
+        ->patchJson(
+            "/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/adjudications/{$adjudication->id}",
+            ['label' => 'non_case'],
+        )
+        ->assertStatus(200)
+        ->assertJsonPath('data.label', null)
+        ->assertJsonPath('agreement.unresolved_conflict_adjudications', 1);
+
+    $this->actingAs($reviewerA)
+        ->getJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/quality-summary")
+        ->assertStatus(200)
+        ->assertJsonPath('data.agreement.review_records', 2)
+        ->assertJsonPath('data.agreement.double_reviewed_adjudications', 1)
+        ->assertJsonPath('data.agreement.conflict_adjudications', 1)
+        ->assertJsonPath('data.agreement.ready_for_promotion', false);
+});
+
+it('resolves reviewer conflicts before computing final metrics', function () {
+    Queue::fake();
+
+    $reviewerA = User::factory()->create();
+    $reviewerA->assignRole('researcher');
+    $reviewerB = User::factory()->create();
+    $reviewerB->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $reviewerA->id]);
+    $validation = CohortPhenotypeValidation::create([
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $reviewerA->id,
+        'status' => ExecutionStatus::Pending,
+        'mode' => 'adjudication',
+        'settings_json' => ['review_state' => 'in_review'],
+    ]);
+    $adjudication = CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 123,
+        'sample_group' => 'cohort_member',
+    ]);
+    CohortPhenotypeAdjudicationReview::create([
+        'phenotype_validation_id' => $validation->id,
+        'adjudication_id' => $adjudication->id,
+        'reviewer_id' => $reviewerA->id,
+        'label' => 'case',
+        'reviewed_at' => now(),
+    ]);
+    CohortPhenotypeAdjudicationReview::create([
+        'phenotype_validation_id' => $validation->id,
+        'adjudication_id' => $adjudication->id,
+        'reviewer_id' => $reviewerB->id,
+        'label' => 'non_case',
+        'reviewed_at' => now(),
+    ]);
+
+    $this->actingAs($reviewerA)
+        ->postJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/compute", [
+            'allow_partial' => true,
+        ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['adjudications']);
+
+    $this->actingAs($reviewerA)
+        ->postJson(
+            "/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/adjudications/{$adjudication->id}/resolve",
+            ['label' => 'case', 'notes' => 'Lead reviewer resolved after chart review.'],
+        )
+        ->assertStatus(200)
+        ->assertJsonPath('data.label', 'case')
+        ->assertJsonPath('agreement.resolved_conflict_adjudications', 1)
+        ->assertJsonPath('agreement.unresolved_conflict_adjudications', 0);
+
+    $this->actingAs($reviewerA)
+        ->postJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/compute")
+        ->assertStatus(202)
+        ->assertJsonPath('counts.true_positives', 1)
+        ->assertJsonPath('agreement.ready_for_promotion', true);
+
+    Queue::assertPushed(RunPhenotypeValidationJob::class);
+});
+
+it('blocks direct cohort validation tier updates without phenotype promotion evidence', function () {
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $cohort = CohortDefinition::factory()->create([
+        'author_id' => $user->id,
+        'quality_tier' => 'draft',
+    ]);
+
+    $this->actingAs($user)
+        ->putJson("/api/v1/cohort-definitions/{$cohort->id}", [
+            'quality_tier' => 'validated',
+        ])
+        ->assertStatus(200);
+
+    expect($cohort->fresh()->quality_tier)->not->toBe('validated');
+    $this->assertDatabaseMissing('cohort_phenotype_promotions', [
+        'cohort_definition_id' => $cohort->id,
+    ]);
+});
+
+it('promotes a cohort to validated only from ready phenotype review evidence', function () {
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create([
+        'author_id' => $user->id,
+        'quality_tier' => 'draft',
+    ]);
+    $validation = CohortPhenotypeValidation::create([
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $user->id,
+        'status' => ExecutionStatus::Completed,
+        'mode' => 'adjudication',
+        'settings_json' => [
+            'review_state' => 'completed',
+            'counts' => [
+                'true_positives' => 1,
+                'false_positives' => 0,
+                'true_negatives' => 0,
+                'false_negatives' => 0,
+            ],
+        ],
+        'result_json' => [
+            'status' => 'completed',
+            'metrics' => [
+                'positive_predictive_value' => ['estimate' => 1.0],
+            ],
+        ],
+        'completed_at' => now(),
+    ]);
+    $adjudication = CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 123,
+        'sample_group' => 'cohort_member',
+        'label' => 'case',
+        'reviewer_id' => $user->id,
+        'reviewed_at' => now(),
+    ]);
+    CohortPhenotypeAdjudicationReview::create([
+        'phenotype_validation_id' => $validation->id,
+        'adjudication_id' => $adjudication->id,
+        'reviewer_id' => $user->id,
+        'label' => 'case',
+        'reviewed_at' => now(),
+    ]);
+
+    $this->actingAs($user)
+        ->postJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/promote", [
+            'approval_notes' => 'Ready for validated release.',
+        ])
+        ->assertStatus(200)
+        ->assertJsonPath('data.promoted_quality_tier', 'validated')
+        ->assertJsonPath('data.quality_summary_json.agreement.ready_for_promotion', true)
+        ->assertJsonPath('cohort_definition.quality_tier', 'validated');
+
+    expect($cohort->fresh()->quality_tier)->toBe('validated');
+    $this->assertDatabaseHas('cohort_phenotype_promotions', [
+        'cohort_definition_id' => $cohort->id,
+        'phenotype_validation_id' => $validation->id,
+        'approver_id' => $user->id,
+        'promoted_quality_tier' => 'validated',
+    ]);
+});
+
+it('rejects promotion until review quality and PheValuator metrics are complete', function () {
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create([
+        'author_id' => $user->id,
+        'quality_tier' => 'draft',
+    ]);
+    $validation = CohortPhenotypeValidation::create([
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $user->id,
+        'status' => ExecutionStatus::Pending,
+        'mode' => 'adjudication',
+        'settings_json' => ['review_state' => 'in_review'],
+    ]);
+    CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 123,
+        'sample_group' => 'cohort_member',
+    ]);
+
+    $this->actingAs($user)
+        ->postJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/promote")
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['review_state']);
+
+    expect($cohort->fresh()->quality_tier)->toBe('draft');
+    expect(CohortPhenotypePromotion::query()->where('cohort_definition_id', $cohort->id)->exists())->toBeFalse();
+});
+
+it('queues phenotype validation metrics from reviewed adjudications', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $cohort = CohortDefinition::factory()->create(['author_id' => $user->id]);
+    $validation = CohortPhenotypeValidation::create([
+        'cohort_definition_id' => $cohort->id,
+        'source_id' => $source->id,
+        'author_id' => $user->id,
+        'status' => ExecutionStatus::Pending,
+        'mode' => 'adjudication',
+    ]);
+
+    CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 101,
+        'sample_group' => 'cohort_member',
+        'label' => 'case',
+    ]);
+    CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 102,
+        'sample_group' => 'cohort_member',
+        'label' => 'non_case',
+    ]);
+    CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 201,
+        'sample_group' => 'non_member',
+        'label' => 'non_case',
+    ]);
+    CohortPhenotypeAdjudication::create([
+        'phenotype_validation_id' => $validation->id,
+        'person_id' => 202,
+        'sample_group' => 'non_member',
+        'label' => 'case',
+    ]);
+
+    $this->actingAs($user)
+        ->postJson("/api/v1/cohort-definitions/{$cohort->id}/phenotype-validations/{$validation->id}/compute")
+        ->assertStatus(202)
+        ->assertJsonPath('data.status', ExecutionStatus::Queued->value)
+        ->assertJsonPath('counts.true_positives', 1)
+        ->assertJsonPath('counts.false_positives', 1)
+        ->assertJsonPath('counts.true_negatives', 1)
+        ->assertJsonPath('counts.false_negatives', 1)
+        ->assertJsonPath('message', 'Phenotype validation queued from adjudications.');
+
+    $this->assertDatabaseHas('cohort_phenotype_validations', [
+        'id' => $validation->id,
+        'status' => ExecutionStatus::Queued->value,
+    ]);
+
+    expect($validation->fresh()->settings_json['counts'])->toMatchArray([
+        'true_positives' => 1,
+        'false_positives' => 1,
+        'true_negatives' => 1,
+        'false_negatives' => 1,
+    ]);
+
+    Queue::assertPushed(RunPhenotypeValidationJob::class);
+});

--- a/backend/tests/Feature/Api/V1/SelfControlledCohortTest.php
+++ b/backend/tests/Feature/Api/V1/SelfControlledCohortTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ExecutionStatus;
+use App\Jobs\Analysis\RunSelfControlledCohortJob;
+use App\Models\App\AnalysisExecution;
+use App\Models\App\SelfControlledCohortAnalysis;
+use App\Models\App\Source;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(RolePermissionSeeder::class);
+});
+
+function selfControlledCohortPayload(): array
+{
+    return [
+        'name' => 'Drug exposure and acute outcome SCC',
+        'description' => 'SelfControlledCohort package analysis',
+        'design_json' => [
+            'exposureCohortId' => 223,
+            'outcomeCohortId' => 225,
+            'exposedWindow' => [
+                'start' => 1,
+                'end' => 30,
+                'addLengthOfExposure' => true,
+            ],
+            'unexposedWindow' => [
+                'start' => -30,
+                'end' => -1,
+                'addLengthOfExposure' => true,
+            ],
+            'studyPopulation' => [
+                'naivePeriod' => 0,
+                'firstOutcomeOnly' => true,
+            ],
+            'firstExposureOnly' => true,
+            'hasFullTimeAtRisk' => false,
+            'washoutPeriod' => 0,
+            'followupPeriod' => 0,
+            'computeTarDistribution' => false,
+        ],
+    ];
+}
+
+it('requires authentication to list self-controlled cohort analyses', function () {
+    $this->getJson('/api/v1/self-controlled-cohorts')
+        ->assertStatus(401);
+});
+
+it('allows viewer access to list self-controlled cohort analyses', function () {
+    $user = User::factory()->create();
+    $user->assignRole('viewer');
+
+    $this->actingAs($user)
+        ->getJson('/api/v1/self-controlled-cohorts')
+        ->assertStatus(200);
+});
+
+it('creates a self-controlled cohort analysis with valid data', function () {
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $response = $this->actingAs($user)
+        ->postJson('/api/v1/self-controlled-cohorts', selfControlledCohortPayload())
+        ->assertStatus(201);
+
+    $response->assertJsonPath('data.name', 'Drug exposure and acute outcome SCC');
+    $response->assertJsonPath('data.design_json.exposureCohortId', 223);
+    $response->assertJsonPath('message', 'Self-Controlled Cohort analysis created.');
+
+    $this->assertDatabaseHas('self_controlled_cohort_analyses', [
+        'name' => 'Drug exposure and acute outcome SCC',
+        'author_id' => $user->id,
+    ]);
+});
+
+it('validates required self-controlled cohort fields', function () {
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $this->actingAs($user)
+        ->postJson('/api/v1/self-controlled-cohorts', [
+            'name' => 'Invalid SCC',
+            'design_json' => [
+                'exposureCohortId' => 223,
+            ],
+        ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('design_json.outcomeCohortId');
+});
+
+it('shows a self-controlled cohort analysis with executions', function () {
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $analysis = SelfControlledCohortAnalysis::create([
+        ...selfControlledCohortPayload(),
+        'author_id' => $user->id,
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson("/api/v1/self-controlled-cohorts/{$analysis->id}")
+        ->assertStatus(200);
+
+    $response->assertJsonPath('data.id', $analysis->id);
+    $response->assertJsonStructure(['data' => ['id', 'name', 'design_json', 'author', 'executions']]);
+});
+
+it('queues a self-controlled cohort execution', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $analysis = SelfControlledCohortAnalysis::create([
+        ...selfControlledCohortPayload(),
+        'author_id' => $user->id,
+    ]);
+
+    $this->actingAs($user)
+        ->postJson("/api/v1/self-controlled-cohorts/{$analysis->id}/execute", [
+            'source_id' => $source->id,
+        ])
+        ->assertStatus(202)
+        ->assertJsonPath('data.status', ExecutionStatus::Queued->value)
+        ->assertJsonPath('message', 'Self-Controlled Cohort execution queued.');
+
+    $this->assertDatabaseHas('analysis_executions', [
+        'analysis_type' => SelfControlledCohortAnalysis::class,
+        'analysis_id' => $analysis->id,
+        'source_id' => $source->id,
+        'status' => ExecutionStatus::Queued->value,
+    ]);
+
+    Queue::assertPushed(RunSelfControlledCohortJob::class);
+});
+
+it('normalizes self-controlled cohort execution results', function () {
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $source = Source::factory()->create();
+    $analysis = SelfControlledCohortAnalysis::create([
+        ...selfControlledCohortPayload(),
+        'author_id' => $user->id,
+    ]);
+    $execution = AnalysisExecution::factory()->completed()->create([
+        'analysis_type' => SelfControlledCohortAnalysis::class,
+        'analysis_id' => $analysis->id,
+        'source_id' => $source->id,
+        'status' => ExecutionStatus::Completed,
+        'result_json' => [
+            'status' => 'completed',
+            'summary' => ['cases' => '10', 'outcomes' => '4'],
+            'estimates' => [
+                [
+                    'name' => 'Exposure 223 / Outcome 225',
+                    'irr' => '1.25',
+                    'ci_lower' => '0.50',
+                    'ci_upper' => '2.25',
+                ],
+            ],
+        ],
+    ]);
+
+    $response = $this->actingAs($user)
+        ->getJson("/api/v1/self-controlled-cohorts/{$analysis->id}/executions/{$execution->id}")
+        ->assertStatus(200);
+
+    $response->assertJsonPath('data.result_json.population.cases', 10);
+    $response->assertJsonPath('data.result_json.population.outcomes', 4);
+    $response->assertJsonPath('data.result_json.estimates.0.covariate', 'Exposure 223 / Outcome 225');
+});

--- a/backend/tests/Feature/FinnGen/CodeExplorerEndpointsTest.php
+++ b/backend/tests/Feature/FinnGen/CodeExplorerEndpointsTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\App\FinnGen\Run;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(\Database\Seeders\Testing\FinnGenTestingSeeder::class);
+    $this->researcher = User::where('email', 'finngen-test-researcher@test.local')->firstOrFail();
+    $this->admin = User::where('email', 'finngen-test-admin@test.local')->firstOrFail();
+
+    try {
+        foreach (\Illuminate\Support\Facades\Redis::connection()->keys('finngen:sync:code-explorer:*') as $k) {
+            \Illuminate\Support\Facades\Redis::connection()->del($k);
+        }
+    } catch (\Throwable $e) {
+        // Redis not available — ignore
+    }
+});
+
+it('GET /counts returns the Darkstar payload on happy path', function () {
+    Http::fake([
+        '*/finngen/romopapi/code-counts*' => Http::response([
+            'concept' => ['concept_id' => 201826, 'concept_name' => 'Diabetes type 2'],
+            'stratified_counts' => [],
+            'node_count' => 0,
+            'descendant_count' => 0,
+        ], 200),
+    ]);
+
+    $this->actingAs($this->researcher)
+        ->getJson('/api/v1/finngen/code-explorer/counts?source=EUNOMIA&concept_id=201826')
+        ->assertStatus(200)
+        ->assertJsonStructure(['concept', 'stratified_counts', 'node_count', 'descendant_count']);
+});
+
+it('GET /counts on missing stratified_code_counts table returns enriched 422', function () {
+    Http::fake([
+        '*/finngen/romopapi/code-counts*' => Http::response([
+            'error' => [
+                'category' => 'DB_SCHEMA_MISMATCH',
+                'message' => 'relation "eunomia_results.stratified_code_counts" does not exist',
+            ],
+        ], 422),
+    ]);
+
+    $response = $this->actingAs($this->researcher)
+        ->getJson('/api/v1/finngen/code-explorer/counts?source=EUNOMIA&concept_id=201826');
+
+    $response->assertStatus(422);
+    $body = $response->json();
+    expect($body['error']['code'])->toBe('FINNGEN_SOURCE_NOT_INITIALIZED');
+    expect($body['error']['action']['type'])->toBe('initialize_source');
+    expect($body['error']['action']['source_key'])->toBe('EUNOMIA');
+});
+
+it('GET /relationships returns data + serves cached response on second call', function () {
+    Http::fake(['*' => Http::response(['relationships' => [['relationship_id' => 'Maps to', 'concept_id_2' => 1]]], 200)]);
+
+    $this->actingAs($this->researcher)
+        ->getJson('/api/v1/finngen/code-explorer/relationships?source=EUNOMIA&concept_id=201826')
+        ->assertStatus(200);
+    $this->actingAs($this->researcher)
+        ->getJson('/api/v1/finngen/code-explorer/relationships?source=EUNOMIA&concept_id=201826')
+        ->assertStatus(200);
+
+    Http::assertSentCount(1);
+})->skip(fn () => redisAvailable() === false, 'Redis not available');
+
+it('GET /ancestors strips mermaid field + clamps max_depth', function () {
+    Http::fake([
+        '*' => Http::response([
+            'nodes' => [['concept_id' => 1]],
+            'edges' => [['src' => 1, 'dst' => 2]],
+            'mermaid' => "graph TD\n  c1 --> c2",
+        ], 200),
+    ]);
+
+    $response = $this->actingAs($this->researcher)
+        ->getJson('/api/v1/finngen/code-explorer/ancestors?source=EUNOMIA&concept_id=201826&max_depth=99');
+
+    $response->assertStatus(200);
+    $body = $response->json();
+    expect($body)->toHaveKeys(['nodes', 'edges']);
+    expect($body)->not->toHaveKey('mermaid');
+
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), 'max_depth=7');
+    });
+});
+
+it('GET /source-readiness returns ready=true when table exists', function () {
+    $response = $this->actingAs($this->researcher)
+        ->getJson('/api/v1/finngen/code-explorer/source-readiness?source=EUNOMIA');
+
+    $response->assertStatus(200)
+        ->assertJsonStructure(['source_key', 'ready', 'missing', 'setup_run_id']);
+    expect($response->json('source_key'))->toBe('EUNOMIA');
+});
+
+it('GET /source-readiness surfaces active setup_run_id', function () {
+    Run::create([
+        'user_id' => $this->researcher->id,
+        'source_key' => 'EUNOMIA',
+        'analysis_type' => 'romopapi.setup',
+        'params' => [],
+        'status' => Run::STATUS_RUNNING,
+        'started_at' => now(),
+    ]);
+
+    $response = $this->actingAs($this->researcher)
+        ->getJson('/api/v1/finngen/code-explorer/source-readiness?source=EUNOMIA');
+
+    $response->assertStatus(200);
+    expect($response->json('setup_run_id'))->not->toBeNull();
+});
+
+it('POST /report dispatches a romopapi.report run', function () {
+    Bus::fake();
+
+    $response = $this->actingAs($this->researcher)
+        ->postJson('/api/v1/finngen/code-explorer/report', [
+            'source_key' => 'EUNOMIA',
+            'concept_id' => 201826,
+        ]);
+
+    $response->assertStatus(201);
+    expect($response->json('analysis_type'))->toBe('romopapi.report');
+    expect($response->json('params.concept_id'))->toBe(201826);
+
+    Bus::assertDispatched(\App\Jobs\FinnGen\RunFinnGenAnalysisJob::class);
+});
+
+it('POST /initialize-source dispatches a romopapi.setup run (admin)', function () {
+    Bus::fake();
+
+    $response = $this->actingAs($this->admin)
+        ->postJson('/api/v1/finngen/code-explorer/initialize-source', [
+            'source_key' => 'EUNOMIA',
+        ]);
+
+    $response->assertStatus(201);
+    expect($response->json('analysis_type'))->toBe('romopapi.setup');
+    expect($response->json('source_key'))->toBe('EUNOMIA');
+});
+
+function redisAvailable(): bool
+{
+    try {
+        return \Illuminate\Support\Facades\Redis::connection()->ping() !== false;
+    } catch (\Throwable $e) {
+        return false;
+    }
+}

--- a/backend/tests/Unit/FinnGen/CodeExplorerCacheKeyTest.php
+++ b/backend/tests/Unit/FinnGen/CodeExplorerCacheKeyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Api\V1\FinnGen\CodeExplorerController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Cache-key format is a contract with both downstream cache-invalidation
+ * tooling AND the observer (ops reading Redis). Any drift breaks both.
+ */
+it('controller defines the expected TTL constants', function () {
+    $reflection = new \ReflectionClass(CodeExplorerController::class);
+    expect($reflection->getConstant('TTL_COUNTS'))->toBe(3600);
+    expect($reflection->getConstant('TTL_RELATIONSHIPS'))->toBe(86400);
+    expect($reflection->getConstant('TTL_ANCESTORS'))->toBe(86400);
+});
+
+it('max-depth cap constant matches spec (§4.1)', function () {
+    $reflection = new \ReflectionClass(CodeExplorerController::class);
+    expect($reflection->getConstant('MAX_DEPTH_CAP'))->toBe(7);
+});
+
+it('cache key format is stable and deterministic', function () {
+    $query1 = ['concept_id' => 201826];
+    $query2 = ['concept_id' => 201826];
+    $hash1 = md5((string) json_encode($query1));
+    $hash2 = md5((string) json_encode($query2));
+    expect($hash1)->toBe($hash2);
+
+    $key = sprintf('finngen:sync:code-explorer:%s:%s:%s', 'counts', 'EUNOMIA', $hash1);
+    expect($key)->toStartWith('finngen:sync:code-explorer:');
+    expect($key)->toContain(':EUNOMIA:');
+    expect(strlen($key))->toBeGreaterThan(40);
+});

--- a/frontend/src/features/cohort-definitions/components/PhenotypeValidationPanel.tsx
+++ b/frontend/src/features/cohort-definitions/components/PhenotypeValidationPanel.tsx
@@ -1,0 +1,1416 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  AlertCircle,
+  Award,
+  BarChart3,
+  Calculator,
+  CheckCircle2,
+  Clock,
+  Download,
+  Eye,
+  FileText,
+  Filter,
+  Loader2,
+  Lock,
+  Play,
+  Save,
+  ShieldCheck,
+  UserCheck,
+  Users,
+  X,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { fetchSources } from "@/features/data-sources/api/sourcesApi";
+import { usePatientNotes, usePatientProfile } from "@/features/profiles/hooks/useProfiles";
+import { useSourceStore } from "@/stores/sourceStore";
+import {
+  useComputePhenotypeValidationFromAdjudications,
+  useExportPhenotypeValidationEvidence,
+  usePhenotypeAdjudications,
+  usePhenotypePromotions,
+  usePhenotypeValidationQualitySummary,
+  usePhenotypeValidations,
+  usePromotePhenotypeValidation,
+  useResolvePhenotypeAdjudication,
+  useRunPhenotypeValidation,
+  useSamplePhenotypeAdjudications,
+  useUpdatePhenotypeAdjudication,
+  useUpdatePhenotypeValidationReviewState,
+} from "../hooks/useCohortDefinitions";
+import type {
+  CohortPhenotypeValidation,
+  PhenotypeAdjudication,
+  PhenotypeAdjudicationLabel,
+  PhenotypeReviewState,
+  PhenotypeSampleStrategy,
+  PhenotypeValidationMetric,
+} from "../types/cohortExpression";
+import { useQuery } from "@tanstack/react-query";
+
+interface PhenotypeValidationPanelProps {
+  definitionId: number;
+}
+
+type CountKey =
+  | "true_positives"
+  | "false_positives"
+  | "true_negatives"
+  | "false_negatives";
+
+type ReviewFilter = "all" | "unreviewed" | "case" | "non_case" | "uncertain";
+
+const COUNT_LABELS: Record<CountKey, { label: string; help: string }> = {
+  true_positives: {
+    label: "True Positives",
+    help: "Confirmed cases captured by the cohort.",
+  },
+  false_positives: {
+    label: "False Positives",
+    help: "Cohort members that were not confirmed cases.",
+  },
+  true_negatives: {
+    label: "True Negatives",
+    help: "Confirmed non-cases excluded by the cohort.",
+  },
+  false_negatives: {
+    label: "False Negatives",
+    help: "Confirmed cases missed by the cohort.",
+  },
+};
+
+const COUNT_KEYS: CountKey[] = [
+  "true_positives",
+  "false_positives",
+  "true_negatives",
+  "false_negatives",
+];
+
+const REVIEW_FILTERS: Array<{ value: ReviewFilter; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "unreviewed", label: "Unreviewed" },
+  { value: "case", label: "Case" },
+  { value: "non_case", label: "Non-case" },
+  { value: "uncertain", label: "Uncertain" },
+];
+
+const REVIEW_STATE_LABELS: Record<PhenotypeReviewState, string> = {
+  draft: "Draft",
+  in_review: "In Review",
+  completed: "Completed",
+  locked: "Locked",
+};
+
+function formatPercent(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatCi(metric: PhenotypeValidationMetric | undefined): string | null {
+  if (!metric || metric.ci_lower == null || metric.ci_upper == null) {
+    return null;
+  }
+
+  return `${formatPercent(metric.ci_lower)} to ${formatPercent(metric.ci_upper)}`;
+}
+
+function StatusBadge({ status }: { status: CohortPhenotypeValidation["status"] }) {
+  const isWorking = status === "queued" || status === "running" || status === "pending";
+  const isDone = status === "completed";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded px-2 py-1 text-[10px] font-medium",
+        isDone
+          ? "bg-success/15 text-success"
+          : isWorking
+            ? "bg-accent/15 text-accent"
+            : "bg-critical/15 text-critical",
+      )}
+    >
+      {isDone ? (
+        <CheckCircle2 size={11} />
+      ) : isWorking ? (
+        <Clock size={11} />
+      ) : (
+        <AlertCircle size={11} />
+      )}
+      {status}
+    </span>
+  );
+}
+
+function MetricCard({
+  label,
+  metric,
+}: {
+  label: string;
+  metric?: PhenotypeValidationMetric;
+}) {
+  const ci = formatCi(metric);
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-raised p-3">
+      <p className="text-[10px] font-medium uppercase text-text-ghost">
+        {label}
+      </p>
+      <p className="mt-1 font-['IBM_Plex_Mono',monospace] text-xl font-semibold text-text-primary">
+        {formatPercent(metric?.estimate)}
+      </p>
+      {ci && (
+        <p className="mt-1 text-[10px] text-text-muted">
+          95% CI {ci}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function labelButtonClass(active: boolean) {
+  return cn(
+    "rounded-md border px-2 py-1 text-[10px] font-medium transition-colors",
+    active
+      ? "border-success/40 bg-success/15 text-success"
+      : "border-border-default bg-surface-base text-text-muted hover:text-text-primary",
+  );
+}
+
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleString();
+}
+
+function PatientContextDrawer({
+  sourceId,
+  adjudication,
+  onClose,
+}: {
+  sourceId: number;
+  adjudication: PhenotypeAdjudication;
+  onClose: () => void;
+}) {
+  const profileQuery = usePatientProfile(sourceId, adjudication.person_id);
+  const notesQuery = usePatientNotes(sourceId, adjudication.person_id, 1, 3);
+  const profile = profileQuery.data;
+  const demo = profile?.demographics;
+  const recentEvents = useMemo(() => {
+    if (!profile) return [];
+    return [
+      ...(profile.conditions ?? []),
+      ...(profile.drugs ?? []),
+      ...(profile.procedures ?? []),
+      ...(profile.measurements ?? []),
+      ...(profile.observations ?? []),
+    ]
+      .sort((a, b) => String(b.start_date).localeCompare(String(a.start_date)))
+      .slice(0, 10);
+  }, [profile]);
+
+  return (
+    <div className="fixed inset-0 z-40 flex justify-end bg-black/40">
+      <div className="h-full w-full max-w-2xl overflow-y-auto border-l border-border-default bg-surface-base shadow-xl">
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-border-default bg-surface-raised px-4 py-3">
+          <div>
+            <p className="text-sm font-semibold text-text-primary">
+              Patient {adjudication.person_id}
+            </p>
+            <p className="text-xs text-text-muted">
+              {adjudication.sample_group === "cohort_member" ? "Cohort member" : "Non-member"}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-2 text-text-muted hover:bg-surface-elevated hover:text-text-primary"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="space-y-4 p-4">
+          {profileQuery.isLoading ? (
+            <div className="flex items-center gap-2 text-xs text-text-ghost">
+              <Loader2 size={12} className="animate-spin" />
+              Loading patient context…
+            </div>
+          ) : profileQuery.isError ? (
+            <div className="rounded-md border border-critical/40 bg-critical/10 px-3 py-2 text-xs text-critical">
+              Patient context could not be loaded.
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="rounded-lg border border-border-default bg-surface-raised p-3">
+                  <p className="text-[10px] text-text-ghost">Demographics</p>
+                  <p className="mt-1 text-sm text-text-primary">
+                    {demo?.gender ?? "Unknown"}
+                    {demo?.year_of_birth ? `, born ${demo.year_of_birth}` : ""}
+                  </p>
+                  <p className="text-xs text-text-muted">
+                    {demo?.race ?? "Unknown race"} / {demo?.ethnicity ?? "Unknown ethnicity"}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-border-default bg-surface-raised p-3">
+                  <p className="text-[10px] text-text-ghost">Record Counts</p>
+                  <p className="mt-1 text-xs text-text-muted">
+                    Conditions {(profile?.conditions ?? []).length.toLocaleString()} · Drugs {(profile?.drugs ?? []).length.toLocaleString()}
+                  </p>
+                  <p className="text-xs text-text-muted">
+                    Procedures {(profile?.procedures ?? []).length.toLocaleString()} · Measurements {(profile?.measurements ?? []).length.toLocaleString()}
+                  </p>
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-border-default bg-surface-raised">
+                <div className="border-b border-border-default px-3 py-2">
+                  <h4 className="text-xs font-semibold text-text-primary">
+                    Recent Clinical Events
+                  </h4>
+                </div>
+                <div className="divide-y divide-border-subtle">
+                  {recentEvents.length > 0 ? recentEvents.map((event, index) => (
+                    <div key={`${event.domain}-${event.occurrence_id ?? index}`} className="px-3 py-2">
+                      <div className="flex items-center justify-between gap-3">
+                        <p className="truncate text-xs font-medium text-text-primary">
+                          {event.concept_name}
+                        </p>
+                        <span className="shrink-0 font-['IBM_Plex_Mono',monospace] text-[10px] text-text-ghost">
+                          {event.start_date}
+                        </span>
+                      </div>
+                      <p className="text-[10px] text-text-muted">
+                        {event.domain}
+                        {event.value != null ? ` · ${event.value}${event.unit ? ` ${event.unit}` : ""}` : ""}
+                      </p>
+                    </div>
+                  )) : (
+                    <p className="px-3 py-4 text-xs text-text-muted">
+                      No recent events returned.
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-border-default bg-surface-raised">
+                <div className="flex items-center gap-2 border-b border-border-default px-3 py-2">
+                  <FileText size={12} className="text-text-muted" />
+                  <h4 className="text-xs font-semibold text-text-primary">
+                    Recent Notes
+                  </h4>
+                </div>
+                <div className="divide-y divide-border-subtle">
+                  {notesQuery.isLoading ? (
+                    <div className="flex items-center gap-2 px-3 py-4 text-xs text-text-ghost">
+                      <Loader2 size={12} className="animate-spin" />
+                      Loading notes…
+                    </div>
+                  ) : (notesQuery.data?.data ?? []).length > 0 ? (
+                    notesQuery.data!.data.map((note) => (
+                      <div key={note.note_id} className="px-3 py-2">
+                        <div className="flex items-center justify-between gap-3">
+                          <p className="truncate text-xs font-medium text-text-primary">
+                            {note.note_title ?? note.note_type ?? "Clinical note"}
+                          </p>
+                          <span className="shrink-0 font-['IBM_Plex_Mono',monospace] text-[10px] text-text-ghost">
+                            {note.note_date}
+                          </span>
+                        </div>
+                        <p className="mt-1 line-clamp-3 text-[10px] leading-relaxed text-text-muted">
+                          {note.note_text}
+                        </p>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="px-3 py-4 text-xs text-text-muted">
+                      No notes returned.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ValidationResults({ validation }: { validation: CohortPhenotypeValidation }) {
+  const result = validation.result_json;
+  const metrics = result?.metrics;
+  const counts = result?.counts ?? validation.settings_json?.counts;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border-default bg-surface-raised px-4 py-3">
+        <div className="flex items-center gap-2">
+          <ShieldCheck size={14} className="text-success" />
+          <span className="text-sm font-semibold text-text-primary">
+            Latest validation
+          </span>
+          <StatusBadge status={validation.status} />
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-[10px] text-text-muted">
+          {validation.source?.source_name && (
+            <span>{validation.source.source_name}</span>
+          )}
+          {result?.package_version && (
+            <span className="rounded bg-surface-overlay px-1.5 py-0.5 font-['IBM_Plex_Mono',monospace]">
+              PheValuator {result.package_version}
+            </span>
+          )}
+          {result?.elapsed_seconds != null && (
+            <span className="font-['IBM_Plex_Mono',monospace]">
+              {result.elapsed_seconds.toFixed(1)}s
+            </span>
+          )}
+        </div>
+      </div>
+
+      {validation.status === "failed" && (
+        <div className="rounded-md border border-critical/40 bg-critical/10 px-3 py-2 text-xs text-critical">
+          {validation.fail_message ?? "Phenotype validation failed."}
+        </div>
+      )}
+
+      {metrics && (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          <MetricCard label="PPV" metric={metrics.positive_predictive_value} />
+          <MetricCard label="Sensitivity" metric={metrics.sensitivity} />
+          <MetricCard label="Specificity" metric={metrics.specificity} />
+          <MetricCard label="NPV" metric={metrics.negative_predictive_value} />
+          <MetricCard label="F1 Score" metric={metrics.f1_score} />
+          <MetricCard label="Estimated Prevalence" metric={metrics.estimated_prevalence} />
+        </div>
+      )}
+
+      {counts && (
+        <div className="rounded-lg border border-border-default bg-surface-raised p-4">
+          <h4 className="text-xs font-semibold text-text-primary">
+            Adjudicated Counts
+          </h4>
+          <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {COUNT_KEYS.map((key) => (
+              <div key={key}>
+                <p className="font-['IBM_Plex_Mono',monospace] text-lg font-semibold text-text-primary">
+                  {counts[key].toLocaleString()}
+                </p>
+                <p className="text-[10px] text-text-muted">
+                  {COUNT_LABELS[key].label}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PhenotypeValidationPanel({
+  definitionId,
+}: PhenotypeValidationPanelProps) {
+  const navigate = useNavigate();
+  const [sourceId, setSourceId] = useState<number | "">("");
+  const [cohortMemberSample, setCohortMemberSample] = useState("25");
+  const [nonMemberSample, setNonMemberSample] = useState("25");
+  const [sampleSeed, setSampleSeed] = useState("");
+  const [sampleStrategy, setSampleStrategy] =
+    useState<PhenotypeSampleStrategy>("balanced_demographics");
+  const [reviewFilter, setReviewFilter] = useState<ReviewFilter>("all");
+  const [noteDrafts, setNoteDrafts] = useState<Record<number, string>>({});
+  const [promotionNotes, setPromotionNotes] = useState("");
+  const [contextAdjudication, setContextAdjudication] =
+    useState<PhenotypeAdjudication | null>(null);
+  const [counts, setCounts] = useState<Record<CountKey, string>>({
+    true_positives: "0",
+    false_positives: "0",
+    true_negatives: "0",
+    false_negatives: "0",
+  });
+  const [notes, setNotes] = useState("");
+
+  const userDefaultSourceId = useSourceStore((s) => s.defaultSourceId);
+  const { data: sources, isLoading: sourcesLoading } = useQuery({
+    queryKey: ["sources"],
+    queryFn: fetchSources,
+  });
+  const validationsQuery = usePhenotypeValidations(definitionId);
+  const reviewSession =
+    validationsQuery.data?.items.find((item) => item.mode === "adjudication") ?? null;
+  const adjudicationsQuery = usePhenotypeAdjudications(
+    definitionId,
+    reviewSession?.id ?? null,
+    reviewFilter,
+  );
+  const runMutation = useRunPhenotypeValidation();
+  const sampleMutation = useSamplePhenotypeAdjudications();
+  const updateAdjudicationMutation = useUpdatePhenotypeAdjudication();
+  const resolveAdjudicationMutation = useResolvePhenotypeAdjudication();
+  const computeMutation = useComputePhenotypeValidationFromAdjudications();
+  const updateReviewStateMutation = useUpdatePhenotypeValidationReviewState();
+  const exportEvidenceMutation = useExportPhenotypeValidationEvidence();
+  const promoteMutation = usePromotePhenotypeValidation();
+  const promotionsQuery = usePhenotypePromotions(definitionId);
+  const qualityQuery = usePhenotypeValidationQualitySummary(
+    definitionId,
+    reviewSession?.id ?? null,
+  );
+
+  useEffect(() => {
+    if (sourceId || !sources || sources.length === 0) return;
+    const defaultSource =
+      (userDefaultSourceId ? sources.find((s) => s.id === userDefaultSourceId) : null)
+      ?? sources[0];
+    setSourceId(defaultSource.id);
+  }, [sourceId, sources, userDefaultSourceId]);
+
+  const parsedCounts = useMemo(
+    () =>
+      Object.fromEntries(
+        COUNT_KEYS.map((key) => [
+          key,
+          Math.max(0, Number.parseInt(counts[key] || "0", 10) || 0),
+        ]),
+      ) as Record<CountKey, number>,
+    [counts],
+  );
+
+  const total = Object.values(parsedCounts).reduce((sum, value) => sum + value, 0);
+  const latest = validationsQuery.data?.items?.[0] ?? null;
+  const adjudications = adjudicationsQuery.data?.items ?? [];
+  const memberRows = adjudications.filter((item) => item.sample_group === "cohort_member");
+  const nonMemberRows = adjudications.filter((item) => item.sample_group === "non_member");
+  const currentReviewed = adjudications.filter((item) => item.label === "case" || item.label === "non_case");
+  const currentUnreviewed = adjudications.filter((item) => item.label == null);
+  const currentUncertain = adjudications.filter((item) => item.label === "uncertain");
+  const reviewedCount =
+    reviewSession?.reviewed_adjudications_count
+    ?? adjudications.filter((item) => item.label === "case" || item.label === "non_case").length;
+  const adjudicationTotal = reviewSession?.adjudications_count ?? adjudications.length;
+  const reviewState = (reviewSession?.settings_json?.review_state ?? "draft") as PhenotypeReviewState;
+  const reviewIsReadOnly = reviewState === "completed" || reviewState === "locked";
+  const reviewIsLocked = reviewState === "locked";
+  const latestSample = reviewSession?.settings_json?.latest_sample ?? null;
+  const agreement = qualityQuery.data?.agreement ?? reviewSession?.settings_json?.agreement_summary ?? null;
+  const promotionReady =
+    !!reviewSession
+    && (reviewState === "completed" || reviewState === "locked")
+    && agreement?.ready_for_promotion === true
+    && reviewSession.status === "completed"
+    && reviewSession.result_json?.status === "completed";
+  const promotions = promotionsQuery.data ?? [];
+
+  const handleRun = () => {
+    if (!sourceId || total === 0) return;
+
+    runMutation.mutate({
+      defId: definitionId,
+      payload: {
+        source_id: sourceId,
+        mode: "counts",
+        counts: parsedCounts,
+        notes: notes.trim() || undefined,
+      },
+    });
+  };
+
+  const handleStartReview = () => {
+    if (!sourceId) return;
+    runMutation.mutate({
+      defId: definitionId,
+      payload: {
+        source_id: sourceId,
+        mode: "adjudication",
+        notes: notes.trim() || undefined,
+      },
+    });
+  };
+
+  const handleSample = () => {
+    if (!reviewSession) return;
+    sampleMutation.mutate({
+      defId: definitionId,
+      validationId: reviewSession.id,
+      payload: {
+        cohort_member_count: Math.max(0, Number.parseInt(cohortMemberSample || "0", 10) || 0),
+        non_member_count: Math.max(0, Number.parseInt(nonMemberSample || "0", 10) || 0),
+        seed: sampleSeed.trim() || undefined,
+        strategy: sampleStrategy,
+      },
+    });
+  };
+
+  const handleLabel = (
+    item: PhenotypeAdjudication,
+    label: PhenotypeAdjudicationLabel,
+  ) => {
+    if (!reviewSession) return;
+    updateAdjudicationMutation.mutate({
+      defId: definitionId,
+      validationId: reviewSession.id,
+      adjudicationId: item.id,
+      label,
+      notes: item.notes,
+    });
+  };
+
+  const handleSaveNote = (item: PhenotypeAdjudication) => {
+    if (!reviewSession) return;
+    updateAdjudicationMutation.mutate({
+      defId: definitionId,
+      validationId: reviewSession.id,
+      adjudicationId: item.id,
+      label: item.label,
+      notes: noteDrafts[item.id] ?? item.notes ?? "",
+    });
+  };
+
+  const handleCompute = () => {
+    if (!reviewSession) return;
+    computeMutation.mutate({
+      defId: definitionId,
+      validationId: reviewSession.id,
+    });
+  };
+
+  const handleResolve = (
+    item: PhenotypeAdjudication,
+    label: Exclude<PhenotypeAdjudicationLabel, null>,
+  ) => {
+    if (!reviewSession) return;
+    resolveAdjudicationMutation.mutate({
+      defId: definitionId,
+      validationId: reviewSession.id,
+      adjudicationId: item.id,
+      label,
+      notes: noteDrafts[item.id] ?? item.notes ?? "",
+    });
+  };
+
+  const handleReviewState = (reviewState: PhenotypeReviewState) => {
+    if (!reviewSession) return;
+    updateReviewStateMutation.mutate({
+      defId: definitionId,
+      validationId: reviewSession.id,
+      reviewState,
+    });
+  };
+
+  const handleExportEvidence = () => {
+    if (!reviewSession) return;
+    exportEvidenceMutation.mutate(
+      {
+        defId: definitionId,
+        validationId: reviewSession.id,
+      },
+      {
+        onSuccess: (payload) => {
+          const blob = new Blob([JSON.stringify(payload, null, 2)], {
+            type: "application/json",
+          });
+          const url = window.URL.createObjectURL(blob);
+          const anchor = document.createElement("a");
+          anchor.href = url;
+          anchor.download = `phenotype-validation-${reviewSession.id}-evidence.json`;
+          document.body.appendChild(anchor);
+          anchor.click();
+          anchor.remove();
+          window.URL.revokeObjectURL(url);
+        },
+      },
+    );
+  };
+
+  const handlePromote = () => {
+    if (!reviewSession || !promotionReady) return;
+    promoteMutation.mutate({
+      defId: definitionId,
+      validationId: reviewSession.id,
+      approvalNotes: promotionNotes.trim() || undefined,
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      {contextAdjudication && reviewSession && (
+        <PatientContextDrawer
+          sourceId={reviewSession.source_id}
+          adjudication={contextAdjudication}
+          onClose={() => setContextAdjudication(null)}
+        />
+      )}
+
+      <div className="rounded-lg border border-border-default bg-surface-raised">
+        <div className="flex items-center gap-2 border-b border-border-default bg-surface-overlay px-4 py-3">
+          <UserCheck size={14} className="text-success" />
+          <h3 className="text-sm font-semibold text-text-primary">
+            Native Review Queue
+          </h3>
+          <span className="rounded px-1.5 py-0.5 text-[9px] font-medium bg-success/15 text-success">
+            preferred
+          </span>
+        </div>
+
+        <div className="space-y-4 p-4">
+          {!reviewSession ? (
+            <div className="space-y-4">
+              <p className="text-xs text-text-muted">
+                Create a review session, sample cohort members and non-members,
+                label the charts, then compute PPV, sensitivity, specificity,
+                NPV, prevalence, and F1 from the labels.
+              </p>
+              <button
+                type="button"
+                onClick={handleStartReview}
+                disabled={!sourceId || runMutation.isPending}
+                className={cn(
+                  "inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors",
+                  sourceId && !runMutation.isPending
+                    ? "bg-success text-surface-base hover:bg-success-dark"
+                    : "border border-border-default bg-surface-overlay text-text-ghost cursor-not-allowed",
+                )}
+              >
+                {runMutation.isPending ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <UserCheck size={14} />
+                )}
+                Start Review Session
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                  <p className="font-['IBM_Plex_Mono',monospace] text-lg font-semibold text-text-primary">
+                    {adjudicationTotal.toLocaleString()}
+                  </p>
+                  <p className="text-[10px] text-text-muted">sampled charts</p>
+                </div>
+                <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                  <p className="font-['IBM_Plex_Mono',monospace] text-lg font-semibold text-text-primary">
+                    {reviewedCount.toLocaleString()}
+                  </p>
+                  <p className="text-[10px] text-text-muted">case/non-case labels</p>
+                </div>
+                <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                  <p className="font-['IBM_Plex_Mono',monospace] text-lg font-semibold text-text-primary">
+                    {reviewSession.source?.source_name ?? "Source"}
+                  </p>
+                  <p className="text-[10px] text-text-muted">review source</p>
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-[10px] font-medium uppercase text-text-ghost">
+                      Review Lifecycle
+                    </p>
+                    <p className="mt-1 text-sm font-semibold text-text-primary">
+                      {REVIEW_STATE_LABELS[reviewState] ?? reviewState}
+                    </p>
+                    {latestSample && (
+                      <p className="mt-1 font-['IBM_Plex_Mono',monospace] text-[10px] text-text-muted">
+                        seed {latestSample.seed} · {latestSample.strategy.replace("_", " ")}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleReviewState("completed")}
+                      disabled={
+                        reviewState !== "in_review"
+                        || updateReviewStateMutation.isPending
+                        || agreement?.ready_for_promotion !== true
+                      }
+                      className="inline-flex items-center gap-1 rounded-md border border-border-default bg-surface-raised px-2.5 py-1.5 text-[10px] font-medium text-text-muted hover:text-text-primary disabled:opacity-50"
+                    >
+                      <CheckCircle2 size={11} />
+                      Complete
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleReviewState("locked")}
+                      disabled={reviewState !== "completed" || updateReviewStateMutation.isPending}
+                      className="inline-flex items-center gap-1 rounded-md border border-border-default bg-surface-raised px-2.5 py-1.5 text-[10px] font-medium text-text-muted hover:text-text-primary disabled:opacity-50"
+                    >
+                      <Lock size={11} />
+                      Lock
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleExportEvidence}
+                      disabled={exportEvidenceMutation.isPending}
+                      className="inline-flex items-center gap-1 rounded-md border border-border-default bg-surface-raised px-2.5 py-1.5 text-[10px] font-medium text-text-muted hover:text-text-primary disabled:opacity-50"
+                    >
+                      {exportEvidenceMutation.isPending ? (
+                        <Loader2 size={11} className="animate-spin" />
+                      ) : (
+                        <Download size={11} />
+                      )}
+                      Export evidence
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              {agreement && (
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-5">
+                  <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                    <p className="font-['IBM_Plex_Mono',monospace] text-base font-semibold text-text-primary">
+                      {agreement.review_records.toLocaleString()}
+                    </p>
+                    <p className="text-[10px] text-text-muted">review records</p>
+                  </div>
+                  <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                    <p className="font-['IBM_Plex_Mono',monospace] text-base font-semibold text-text-primary">
+                      {agreement.double_reviewed_adjudications.toLocaleString()}
+                    </p>
+                    <p className="text-[10px] text-text-muted">double reviewed</p>
+                  </div>
+                  <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                    <p className="font-['IBM_Plex_Mono',monospace] text-base font-semibold text-text-primary">
+                      {agreement.unresolved_conflict_adjudications.toLocaleString()}
+                    </p>
+                    <p className="text-[10px] text-text-muted">unresolved conflicts</p>
+                  </div>
+                  <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                    <p className="font-['IBM_Plex_Mono',monospace] text-base font-semibold text-text-primary">
+                      {formatPercent(agreement.observed_pairwise_agreement)}
+                    </p>
+                    <p className="text-[10px] text-text-muted">pairwise agreement</p>
+                  </div>
+                  <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                    <p className="font-['IBM_Plex_Mono',monospace] text-base font-semibold text-text-primary">
+                      {agreement.cohen_kappa == null ? "—" : agreement.cohen_kappa.toFixed(2)}
+                    </p>
+                    <p className="text-[10px] text-text-muted">kappa</p>
+                  </div>
+                </div>
+              )}
+
+              <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <Award size={13} className="text-accent" />
+                      <p className="text-xs font-semibold text-text-primary">
+                        Promotion Governance
+                      </p>
+                    </div>
+                    <p className="mt-1 text-[10px] text-text-muted">
+                      Requires completed review quality and completed PheValuator metrics.
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-2 text-[10px]">
+                      <span className={cn(
+                        "rounded px-1.5 py-0.5",
+                        reviewState === "completed" || reviewState === "locked"
+                          ? "bg-success/15 text-success"
+                          : "bg-surface-overlay text-text-ghost",
+                      )}>
+                        review complete
+                      </span>
+                      <span className={cn(
+                        "rounded px-1.5 py-0.5",
+                        agreement?.ready_for_promotion
+                          ? "bg-success/15 text-success"
+                          : "bg-surface-overlay text-text-ghost",
+                      )}>
+                        quality ready
+                      </span>
+                      <span className={cn(
+                        "rounded px-1.5 py-0.5",
+                        reviewSession.status === "completed" && reviewSession.result_json?.status === "completed"
+                          ? "bg-success/15 text-success"
+                          : "bg-surface-overlay text-text-ghost",
+                      )}>
+                        metrics complete
+                      </span>
+                    </div>
+                  </div>
+                  <div className="w-full max-w-md space-y-2">
+                    <textarea
+                      value={promotionNotes}
+                      onChange={(event) => setPromotionNotes(event.target.value)}
+                      rows={2}
+                      placeholder="Approval notes"
+                      className="w-full resize-none rounded-md border border-border-default bg-surface-raised px-3 py-2 text-xs text-text-primary placeholder:text-text-ghost focus:outline-none focus:border-success"
+                    />
+                    <button
+                      type="button"
+                      onClick={handlePromote}
+                      disabled={!promotionReady || promoteMutation.isPending}
+                      className={cn(
+                        "inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2 text-xs font-medium transition-colors",
+                        promotionReady && !promoteMutation.isPending
+                          ? "bg-accent text-surface-base hover:bg-accent/80"
+                          : "border border-border-default bg-surface-overlay text-text-ghost cursor-not-allowed",
+                      )}
+                    >
+                      {promoteMutation.isPending ? (
+                        <Loader2 size={13} className="animate-spin" />
+                      ) : (
+                        <Award size={13} />
+                      )}
+                      Promote to Validated
+                    </button>
+                  </div>
+                </div>
+                {promoteMutation.isError && (
+                  <div className="mt-3 flex items-start gap-2 rounded-md border border-critical/40 bg-critical/10 px-3 py-2 text-xs text-critical">
+                    <AlertCircle size={12} className="mt-0.5 shrink-0" />
+                    <span>
+                      {promoteMutation.error instanceof Error
+                        ? promoteMutation.error.message
+                        : "Failed to promote phenotype."}
+                    </span>
+                  </div>
+                )}
+                {promotions.length > 0 && (
+                  <div className="mt-3 border-t border-border-subtle pt-3">
+                    <p className="text-[10px] font-medium uppercase text-text-ghost">
+                      Promotion History
+                    </p>
+                    <div className="mt-2 space-y-1">
+                      {promotions.slice(0, 3).map((promotion) => (
+                        <div key={promotion.id} className="flex flex-wrap items-center justify-between gap-2 text-[10px] text-text-muted">
+                          <span>
+                            {promotion.approver?.name ?? "Approver"} promoted validation {promotion.phenotype_validation_id}
+                          </span>
+                          <span className="font-['IBM_Plex_Mono',monospace] text-text-ghost">
+                            {formatDateTime(promotion.promoted_at)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-5">
+                <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                  <p className="font-['IBM_Plex_Mono',monospace] text-base font-semibold text-text-primary">
+                    {memberRows.length.toLocaleString()}
+                  </p>
+                  <p className="text-[10px] text-text-muted">members in view</p>
+                </div>
+                <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                  <p className="font-['IBM_Plex_Mono',monospace] text-base font-semibold text-text-primary">
+                    {nonMemberRows.length.toLocaleString()}
+                  </p>
+                  <p className="text-[10px] text-text-muted">non-members in view</p>
+                </div>
+                <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                  <p className="font-['IBM_Plex_Mono',monospace] text-base font-semibold text-text-primary">
+                    {currentReviewed.length.toLocaleString()}
+                  </p>
+                  <p className="text-[10px] text-text-muted">reviewed in view</p>
+                </div>
+                <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                  <p className="font-['IBM_Plex_Mono',monospace] text-base font-semibold text-text-primary">
+                    {currentUnreviewed.length.toLocaleString()}
+                  </p>
+                  <p className="text-[10px] text-text-muted">unreviewed in view</p>
+                </div>
+                <div className="rounded-lg border border-border-default bg-surface-base p-3">
+                  <p className="font-['IBM_Plex_Mono',monospace] text-base font-semibold text-text-primary">
+                    {currentUncertain.length.toLocaleString()}
+                  </p>
+                  <p className="text-[10px] text-text-muted">uncertain in view</p>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-4">
+                <label className="space-y-1.5">
+                  <span className="text-xs font-medium text-text-muted">
+                    Cohort Members
+                  </span>
+                  <input
+                    type="number"
+                    min={0}
+                    max={500}
+                    value={cohortMemberSample}
+                    onChange={(event) => setCohortMemberSample(event.target.value)}
+                    className="w-full rounded-md border border-border-default bg-surface-base px-3 py-2 font-['IBM_Plex_Mono',monospace] text-sm text-text-primary focus:outline-none focus:border-success"
+                  />
+                </label>
+                <label className="space-y-1.5">
+                  <span className="text-xs font-medium text-text-muted">
+                    Non-Members
+                  </span>
+                  <input
+                    type="number"
+                    min={0}
+                    max={500}
+                    value={nonMemberSample}
+                    onChange={(event) => setNonMemberSample(event.target.value)}
+                    className="w-full rounded-md border border-border-default bg-surface-base px-3 py-2 font-['IBM_Plex_Mono',monospace] text-sm text-text-primary focus:outline-none focus:border-success"
+                  />
+                </label>
+                <label className="space-y-1.5">
+                  <span className="text-xs font-medium text-text-muted">
+                    Seed
+                  </span>
+                  <input
+                    type="text"
+                    value={sampleSeed}
+                    onChange={(event) => setSampleSeed(event.target.value)}
+                    placeholder="auto"
+                    className="w-full rounded-md border border-border-default bg-surface-base px-3 py-2 font-['IBM_Plex_Mono',monospace] text-sm text-text-primary placeholder:text-text-ghost focus:outline-none focus:border-success"
+                  />
+                </label>
+                <label className="space-y-1.5">
+                  <span className="text-xs font-medium text-text-muted">
+                    Strategy
+                  </span>
+                  <select
+                    value={sampleStrategy}
+                    onChange={(event) =>
+                      setSampleStrategy(event.target.value as PhenotypeSampleStrategy)
+                    }
+                    className="w-full rounded-md border border-border-default bg-surface-base px-3 py-2 text-sm text-text-primary focus:outline-none focus:border-success"
+                  >
+                    <option value="balanced_demographics">Balanced demographics</option>
+                    <option value="random">Seeded random</option>
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  onClick={handleSample}
+                  disabled={sampleMutation.isPending || reviewIsReadOnly}
+                  className="self-end inline-flex items-center justify-center gap-2 rounded-lg border border-border-default bg-surface-base px-4 py-2.5 text-sm font-medium text-text-primary hover:bg-surface-elevated transition-colors disabled:opacity-50"
+                >
+                  {sampleMutation.isPending ? (
+                    <Loader2 size={14} className="animate-spin" />
+                  ) : (
+                    <Users size={14} />
+                  )}
+                  Sample
+                </button>
+              </div>
+
+              {sampleMutation.isError && (
+                <div className="flex items-start gap-2 rounded-md border border-critical/40 bg-critical/10 px-3 py-2 text-xs text-critical">
+                  <AlertCircle size={12} className="mt-0.5 shrink-0" />
+                  <span>
+                    {sampleMutation.error instanceof Error
+                      ? sampleMutation.error.message
+                      : "Failed to create review sample."}
+                  </span>
+                </div>
+              )}
+
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="flex items-center gap-1 text-xs text-text-muted">
+                  <Filter size={12} />
+                  Queue filter
+                </div>
+                {REVIEW_FILTERS.map((filter) => (
+                  <button
+                    key={filter.value}
+                    type="button"
+                    onClick={() => setReviewFilter(filter.value)}
+                    className={cn(
+                      "rounded-md border px-2.5 py-1 text-[10px] font-medium transition-colors",
+                      reviewFilter === filter.value
+                        ? "border-primary/40 bg-primary/15 text-primary"
+                        : "border-border-default bg-surface-base text-text-muted hover:text-text-primary",
+                    )}
+                  >
+                    {filter.label}
+                  </button>
+                ))}
+              </div>
+
+              {adjudicationsQuery.isLoading ? (
+                <div className="flex items-center gap-2 text-xs text-text-ghost">
+                  <Loader2 size={12} className="animate-spin" />
+                  Loading review queue…
+                </div>
+              ) : adjudications.length > 0 ? (
+                <div className="overflow-x-auto rounded-lg border border-border-default">
+                  <table className="w-full text-xs">
+                    <thead className="bg-surface-overlay text-text-muted">
+                      <tr>
+                        <th className="px-3 py-2 text-left font-medium">Patient</th>
+                        <th className="px-3 py-2 text-left font-medium">Sample</th>
+                        <th className="px-3 py-2 text-left font-medium">Demographics</th>
+                        <th className="px-3 py-2 text-left font-medium">Label</th>
+                        <th className="px-3 py-2 text-left font-medium">Reviewer</th>
+                        <th className="px-3 py-2 text-left font-medium">Notes</th>
+                        <th className="px-3 py-2 text-right font-medium">Profile</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {adjudications.map((item) => {
+                        const definitiveLabels = (item.reviews ?? [])
+                          .map((review) => review.label)
+                          .filter((label) => label === "case" || label === "non_case");
+                        const hasConflict =
+                          new Set(definitiveLabels).size > 1 && item.label == null;
+
+                        return (
+                        <tr key={item.id} className="border-t border-border-subtle">
+                          <td className="px-3 py-2 font-['IBM_Plex_Mono',monospace] text-text-primary">
+                            {item.person_id}
+                          </td>
+                          <td className="px-3 py-2 text-text-muted">
+                            <p>{item.sample_group === "cohort_member" ? "Member" : "Non-member"}</p>
+                            {item.sampling_json?.stratum && (
+                              <p className="font-['IBM_Plex_Mono',monospace] text-[10px] text-text-ghost">
+                                {item.sampling_json.stratum}
+                              </p>
+                            )}
+                          </td>
+                          <td className="px-3 py-2 text-text-muted">
+                            {item.demographics_json?.gender ?? "Unknown"}
+                            {item.demographics_json?.year_of_birth
+                              ? `, born ${item.demographics_json.year_of_birth}`
+                              : ""}
+                          </td>
+                          <td className="px-3 py-2">
+                            <div className="flex flex-wrap gap-1">
+                              <button
+                                type="button"
+                                onClick={() => handleLabel(item, "case")}
+                                disabled={reviewIsReadOnly}
+                                className={labelButtonClass(item.label === "case")}
+                              >
+                                Case
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => handleLabel(item, "non_case")}
+                                disabled={reviewIsReadOnly}
+                                className={labelButtonClass(item.label === "non_case")}
+                              >
+                                Non-case
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => handleLabel(item, "uncertain")}
+                                disabled={reviewIsReadOnly}
+                                className={labelButtonClass(item.label === "uncertain")}
+                              >
+                                Uncertain
+                              </button>
+                            </div>
+                            {hasConflict && (
+                              <div className="mt-2 rounded-md border border-critical/30 bg-critical/10 p-2">
+                                <p className="text-[10px] font-medium text-critical">
+                                  Reviewer conflict
+                                </p>
+                                <div className="mt-1 flex flex-wrap gap-1">
+                                  <button
+                                    type="button"
+                                    onClick={() => handleResolve(item, "case")}
+                                    disabled={reviewIsReadOnly || resolveAdjudicationMutation.isPending}
+                                    className="rounded-md border border-border-default bg-surface-base px-2 py-1 text-[10px] text-text-muted hover:text-text-primary disabled:opacity-50"
+                                  >
+                                    Resolve case
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => handleResolve(item, "non_case")}
+                                    disabled={reviewIsReadOnly || resolveAdjudicationMutation.isPending}
+                                    className="rounded-md border border-border-default bg-surface-base px-2 py-1 text-[10px] text-text-muted hover:text-text-primary disabled:opacity-50"
+                                  >
+                                    Resolve non-case
+                                  </button>
+                                </div>
+                              </div>
+                            )}
+                          </td>
+                          <td className="px-3 py-2 text-text-muted">
+                            <p>{item.reviewer?.name ?? "—"}</p>
+                            <p className="font-['IBM_Plex_Mono',monospace] text-[10px] text-text-ghost">
+                              {formatDateTime(item.reviewed_at)}
+                            </p>
+                            {item.events && item.events.length > 0 && (
+                              <p className="mt-1 text-[10px] text-text-ghost">
+                                {item.events.length} audit event{item.events.length === 1 ? "" : "s"}
+                              </p>
+                            )}
+                            {(item.reviews ?? []).length > 0 && (
+                              <div className="mt-2 space-y-1">
+                                {(item.reviews ?? []).slice(0, 3).map((review) => (
+                                  <p key={review.id} className="text-[10px] text-text-ghost">
+                                    {review.reviewer?.name ?? "Reviewer"}: {review.label ?? "pending"}
+                                  </p>
+                                ))}
+                              </div>
+                            )}
+                          </td>
+                          <td className="min-w-64 px-3 py-2">
+                            <textarea
+                              value={noteDrafts[item.id] ?? item.notes ?? ""}
+                              onChange={(event) =>
+                                setNoteDrafts((prev) => ({
+                                  ...prev,
+                                  [item.id]: event.target.value,
+                                }))
+                              }
+                              rows={2}
+                              placeholder="Review note"
+                              className="w-full resize-none rounded-md border border-border-default bg-surface-base px-2 py-1 text-xs text-text-primary placeholder:text-text-ghost focus:outline-none focus:border-success"
+                            />
+                            <button
+                              type="button"
+                              onClick={() => handleSaveNote(item)}
+                              disabled={updateAdjudicationMutation.isPending || reviewIsReadOnly}
+                              className="mt-1 inline-flex items-center gap-1 rounded-md px-2 py-1 text-[10px] text-text-muted hover:bg-surface-elevated hover:text-text-primary transition-colors disabled:opacity-50"
+                            >
+                              <Save size={11} />
+                              Save note
+                            </button>
+                          </td>
+                          <td className="px-3 py-2 text-right">
+                            <button
+                              type="button"
+                              onClick={() => setContextAdjudication(item)}
+                              className="mr-1 inline-flex items-center gap-1 rounded-md px-2 py-1 text-[10px] text-text-muted hover:bg-surface-elevated hover:text-text-primary transition-colors"
+                            >
+                              <FileText size={11} />
+                              Context
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() =>
+                                navigate(`/profiles/${item.person_id}?sourceId=${reviewSession.source_id}`)
+                              }
+                              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[10px] text-text-muted hover:bg-surface-elevated hover:text-text-primary transition-colors"
+                            >
+                              <Eye size={11} />
+                              Open
+                            </button>
+                          </td>
+                        </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <div className="rounded-lg border border-dashed border-surface-highlight bg-surface-base px-4 py-6 text-center text-xs text-text-muted">
+                  No charts sampled yet.
+                </div>
+              )}
+
+              <button
+                type="button"
+                onClick={handleCompute}
+                disabled={reviewedCount === 0 || computeMutation.isPending || reviewIsLocked}
+                className={cn(
+                  "inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors",
+                  reviewedCount > 0 && !computeMutation.isPending && !reviewIsLocked
+                    ? "bg-primary text-primary-foreground hover:bg-primary/80"
+                    : "border border-border-default bg-surface-overlay text-text-ghost cursor-not-allowed",
+                )}
+              >
+                {computeMutation.isPending ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Calculator size={14} />
+                )}
+                Compute Metrics From Review
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border-default bg-surface-raised">
+        <div className="flex items-center gap-2 border-b border-border-default bg-surface-overlay px-4 py-3">
+          <BarChart3 size={14} className="text-primary" />
+          <h3 className="text-sm font-semibold text-text-primary">
+            Phenotype Validation
+          </h3>
+          <span className="rounded px-1.5 py-0.5 text-[9px] font-medium bg-primary/15 text-primary">
+            PheValuator
+          </span>
+        </div>
+
+        <div className="space-y-5 p-4">
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-text-muted">
+              Data Source
+            </label>
+            {sourcesLoading ? (
+              <div className="flex items-center gap-2 text-xs text-text-ghost">
+                <Loader2 size={12} className="animate-spin" />
+                Loading sources…
+              </div>
+            ) : !sources || sources.length === 0 ? (
+              <div className="flex items-center gap-2 text-xs text-critical">
+                <AlertCircle size={12} />
+                No data sources configured.
+              </div>
+            ) : (
+              <select
+                value={sourceId}
+                onChange={(event) => setSourceId(Number(event.target.value))}
+                className={cn(
+                  "w-full rounded-md border border-border-default bg-surface-base px-3 py-2 text-sm text-text-primary",
+                  "focus:outline-none focus:border-success transition-colors",
+                )}
+              >
+                <option value="" disabled>
+                  Select a source…
+                </option>
+                {sources.map((source) => (
+                  <option key={source.id} value={source.id}>
+                    {source.source_name}
+                    {source.id === userDefaultSourceId ? " (default)" : ""}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {COUNT_KEYS.map((key) => (
+              <label key={key} className="space-y-1.5">
+                <span className="text-xs font-medium text-text-muted">
+                  {COUNT_LABELS[key].label}
+                </span>
+                <input
+                  type="number"
+                  min={0}
+                  step={1}
+                  value={counts[key]}
+                  onChange={(event) =>
+                    setCounts((prev) => ({
+                      ...prev,
+                      [key]: event.target.value,
+                    }))
+                  }
+                  className={cn(
+                    "w-full rounded-md border border-border-default bg-surface-base px-3 py-2",
+                    "font-['IBM_Plex_Mono',monospace] text-sm text-text-primary",
+                    "focus:outline-none focus:border-success transition-colors",
+                  )}
+                />
+                <span className="block text-[10px] text-text-ghost">
+                  {COUNT_LABELS[key].help}
+                </span>
+              </label>
+            ))}
+          </div>
+
+          <label className="space-y-1.5">
+            <span className="text-xs font-medium text-text-muted">
+              Notes
+            </span>
+            <textarea
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              rows={2}
+              placeholder="Reference set, reviewer, sampling method."
+              className={cn(
+                "w-full resize-none rounded-md border border-border-default bg-surface-base px-3 py-2",
+                "text-sm text-text-primary placeholder:text-text-ghost",
+                "focus:outline-none focus:border-success transition-colors",
+              )}
+            />
+          </label>
+
+          {runMutation.isError && (
+            <div className="flex items-start gap-2 rounded-md border border-critical/40 bg-critical/10 px-3 py-2 text-xs text-critical">
+              <AlertCircle size={12} className="mt-0.5 shrink-0" />
+              <span>
+                {runMutation.error instanceof Error
+                  ? runMutation.error.message
+                  : "Failed to queue phenotype validation."}
+              </span>
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={handleRun}
+            disabled={!sourceId || total === 0 || runMutation.isPending}
+            className={cn(
+              "inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors",
+              sourceId && total > 0 && !runMutation.isPending
+                ? "bg-primary text-primary-foreground hover:bg-primary/80"
+                : "border border-border-default bg-surface-overlay text-text-ghost cursor-not-allowed",
+            )}
+          >
+            {runMutation.isPending ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Play size={14} />
+            )}
+            Run Validation
+          </button>
+
+          <p className="text-center text-[10px] text-text-ghost">
+            Count-based validation uses adjudicated reference labels and persists the
+            PheValuator metric output for review.
+          </p>
+        </div>
+      </div>
+
+      {validationsQuery.isLoading ? (
+        <div className="flex items-center gap-2 text-xs text-text-ghost">
+          <Loader2 size={12} className="animate-spin" />
+          Loading validation history…
+        </div>
+      ) : latest ? (
+        <ValidationResults validation={latest} />
+      ) : (
+        <div className="rounded-lg border border-border-default bg-surface-raised px-4 py-6 text-center text-xs text-text-muted">
+          No phenotype validations have been run for this cohort.
+        </div>
+      )}
+
+      {validationsQuery.data?.items && validationsQuery.data.items.length > 1 && (
+        <div className="rounded-lg border border-border-default bg-surface-raised">
+          <div className="border-b border-border-default px-4 py-3">
+            <h4 className="text-xs font-semibold text-text-primary">
+              Validation History
+            </h4>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border-subtle text-text-muted">
+                  <th className="px-3 py-2 text-left font-medium">Run</th>
+                  <th className="px-3 py-2 text-left font-medium">Status</th>
+                  <th className="px-3 py-2 text-left font-medium">Source</th>
+                  <th className="px-3 py-2 text-right font-medium">PPV</th>
+                  <th className="px-3 py-2 text-right font-medium">Sensitivity</th>
+                </tr>
+              </thead>
+              <tbody>
+                {validationsQuery.data.items.slice(1, 8).map((validation) => (
+                  <tr key={validation.id} className="border-b border-border-subtle">
+                    <td className="px-3 py-2 text-text-secondary">
+                      {new Date(validation.created_at).toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2">
+                      <StatusBadge status={validation.status} />
+                    </td>
+                    <td className="px-3 py-2 text-text-muted">
+                      {validation.source?.source_name ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 text-right font-['IBM_Plex_Mono',monospace] text-text-primary">
+                      {formatPercent(validation.result_json?.metrics?.positive_predictive_value?.estimate)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-['IBM_Plex_Mono',monospace] text-text-primary">
+                      {formatPercent(validation.result_json?.metrics?.sensitivity?.estimate)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/self-controlled-cohort/components/SelfControlledCohortDesigner.tsx
+++ b/frontend/src/features/self-controlled-cohort/components/SelfControlledCohortDesigner.tsx
@@ -1,0 +1,359 @@
+import { useState, useEffect } from "react";
+import { Loader2, Save, X, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useQuery } from "@tanstack/react-query";
+import { getCohortDefinitions } from "@/features/cohort-definitions/api/cohortApi";
+import { CovariateSettingsPanel } from "@/components/analysis/CovariateSettingsPanel";
+import type { SelfControlledCohortDesign, SelfControlledCohortAnalysis, SelfControlledCohortRiskWindow } from "../types/selfControlledCohort";
+import { useCreateSelfControlledCohort, useUpdateSelfControlledCohort } from "../hooks/useSelfControlledCohort";
+
+const defaultSelfControlledCohortRiskWindow: SelfControlledCohortRiskWindow = {
+  start: 0,
+  end: 30,
+  startAnchor: "era_start",
+  endAnchor: "era_start",
+  label: "Risk Window 1",
+};
+
+const defaultDesign: SelfControlledCohortDesign = {
+  exposureCohortId: 0,
+  outcomeCohortId: 0,
+  riskWindows: [{ ...defaultSelfControlledCohortRiskWindow }],
+  model: { type: "simple" },
+  studyPopulation: {
+    naivePeriod: 365,
+    firstOutcomeOnly: true,
+  },
+  covariateSettings: {
+    useDemographics: false,
+    useConditionOccurrence: true,
+    useDrugExposure: true,
+    useProcedureOccurrence: false,
+    useMeasurement: false,
+    timeWindows: [{ start: -365, end: 0 }],
+  },
+};
+
+interface SelfControlledCohortDesignerProps {
+  analysis?: SelfControlledCohortAnalysis | null;
+  isNew?: boolean;
+  onSaved?: (s: SelfControlledCohortAnalysis) => void;
+}
+
+export function SelfControlledCohortDesigner({ analysis, isNew, onSaved }: SelfControlledCohortDesignerProps) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [design, setDesign] = useState<SelfControlledCohortDesign>(defaultDesign);
+
+  const { data: cohortData, isLoading: loadingCohorts } = useQuery({
+    queryKey: ["cohort-definitions", { page: 1, limit: 200 }],
+    queryFn: () => getCohortDefinitions({ page: 1, limit: 200 }),
+  });
+
+  const createMutation = useCreateSelfControlledCohort();
+  const updateMutation = useUpdateSelfControlledCohort();
+
+  const cohorts = cohortData?.items ?? [];
+
+  useEffect(() => {
+    if (analysis) {
+      setName(analysis.name);
+      setDescription(analysis.description ?? "");
+      // design_json may arrive from API in snake_case or camelCase — cast to Record for safe access
+      const dj = (analysis.design_json ?? {}) as unknown as Record<string, unknown>;
+      const studyPop = (dj.studyPopulation ?? dj.studyPopulationSettings ?? defaultDesign.studyPopulation) as Record<string, unknown>;
+      setDesign({
+        ...defaultDesign,
+        ...(analysis.design_json ?? {}),
+        studyPopulation: {
+          naivePeriod: (studyPop?.naivePeriod ?? studyPop?.naive_period ?? 365) as number,
+          firstOutcomeOnly: (studyPop?.firstOutcomeOnly ?? studyPop?.first_outcome_only ?? true) as boolean,
+        },
+        riskWindows: (dj.riskWindows ?? dj.risk_windows ?? defaultDesign.riskWindows) as SelfControlledCohortDesign["riskWindows"],
+      });
+    }
+  }, [analysis]);
+
+  const handleSave = () => {
+    if (!name.trim()) return;
+
+    if (isNew || !analysis) {
+      createMutation.mutate(
+        { name: name.trim(), description: description.trim() || undefined, design_json: design },
+        { onSuccess: (s) => onSaved?.(s) },
+      );
+    } else {
+      updateMutation.mutate(
+        { id: analysis.id, payload: { name: name.trim(), description: description.trim(), design_json: design } },
+        { onSuccess: (s) => onSaved?.(s) },
+      );
+    }
+  };
+
+  const isSaving = createMutation.isPending || updateMutation.isPending;
+
+  const addSelfControlledCohortRiskWindow = () => {
+    setDesign((d) => ({
+      ...d,
+      riskWindows: [
+        ...d.riskWindows,
+        {
+          ...defaultSelfControlledCohortRiskWindow,
+          label: `Risk Window ${d.riskWindows.length + 1}`,
+        },
+      ],
+    }));
+  };
+
+  const removeSelfControlledCohortRiskWindow = (idx: number) => {
+    setDesign((d) => ({
+      ...d,
+      riskWindows: d.riskWindows.filter((_, i) => i !== idx),
+    }));
+  };
+
+  const updateSelfControlledCohortRiskWindow = (idx: number, updates: Partial<SelfControlledCohortRiskWindow>) => {
+    setDesign((d) => ({
+      ...d,
+      riskWindows: d.riskWindows.map((w, i) => (i === idx ? { ...w, ...updates } : w)),
+    }));
+  };
+
+  const inputCls = cn(
+    "w-full rounded-lg border border-border-default bg-surface-base px-3 py-2 text-sm",
+    "text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/30",
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Name & Description */}
+      <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-4">
+        <h3 className="text-sm font-semibold text-text-primary">Basic Information</h3>
+        <div className="space-y-3">
+          <div>
+            <label className="block text-xs font-medium text-text-muted mb-1">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Self-Controlled Cohort analysis name"
+              className={cn(inputCls, "placeholder:text-text-ghost")}
+            />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-text-muted mb-1">Description</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional description"
+              rows={2}
+              className={cn(inputCls, "placeholder:text-text-ghost resize-none")}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Exposure Cohort */}
+      <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-3">
+        <h3 className="text-sm font-semibold text-text-primary">Exposure Cohort</h3>
+        <p className="text-xs text-text-muted">Select the drug/exposure cohort. Each patient serves as their own control.</p>
+        {loadingCohorts ? (
+          <Loader2 size={16} className="animate-spin text-text-muted" />
+        ) : (
+          <select
+            value={design.exposureCohortId || ""}
+            onChange={(e) => setDesign((d) => ({ ...d, exposureCohortId: Number(e.target.value) || 0 }))}
+            className={inputCls}
+          >
+            <option value="">Select exposure cohort...</option>
+            {cohorts.map((c) => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {/* Outcome Cohort */}
+      <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-3">
+        <h3 className="text-sm font-semibold text-text-primary">Outcome Cohort</h3>
+        <p className="text-xs text-text-muted">Select the adverse event/outcome to study.</p>
+        {loadingCohorts ? (
+          <Loader2 size={16} className="animate-spin text-text-muted" />
+        ) : (
+          <select
+            value={design.outcomeCohortId || ""}
+            onChange={(e) => setDesign((d) => ({ ...d, outcomeCohortId: Number(e.target.value) || 0 }))}
+            className={inputCls}
+          >
+            <option value="">Select outcome cohort...</option>
+            {cohorts.map((c) => (
+              <option key={c.id} value={c.id}>{c.name}</option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {/* Risk Windows */}
+      <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-text-primary">Risk Windows</h3>
+          <button
+            type="button"
+            onClick={addSelfControlledCohortRiskWindow}
+            className="inline-flex items-center gap-1 text-xs text-success hover:text-success-dark transition-colors"
+          >
+            <Plus size={12} /> Add Window
+          </button>
+        </div>
+        <p className="text-xs text-text-muted">
+          Define time windows relative to the exposure era where the outcome risk is assessed.
+        </p>
+        {design.riskWindows.map((rw, idx) => (
+          <div key={idx} className="rounded-lg border border-border-default bg-surface-base p-3 space-y-3">
+            <div className="flex items-center justify-between">
+              <input
+                type="text"
+                value={rw.label}
+                onChange={(e) => updateSelfControlledCohortRiskWindow(idx, { label: e.target.value })}
+                className="bg-transparent text-sm text-text-primary font-medium focus:outline-none border-b border-transparent focus:border-accent transition-colors"
+              />
+              {design.riskWindows.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => removeSelfControlledCohortRiskWindow(idx)}
+                  className="text-text-muted hover:text-critical transition-colors"
+                >
+                  <X size={14} />
+                </button>
+              )}
+            </div>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              <div>
+                <label className="block text-[10px] text-text-ghost mb-1">Start Day</label>
+                <input
+                  type="number"
+                  value={rw.start}
+                  onChange={(e) => updateSelfControlledCohortRiskWindow(idx, { start: Number(e.target.value) })}
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className="block text-[10px] text-text-ghost mb-1">Start Anchor</label>
+                <select
+                  value={rw.startAnchor}
+                  onChange={(e) => updateSelfControlledCohortRiskWindow(idx, { startAnchor: e.target.value as "era_start" | "era_end" })}
+                  className={inputCls}
+                >
+                  <option value="era_start">Era Start</option>
+                  <option value="era_end">Era End</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-[10px] text-text-ghost mb-1">End Day</label>
+                <input
+                  type="number"
+                  value={rw.end}
+                  onChange={(e) => updateSelfControlledCohortRiskWindow(idx, { end: Number(e.target.value) })}
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label className="block text-[10px] text-text-ghost mb-1">End Anchor</label>
+                <select
+                  value={rw.endAnchor}
+                  onChange={(e) => updateSelfControlledCohortRiskWindow(idx, { endAnchor: e.target.value as "era_start" | "era_end" })}
+                  className={inputCls}
+                >
+                  <option value="era_start">Era Start</option>
+                  <option value="era_end">Era End</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Model & Population Settings */}
+      <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-4">
+        <h3 className="text-sm font-semibold text-text-primary">Model & Population</h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-xs font-medium text-text-muted mb-1">Model Type</label>
+            <select
+              value={design.model.type}
+              onChange={(e) => setDesign((d) => ({ ...d, model: { ...d.model, type: e.target.value as SelfControlledCohortDesign["model"]["type"] } }))}
+              className={inputCls}
+            >
+              <option value="simple">Simple (no adjustments)</option>
+              <option value="age_adjusted">Age-adjusted</option>
+              <option value="season_adjusted">Season-adjusted</option>
+              <option value="age_season_adjusted">Age + Season adjusted</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-text-muted mb-1">Naive Period (days)</label>
+            <input
+              type="number"
+              min={0}
+              value={design.studyPopulation?.naivePeriod ?? 365}
+              onChange={(e) => setDesign((d) => ({
+                ...d,
+                studyPopulation: { ...(d.studyPopulation ?? defaultDesign.studyPopulation), naivePeriod: Number(e.target.value) },
+              }))}
+              className={inputCls}
+            />
+          </div>
+        </div>
+        <div className="flex items-center gap-6">
+          <label className="flex items-center gap-2 text-sm text-text-secondary cursor-pointer">
+            <button
+              type="button"
+              onClick={() => setDesign((d) => ({
+                ...d,
+                studyPopulation: { ...(d.studyPopulation ?? defaultDesign.studyPopulation), firstOutcomeOnly: !(d.studyPopulation?.firstOutcomeOnly ?? true) },
+              }))}
+              className={cn(
+                "relative w-9 h-5 rounded-full transition-colors",
+                (design.studyPopulation?.firstOutcomeOnly ?? true) ? "bg-success" : "bg-surface-highlight",
+              )}
+            >
+              <span className={cn(
+                "absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform",
+                (design.studyPopulation?.firstOutcomeOnly ?? true) && "translate-x-4",
+              )} />
+            </button>
+            First Outcome Only
+          </label>
+        </div>
+      </div>
+
+      {/* Covariate Settings */}
+      {design.covariateSettings && (
+        <CovariateSettingsPanel
+          settings={design.covariateSettings}
+          onChange={(covariateSettings) => setDesign((d) => ({ ...d, covariateSettings }))}
+          visibleKeys={[
+            "useDemographics",
+            "useConditionOccurrence",
+            "useDrugExposure",
+            "useProcedureOccurrence",
+            "useMeasurement",
+          ]}
+        />
+      )}
+
+      {/* Save Button */}
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={isSaving || !name.trim()}
+          className="inline-flex items-center gap-2 rounded-lg bg-success px-5 py-2.5 text-sm font-medium text-surface-base hover:bg-success-dark transition-colors disabled:opacity-50"
+        >
+          {isSaving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+          {isNew ? "Create" : "Save Changes"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/self-controlled-cohort/hooks/useSelfControlledCohort.ts
+++ b/frontend/src/features/self-controlled-cohort/hooks/useSelfControlledCohort.ts
@@ -1,0 +1,127 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  listSelfControlledCohorts,
+  getSelfControlledCohort,
+  createSelfControlledCohort,
+  updateSelfControlledCohort,
+  deleteSelfControlledCohort,
+  executeSelfControlledCohort,
+  listSelfControlledCohortsExecutions,
+  getSelfControlledCohortExecution,
+} from "../api/selfControlledCohortApi";
+import type { SelfControlledCohortDesign } from "../types/selfControlledCohort";
+
+// ---------------------------------------------------------------------------
+// Query hooks
+// ---------------------------------------------------------------------------
+
+export function useSelfControlledCohortAnalyses(page?: number, search?: string) {
+  return useQuery({
+    queryKey: ["self-controlled-cohorts", { page, search }],
+    queryFn: () => listSelfControlledCohorts({ page, search }),
+  });
+}
+
+export function useSelfControlledCohortAnalysis(id: number | null) {
+  return useQuery({
+    queryKey: ["self-controlled-cohorts", id],
+    queryFn: () => getSelfControlledCohort(id!),
+    enabled: id != null && id > 0,
+  });
+}
+
+export function useSelfControlledCohortExecutions(id: number | null) {
+  return useQuery({
+    queryKey: ["self-controlled-cohorts", id, "executions"],
+    queryFn: () => listSelfControlledCohortsExecutions(id!),
+    enabled: id != null && id > 0,
+  });
+}
+
+export function useSelfControlledCohortExecution(
+  id: number | null,
+  executionId: number | null,
+) {
+  return useQuery({
+    queryKey: ["self-controlled-cohorts", id, "executions", executionId],
+    queryFn: () => getSelfControlledCohortExecution(id!, executionId!),
+    enabled:
+      id != null && id > 0 && executionId != null && executionId > 0,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (status === "running" || status === "queued" || status === "pending") {
+        return 2000;
+      }
+      return false;
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mutation hooks
+// ---------------------------------------------------------------------------
+
+export function useCreateSelfControlledCohort() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: {
+      name: string;
+      description?: string;
+      design_json: SelfControlledCohortDesign;
+    }) => createSelfControlledCohort(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["self-controlled-cohorts"] });
+    },
+  });
+}
+
+export function useUpdateSelfControlledCohort() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      payload,
+    }: {
+      id: number;
+      payload: Partial<{
+        name: string;
+        description: string;
+        design_json: SelfControlledCohortDesign;
+      }>;
+    }) => updateSelfControlledCohort(id, payload),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["self-controlled-cohorts", variables.id] });
+      queryClient.invalidateQueries({ queryKey: ["self-controlled-cohorts"] });
+    },
+  });
+}
+
+export function useDeleteSelfControlledCohort() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => deleteSelfControlledCohort(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["self-controlled-cohorts"] });
+    },
+  });
+}
+
+export function useExecuteSelfControlledCohort() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, sourceId }: { id: number; sourceId: number }) =>
+      executeSelfControlledCohort(id, sourceId),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["self-controlled-cohorts", variables.id, "executions"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["self-controlled-cohorts", variables.id],
+      });
+    },
+  });
+}

--- a/frontend/src/features/self-controlled-cohort/pages/SelfControlledCohortDetailPage.tsx
+++ b/frontend/src/features/self-controlled-cohort/pages/SelfControlledCohortDetailPage.tsx
@@ -1,0 +1,330 @@
+import { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ArrowLeft,
+  Loader2,
+  Trash2,
+  Play,
+  Database,
+  ChevronDown,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { fetchSources } from "@/features/data-sources/api/sourcesApi";
+import { SelfControlledCohortDesigner } from "../components/SelfControlledCohortDesigner";
+import { SccsResults } from "@/features/sccs/components/SccsResults";
+import { ExecutionStatusBadge } from "@/features/analyses/components/ExecutionStatusBadge";
+import {
+  useSelfControlledCohortAnalysis,
+  useDeleteSelfControlledCohort,
+  useExecuteSelfControlledCohort,
+  useSelfControlledCohortExecution,
+} from "../hooks/useSelfControlledCohort";
+
+type Tab = "design" | "results";
+
+export default function SelfControlledCohortDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const analysisId = id === "new" ? null : Number(id);
+  const isNew = id === "new";
+
+  const {
+    data: selfControlledCohort,
+    isLoading,
+    error,
+  } = useSelfControlledCohortAnalysis(analysisId);
+  const deleteMutation = useDeleteSelfControlledCohort();
+  const executeMutation = useExecuteSelfControlledCohort();
+
+  const [activeTab, setActiveTab] = useState<Tab>("design");
+  const [sourceId, setSourceId] = useState<number | null>(null);
+  const [activeExecId, setActiveExecId] = useState<number | null>(null);
+
+  const { data: sources, isLoading: loadingSources } = useQuery({
+    queryKey: ["sources"],
+    queryFn: fetchSources,
+  });
+
+  // Auto-select latest completed execution
+  useEffect(() => {
+    if (selfControlledCohort?.executions?.length && !activeExecId) {
+      const completed = selfControlledCohort.executions.find((e) => e.status === "completed");
+      const latest = completed ?? selfControlledCohort.executions[0];
+      if (latest) setActiveExecId(latest.id);
+    }
+  }, [selfControlledCohort?.executions, activeExecId]);
+
+  const { data: activeExec } = useSelfControlledCohortExecution(
+    analysisId,
+    activeExecId,
+  );
+
+  const handleDelete = () => {
+    if (!analysisId) return;
+    if (
+      window.confirm(
+        "Are you sure you want to delete this Self-Controlled Cohort analysis?",
+      )
+    ) {
+      deleteMutation.mutate(analysisId, {
+        onSuccess: () => navigate("/analyses"),
+      });
+    }
+  };
+
+  const handleExecute = () => {
+    if (!analysisId || !sourceId) return;
+    executeMutation.mutate(
+      { id: analysisId, sourceId },
+      {
+        onSuccess: (exec) => {
+          setActiveExecId(exec.id);
+          setActiveTab("results");
+        },
+      },
+    );
+  };
+
+  const isRunning =
+    activeExec?.status === "running" ||
+    activeExec?.status === "queued" ||
+    activeExec?.status === "pending";
+
+  if (isLoading && !isNew) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 size={24} className="animate-spin text-text-muted" />
+      </div>
+    );
+  }
+
+  if (!isNew && (error || !selfControlledCohort)) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-center">
+          <p className="text-critical">
+            Failed to load Self-Controlled Cohort analysis
+          </p>
+          <button
+            type="button"
+            onClick={() => navigate("/analyses")}
+            className="mt-4 text-sm text-text-muted hover:text-text-primary transition-colors"
+          >
+            Back to analyses
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <button
+            type="button"
+            onClick={() => navigate("/analyses")}
+            className="inline-flex items-center gap-1 text-sm text-text-muted hover:text-text-primary transition-colors mb-3"
+          >
+            <ArrowLeft size={14} />
+            Analyses
+          </button>
+          <h1 className="text-2xl font-bold text-text-primary">
+            {isNew ? "New Self-Controlled Cohort Analysis" : selfControlledCohort?.name ?? "Self-Controlled Cohort Analysis"}
+          </h1>
+          {selfControlledCohort?.description && (
+            <p className="mt-1 text-sm text-text-muted">
+              {selfControlledCohort.description}
+            </p>
+          )}
+        </div>
+
+        {!isNew && (
+          <div className="flex items-center gap-2 shrink-0">
+            <div className="flex items-center gap-2">
+              <div className="relative">
+                <Database
+                  size={12}
+                  className="absolute left-3 top-1/2 -translate-y-1/2 text-text-ghost"
+                />
+                <select
+                  value={sourceId ?? ""}
+                  onChange={(e) =>
+                    setSourceId(Number(e.target.value) || null)
+                  }
+                  disabled={loadingSources}
+                  className={cn(
+                    "appearance-none rounded-lg border border-border-default bg-surface-base pl-8 pr-8 py-2 text-sm",
+                    "text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent/30",
+                  )}
+                >
+                  <option value="">Source</option>
+                  {sources?.map((src) => (
+                    <option key={src.id} value={src.id}>
+                      {src.source_name}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown
+                  size={12}
+                  className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-text-ghost"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={handleExecute}
+                disabled={
+                  !sourceId ||
+                  executeMutation.isPending ||
+                  isRunning
+                }
+                className="inline-flex items-center gap-1.5 rounded-lg bg-success px-3 py-2 text-sm font-medium text-surface-base hover:bg-success-dark transition-colors disabled:opacity-50"
+              >
+                {executeMutation.isPending || isRunning ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Play size={14} />
+                )}
+                Execute
+              </button>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border-default bg-surface-raised px-3 py-2 text-sm text-text-muted hover:text-critical hover:border-critical/30 transition-colors disabled:opacity-50"
+            >
+              {deleteMutation.isPending ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Trash2 size={14} />
+              )}
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Tab navigation */}
+      {!isNew && (
+        <div className="flex items-center gap-1 border-b border-border-default">
+          {(
+            [
+              { key: "design" as const, label: "Design" },
+              { key: "results" as const, label: "Results" },
+            ]
+          ).map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setActiveTab(tab.key)}
+              className={cn(
+                "relative px-4 py-2.5 text-sm font-medium transition-colors",
+                activeTab === tab.key
+                  ? "text-success"
+                  : "text-text-muted hover:text-text-secondary",
+              )}
+            >
+              {tab.label}
+              {activeTab === tab.key && (
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-success" />
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Tab content */}
+      {activeTab === "design" || isNew ? (
+        <SelfControlledCohortDesigner
+          analysis={selfControlledCohort}
+          isNew={isNew}
+          onSaved={(s) => {
+            if (isNew) navigate(`/analyses/self-controlled-cohorts/${s.id}`);
+          }}
+        />
+      ) : (
+        <div className="space-y-6">
+          <SccsResults execution={activeExec ?? null} isLoading={!activeExec && !!activeExecId} />
+
+          {/* Execution History */}
+          {selfControlledCohort?.executions && selfControlledCohort.executions.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-text-primary mb-3">
+                Execution History
+              </h3>
+              <div className="rounded-lg border border-border-default bg-surface-raised overflow-hidden">
+                <table className="w-full">
+                  <thead>
+                    <tr className="bg-surface-overlay">
+                      <th className="px-4 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+                        Status
+                      </th>
+                      <th className="px-4 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+                        Source
+                      </th>
+                      <th className="px-4 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+                        Started
+                      </th>
+                      <th className="px-4 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-text-muted">
+                        Completed
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {selfControlledCohort.executions.map((exec, i) => (
+                      <tr
+                        key={exec.id}
+                        onClick={() => {
+                          if (exec.status === "completed") {
+                            setActiveExecId(exec.id);
+                          }
+                        }}
+                        className={cn(
+                          "border-t border-border-subtle transition-colors",
+                          exec.status === "completed" &&
+                            "cursor-pointer hover:bg-surface-overlay",
+                          i % 2 === 0
+                            ? "bg-surface-raised"
+                            : "bg-surface-overlay",
+                          activeExecId === exec.id &&
+                            "ring-1 ring-inset ring-success/30",
+                        )}
+                      >
+                        <td className="px-4 py-3">
+                          <ExecutionStatusBadge
+                            status={exec.status}
+                          />
+                        </td>
+                        <td className="px-4 py-3 text-xs text-text-muted">
+                          Source #{exec.source_id}
+                        </td>
+                        <td className="px-4 py-3 text-xs text-text-muted">
+                          {exec.started_at
+                            ? new Date(
+                                exec.started_at,
+                              ).toLocaleString()
+                            : "--"}
+                        </td>
+                        <td className="px-4 py-3 text-xs text-text-muted">
+                          {exec.completed_at
+                            ? new Date(
+                                exec.completed_at,
+                              ).toLocaleString()
+                            : "--"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Risk: MEDIUM — completes features already on main; has one misleading commit message

Completes the PhenotypeValidation, SelfControlledCohort, and CohortAuthoringArtifact features whose controllers already landed on main via 83ce271d2.

## Two commits on this branch:

### 1. \`2fb2c52dc\` — MESSAGE IS WRONG, CONTENT IS RIGHT
Commit message says \"test(finngen): CodeExplorer feature tests — 8 endpoint happy paths + error enrichment (Task A.4)\" but contents are the 20 extracted phenotype-sc files + 1 FinnGen CodeExplorer test file. A parallel session grabbed my staging during a pre-commit race and committed under its own message. **The code is correct; only the message is misleading.** Fix by \`git rebase -i\` + \`reword\` on the PR branch before merge, or just accept the caveat.

Files in that commit (21):
- 2 Jobs: RunPhenotypeValidationJob, RunSelfControlledCohortJob
- 4 Services: PhenotypeValidationService, PhenotypeAdjudicationService, SelfControlledCohortService, CohortAuthoringArtifactService
- 3 Models: CohortAuthoringArtifact, CohortPhenotypeAdjudicationEvent, CohortPhenotypeAdjudicationReview
- 4 migrations: adjudication_events, adjudication_reviews, sampling_metadata, authoring_artifacts
- 3 feature tests: CohortAuthoringArtifactTest, PhenotypeValidationTest, SelfControlledCohortTest
- 4 frontend files: PhenotypeValidationPanel, SelfControlledCohortDesigner + hook + page
- Plus 1 extra: Tests/Feature/FinnGen/CodeExplorerEndpointsTest.php (legitimate FinnGen test that was in the parallel session's staging)

### 2. \`423ad2ae3\` — correctly labeled follow-up
- RService::runSelfControlledCohort() + runPhenotypeValidation() HTTP clients (pure-forward from stash; main ≡ stash base)
- \`default => throw\` branches on two CohortAuthoringArtifactService match expressions (PHPStan exhaustivity)
- Pint fix to routes/api.php (pre-existing style drift from a non-Docker-Pint commit)

## Depends on
\`feature/darkstar-phenotype-r-apis\` (#128) — the R endpoints RService calls into. **Merge #128 first.**

## Deployment
\`\`\`bash
./deploy.sh --db  # runs 4 new migrations
docker compose up -d --force-recreate r-runtime  # pick up new R endpoints
\`\`\`

## Test plan
- [ ] Commit message on 2fb2c52dc renamed if desired
- [ ] 4 migrations run clean (GRANT to parthenon_app verified)
- [ ] Pest: PhenotypeValidationTest + SelfControlledCohortTest + CohortAuthoringArtifactTest all pass
- [ ] SPA: PhenotypeValidationPanel loads without console errors