### PR TITLE
feat(study-designer): service layer + enum convention alignment

### DIFF
--- a/backend/app/Enums/StudyDesignAssetStatus.php
+++ b/backend/app/Enums/StudyDesignAssetStatus.php
@@ -4,8 +4,9 @@ namespace App\Enums;
 
 enum StudyDesignAssetStatus: string
 {
-    case NeedsReview = 'needs_review';
-    case Accepted = 'accepted';
-    case Rejected = 'rejected';
-    case Deferred = 'deferred';
+    case NEEDS_REVIEW = 'needs_review';
+    case ACCEPTED = 'accepted';
+    case REJECTED = 'rejected';
+    case DEFERRED = 'deferred';
+    case MATERIALIZED = 'materialized';
 }

--- a/backend/app/Enums/StudyDesignVerificationStatus.php
+++ b/backend/app/Enums/StudyDesignVerificationStatus.php
@@ -4,7 +4,8 @@ namespace App\Enums;
 
 enum StudyDesignVerificationStatus: string
 {
-    case Unverified = 'unverified';
-    case Verified = 'verified';
-    case Blocked = 'blocked';
+    case UNVERIFIED = 'unverified';
+    case VERIFIED = 'verified';
+    case BLOCKED = 'blocked';
+    case PARTIAL = 'partial';
 }

--- a/backend/app/Http/Controllers/Api/V1/StudyDesignController.php
+++ b/backend/app/Http/Controllers/Api/V1/StudyDesignController.php
@@ -164,13 +164,13 @@ class StudyDesignController extends Controller
             $this->createAsset($session, $version, [
                 'asset_type' => 'imported_study_cohort',
                 'role' => $studyCohort->role,
-                'status' => StudyDesignAssetStatus::Accepted->value,
+                'status' => StudyDesignAssetStatus::ACCEPTED->value,
                 'canonical_type' => CohortDefinition::class,
                 'canonical_id' => $definition?->id,
                 'materialized_type' => CohortDefinition::class,
                 'materialized_id' => $definition?->id,
                 'materialized_at' => $definition ? now() : null,
-                'verification_status' => $deprecated ? StudyDesignVerificationStatus::Blocked->value : StudyDesignVerificationStatus::Verified->value,
+                'verification_status' => $deprecated ? StudyDesignVerificationStatus::BLOCKED->value : StudyDesignVerificationStatus::VERIFIED->value,
                 'verified_at' => $deprecated ? null : now(),
                 'draft_payload_json' => [
                     'title' => $studyCohort->label ?? $definition?->name,
@@ -194,8 +194,8 @@ class StudyDesignController extends Controller
             $this->createAsset($session, $version, [
                 'asset_type' => 'imported_study_analysis',
                 'role' => 'analysis',
-                'status' => StudyDesignAssetStatus::Accepted->value,
-                'verification_status' => StudyDesignVerificationStatus::Verified->value,
+                'status' => StudyDesignAssetStatus::ACCEPTED->value,
+                'verification_status' => StudyDesignVerificationStatus::VERIFIED->value,
                 'verified_at' => now(),
                 'materialized_type' => StudyAnalysis::class,
                 'materialized_id' => $analysis->id,
@@ -228,8 +228,8 @@ class StudyDesignController extends Controller
         $assets = collect($findings)->map(fn (array $finding) => $this->createAsset($session, $version, [
             'asset_type' => 'design_critique',
             'role' => $finding['role'],
-            'status' => StudyDesignAssetStatus::NeedsReview->value,
-            'verification_status' => StudyDesignVerificationStatus::Verified->value,
+            'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+            'verification_status' => StudyDesignVerificationStatus::VERIFIED->value,
             'verified_at' => now(),
             'rank_score' => $finding['severity'] === 'high' ? 0.95 : 0.65,
             'draft_payload_json' => $finding,
@@ -251,8 +251,8 @@ class StudyDesignController extends Controller
         $asset = $this->createAsset($session, $version, [
             'asset_type' => 'phenotype_recommendation',
             'role' => 'population',
-            'status' => StudyDesignAssetStatus::NeedsReview->value,
-            'verification_status' => StudyDesignVerificationStatus::Unverified->value,
+            'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+            'verification_status' => StudyDesignVerificationStatus::UNVERIFIED->value,
             'rank_score' => 0.7,
             'draft_payload_json' => [
                 'title' => $intent['pico']['population'] ?? $study->title,
@@ -300,8 +300,8 @@ class StudyDesignController extends Controller
         $assets = collect($drafts)->map(fn (array $draft) => $this->createAsset($session, $version, [
             'asset_type' => 'concept_set_draft',
             'role' => $draft['role'] ?? $validated['role'] ?? 'population',
-            'status' => StudyDesignAssetStatus::NeedsReview->value,
-            'verification_status' => StudyDesignVerificationStatus::Unverified->value,
+            'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+            'verification_status' => StudyDesignVerificationStatus::UNVERIFIED->value,
             'draft_payload_json' => $draft,
             'provenance_json' => ['source' => 'study_design_concept_set_draft'],
         ]))->values();
@@ -358,9 +358,9 @@ class StudyDesignController extends Controller
 
         $asset->update([
             'status' => match ($validated['decision']) {
-                'accept' => StudyDesignAssetStatus::Accepted->value,
-                'reject' => StudyDesignAssetStatus::Rejected->value,
-                default => StudyDesignAssetStatus::Deferred->value,
+                'accept' => StudyDesignAssetStatus::ACCEPTED->value,
+                'reject' => StudyDesignAssetStatus::REJECTED->value,
+                default => StudyDesignAssetStatus::DEFERRED->value,
             },
             'review_notes' => $validated['review_notes'] ?? null,
             'reviewed_by' => $request->user()->id,
@@ -402,7 +402,7 @@ class StudyDesignController extends Controller
         $asset->update([
             'role' => $validated['role'] ?? $asset->role,
             'draft_payload_json' => $validated,
-            'verification_status' => StudyDesignVerificationStatus::Unverified->value,
+            'verification_status' => StudyDesignVerificationStatus::UNVERIFIED->value,
             'verification_json' => null,
             'verified_at' => null,
         ]);
@@ -437,7 +437,7 @@ class StudyDesignController extends Controller
         }
 
         $asset->update([
-            'status' => StudyDesignAssetStatus::Accepted->value,
+            'status' => StudyDesignAssetStatus::ACCEPTED->value,
             'materialized_type' => ConceptSet::class,
             'materialized_id' => $conceptSet->id,
             'materialized_at' => now(),
@@ -464,8 +464,8 @@ class StudyDesignController extends Controller
         $assets = $conceptAssets->map(fn (StudyDesignAsset $conceptAsset) => $this->createAsset($session, $version, [
             'asset_type' => 'cohort_draft',
             'role' => $validated['role'] ?? $conceptAsset->role ?? 'target',
-            'status' => StudyDesignAssetStatus::NeedsReview->value,
-            'verification_status' => StudyDesignVerificationStatus::Unverified->value,
+            'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+            'verification_status' => StudyDesignVerificationStatus::UNVERIFIED->value,
             'draft_payload_json' => [
                 'title' => ($conceptAsset->draft_payload_json['title'] ?? 'Study Designer').' Cohort',
                 'role' => $validated['role'] ?? $conceptAsset->role ?? 'target',
@@ -481,8 +481,8 @@ class StudyDesignController extends Controller
             $assets->push($this->createAsset($session, $version, [
                 'asset_type' => 'cohort_draft',
                 'role' => $validated['role'] ?? 'target',
-                'status' => StudyDesignAssetStatus::NeedsReview->value,
-                'verification_status' => StudyDesignVerificationStatus::Blocked->value,
+                'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+                'verification_status' => StudyDesignVerificationStatus::BLOCKED->value,
                 'draft_payload_json' => ['title' => "{$study->title} Cohort", 'role' => $validated['role'] ?? 'target'],
                 'verification_json' => ['messages' => ['Materialized concept sets are required before cohort draft verification.']],
                 'provenance_json' => ['source' => 'study_design_cohort_draft'],
@@ -523,7 +523,7 @@ class StudyDesignController extends Controller
         ]);
 
         $asset->update([
-            'status' => StudyDesignAssetStatus::Accepted->value,
+            'status' => StudyDesignAssetStatus::ACCEPTED->value,
             'materialized_type' => CohortDefinition::class,
             'materialized_id' => $cohort->id,
             'materialized_at' => now(),
@@ -577,8 +577,8 @@ class StudyDesignController extends Controller
         $asset = $this->createAsset($session, $version, [
             'asset_type' => 'feasibility_evidence',
             'role' => 'feasibility',
-            'status' => StudyDesignAssetStatus::Accepted->value,
-            'verification_status' => $blocked ? StudyDesignVerificationStatus::Blocked->value : StudyDesignVerificationStatus::Verified->value,
+            'status' => StudyDesignAssetStatus::ACCEPTED->value,
+            'verification_status' => $blocked ? StudyDesignVerificationStatus::BLOCKED->value : StudyDesignVerificationStatus::VERIFIED->value,
             'verified_at' => $blocked ? null : now(),
             'draft_payload_json' => [
                 'source' => 'local_database',
@@ -606,8 +606,8 @@ class StudyDesignController extends Controller
         $asset = $this->createAsset($session, $version, [
             'asset_type' => 'analysis_plan_draft',
             'role' => 'analysis',
-            'status' => StudyDesignAssetStatus::NeedsReview->value,
-            'verification_status' => StudyDesignVerificationStatus::Unverified->value,
+            'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+            'verification_status' => StudyDesignVerificationStatus::UNVERIFIED->value,
             'draft_payload_json' => [
                 'analysis_type' => $validated['analysis_type'] ?? 'characterization',
                 'title' => "{$study->title} Analysis Plan",
@@ -632,7 +632,7 @@ class StudyDesignController extends Controller
         $blocked = ! $readiness['ready'];
 
         $asset->update([
-            'verification_status' => $blocked ? StudyDesignVerificationStatus::Blocked->value : StudyDesignVerificationStatus::Verified->value,
+            'verification_status' => $blocked ? StudyDesignVerificationStatus::BLOCKED->value : StudyDesignVerificationStatus::VERIFIED->value,
             'verified_at' => $blocked ? null : now(),
             'verification_json' => [
                 'checks' => [
@@ -667,7 +667,7 @@ class StudyDesignController extends Controller
         ]);
 
         $asset->update([
-            'status' => StudyDesignAssetStatus::Accepted->value,
+            'status' => StudyDesignAssetStatus::ACCEPTED->value,
             'materialized_type' => StudyAnalysis::class,
             'materialized_id' => $studyAnalysis->id,
             'materialized_at' => now(),
@@ -763,7 +763,7 @@ class StudyDesignController extends Controller
 
     private function guardVerified(StudyDesignAsset $asset): void
     {
-        abort_if($this->verificationValue($asset) !== StudyDesignVerificationStatus::Verified->value, 422, 'Asset must be verified before materialization.');
+        abort_if($this->verificationValue($asset) !== StudyDesignVerificationStatus::VERIFIED->value, 422, 'Asset must be verified before materialization.');
     }
 
     private function isLocked(StudyDesignVersion $version): bool
@@ -782,8 +782,8 @@ class StudyDesignController extends Controller
     {
         return $session->assets()->create(array_merge([
             'version_id' => $version->id,
-            'status' => StudyDesignAssetStatus::NeedsReview->value,
-            'verification_status' => StudyDesignVerificationStatus::Unverified->value,
+            'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+            'verification_status' => StudyDesignVerificationStatus::UNVERIFIED->value,
         ], $attributes));
     }
 

--- a/backend/app/Http/Requests/StudyDesign/DraftStudyAnalysisPlansRequest.php
+++ b/backend/app/Http/Requests/StudyDesign/DraftStudyAnalysisPlansRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\StudyDesign;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DraftStudyAnalysisPlansRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'analysis_types' => 'nullable|array',
+            'analysis_types.*' => 'string|in:characterization,incidence_rate,pathway,estimation,prediction,sccs,self_controlled_cohort,evidence_synthesis',
+        ];
+    }
+}

--- a/backend/app/Http/Requests/StudyDesign/DraftStudyCohortsRequest.php
+++ b/backend/app/Http/Requests/StudyDesign/DraftStudyCohortsRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\StudyDesign;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class DraftStudyCohortsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'role' => ['nullable', 'string', Rule::in(['target', 'comparator', 'outcome', 'exclusion', 'subgroup', 'event', 'population', 'exposure', 'intervention'])],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/StudyDesign/DraftStudyConceptSetsRequest.php
+++ b/backend/app/Http/Requests/StudyDesign/DraftStudyConceptSetsRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\StudyDesign;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class DraftStudyConceptSetsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $roles = ['population', 'exposure', 'intervention', 'comparator', 'outcome', 'exclusion', 'subgroup'];
+
+        return [
+            'asset_ids' => ['nullable', 'array'],
+            'asset_ids.*' => ['integer'],
+            'role' => ['nullable', 'string', Rule::in($roles)],
+            'drafts' => ['nullable', 'array'],
+            'drafts.*.title' => ['required_with:drafts', 'string', 'max:255'],
+            'drafts.*.role' => ['nullable', 'string', Rule::in($roles)],
+            'drafts.*.domain' => ['nullable', 'string', 'max:64'],
+            'drafts.*.clinical_rationale' => ['nullable', 'string', 'max:5000'],
+            'drafts.*.search_terms' => ['nullable', 'array'],
+            'drafts.*.search_terms.*' => ['string', 'max:255'],
+            'drafts.*.concepts' => ['required_with:drafts', 'array', 'min:1'],
+            'drafts.*.concepts.*.concept_id' => ['required', 'integer'],
+            'drafts.*.concepts.*.is_excluded' => ['nullable', 'boolean'],
+            'drafts.*.concepts.*.include_descendants' => ['nullable', 'boolean'],
+            'drafts.*.concepts.*.include_mapped' => ['nullable', 'boolean'],
+            'drafts.*.concepts.*.rationale' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/StudyDesign/GenerateStudyIntentRequest.php
+++ b/backend/app/Http/Requests/StudyDesign/GenerateStudyIntentRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\StudyDesign;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GenerateStudyIntentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'research_question' => ['required', 'string', 'min:10', 'max:5000'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/StudyDesign/LinkStudyCohortRequest.php
+++ b/backend/app/Http/Requests/StudyDesign/LinkStudyCohortRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\StudyDesign;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class LinkStudyCohortRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'role' => ['nullable', 'string', Rule::in(['target', 'comparator', 'outcome', 'exclusion', 'subgroup', 'event', 'population', 'exposure', 'intervention'])],
+            'label' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/StudyDesign/ReviewStudyDesignAssetRequest.php
+++ b/backend/app/Http/Requests/StudyDesign/ReviewStudyDesignAssetRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\StudyDesign;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ReviewStudyDesignAssetRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'decision' => ['required', Rule::in(['accept', 'reject', 'defer'])],
+            'review_notes' => ['nullable', 'string', 'max:5000'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/StudyDesign/RunStudyFeasibilityRequest.php
+++ b/backend/app/Http/Requests/StudyDesign/RunStudyFeasibilityRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\StudyDesign;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RunStudyFeasibilityRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'source_ids' => ['required', 'array', 'min:1'],
+            'source_ids.*' => ['integer', 'distinct', 'exists:sources,id'],
+            'min_cell_count' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/StudyDesign/StoreStudyDesignSessionRequest.php
+++ b/backend/app/Http/Requests/StudyDesign/StoreStudyDesignSessionRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\StudyDesign;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreStudyDesignSessionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => ['nullable', 'string', 'max:255'],
+            'source_mode' => ['nullable', 'string', 'max:80'],
+            'settings_json' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/StudyDesign/UpdateStudyConceptSetDraftRequest.php
+++ b/backend/app/Http/Requests/StudyDesign/UpdateStudyConceptSetDraftRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\StudyDesign;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateStudyConceptSetDraftRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $roles = ['population', 'exposure', 'intervention', 'comparator', 'outcome', 'exclusion', 'subgroup'];
+
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'role' => ['nullable', 'string', Rule::in($roles)],
+            'domain' => ['nullable', 'string', 'max:64'],
+            'clinical_rationale' => ['nullable', 'string', 'max:5000'],
+            'search_terms' => ['nullable', 'array'],
+            'search_terms.*' => ['string', 'max:255'],
+            'source_concept_set_references' => ['nullable', 'array'],
+            'concepts' => ['required', 'array'],
+            'concepts.*.concept_id' => ['required', 'integer'],
+            'concepts.*.is_excluded' => ['nullable', 'boolean'],
+            'concepts.*.include_descendants' => ['nullable', 'boolean'],
+            'concepts.*.include_mapped' => ['nullable', 'boolean'],
+            'concepts.*.rationale' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/StudyDesign/UpdateStudyDesignVersionRequest.php
+++ b/backend/app/Http/Requests/StudyDesign/UpdateStudyDesignVersionRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\StudyDesign;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateStudyDesignVersionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'spec_json' => ['required', 'array'],
+        ];
+    }
+}

--- a/backend/app/Models/App/StudyDesignVersion.php
+++ b/backend/app/Models/App/StudyDesignVersion.php
@@ -46,4 +46,9 @@ class StudyDesignVersion extends Model
     {
         return $this->hasMany(StudyDesignAsset::class, 'version_id');
     }
+
+    public function aiEvents(): HasMany
+    {
+        return $this->hasMany(StudyDesignAiEvent::class, 'version_id');
+    }
 }

--- a/backend/app/Services/StudyDesign/StudyAnalysisPlanMaterializer.php
+++ b/backend/app/Services/StudyDesign/StudyAnalysisPlanMaterializer.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignAssetStatus;
+use App\Enums\StudyDesignVerificationStatus;
+use App\Models\App\Characterization;
+use App\Models\App\EstimationAnalysis;
+use App\Models\App\EvidenceSynthesisAnalysis;
+use App\Models\App\IncidenceRateAnalysis;
+use App\Models\App\PathwayAnalysis;
+use App\Models\App\PredictionAnalysis;
+use App\Models\App\SccsAnalysis;
+use App\Models\App\SelfControlledCohortAnalysis;
+use App\Models\App\StudyAnalysis;
+use App\Models\App\StudyDesignAsset;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class StudyAnalysisPlanMaterializer
+{
+    private const MODEL_BY_TYPE = [
+        'characterization' => Characterization::class,
+        'incidence_rate' => IncidenceRateAnalysis::class,
+        'pathway' => PathwayAnalysis::class,
+        'estimation' => EstimationAnalysis::class,
+        'prediction' => PredictionAnalysis::class,
+        'sccs' => SccsAnalysis::class,
+        'self_controlled_cohort' => SelfControlledCohortAnalysis::class,
+        'evidence_synthesis' => EvidenceSynthesisAnalysis::class,
+    ];
+
+    public function __construct(
+        private readonly StudyAnalysisPlanVerifier $verifier,
+    ) {}
+
+    /**
+     * @return array{analysis: Model, study_analysis: StudyAnalysis}
+     */
+    public function materialize(StudyDesignAsset $asset, int $userId): array
+    {
+        if ($asset->asset_type !== 'analysis_plan') {
+            throw ValidationException::withMessages(['asset' => 'Only analysis plan assets can be materialized.']);
+        }
+
+        if ($asset->materialized_type !== null || $asset->materialized_id !== null) {
+            throw ValidationException::withMessages(['asset' => 'This analysis plan has already been materialized.']);
+        }
+
+        if ($asset->verification_status === StudyDesignVerificationStatus::UNVERIFIED->value) {
+            $asset = $this->verifier->verify($asset);
+        }
+
+        if ($asset->verification_status !== StudyDesignVerificationStatus::VERIFIED->value) {
+            throw ValidationException::withMessages(['verification' => 'Only verified analysis plans can be materialized.']);
+        }
+
+        if ($asset->status !== StudyDesignAssetStatus::ACCEPTED->value) {
+            throw ValidationException::withMessages(['asset' => 'Accept the verified analysis plan before materializing it.']);
+        }
+
+        $payload = $asset->draft_payload_json ?? [];
+        $analysisType = (string) ($payload['analysis_type'] ?? '');
+        $modelClass = self::MODEL_BY_TYPE[$analysisType] ?? null;
+
+        if ($modelClass === null) {
+            throw ValidationException::withMessages(['analysis_type' => 'Analysis plan type is not supported for materialization.']);
+        }
+
+        return DB::transaction(function () use ($asset, $userId, $payload, $modelClass): array {
+            $analysis = $modelClass::create([
+                'name' => (string) ($payload['title'] ?? 'Study Designer analysis plan'),
+                'description' => $payload['description'] ?? null,
+                'design_json' => $payload['design_json'] ?? [],
+                'author_id' => $userId,
+            ]);
+
+            $studyAnalysis = StudyAnalysis::create([
+                'study_id' => $asset->session->study_id,
+                'analysis_type' => $modelClass,
+                'analysis_id' => $analysis->id,
+            ]);
+
+            $asset->update([
+                'status' => StudyDesignAssetStatus::MATERIALIZED->value,
+                'materialized_type' => $modelClass,
+                'materialized_id' => $analysis->id,
+                'materialized_at' => now(),
+            ]);
+
+            return [
+                'analysis' => $analysis->fresh('author:id,name,email') ?? $analysis,
+                'study_analysis' => $studyAnalysis->fresh('analysis') ?? $studyAnalysis,
+            ];
+        });
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyAnalysisPlanService.php
+++ b/backend/app/Services/StudyDesign/StudyAnalysisPlanService.php
@@ -1,0 +1,399 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignAssetStatus;
+use App\Models\App\Study;
+use App\Models\App\StudyCohort;
+use App\Models\App\StudyDesignAsset;
+use App\Models\App\StudyDesignSession;
+use App\Models\App\StudyDesignVersion;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class StudyAnalysisPlanService
+{
+    private const ANALYSIS_PACKAGES = [
+        'characterization' => ['package' => 'Characterization', 'endpoint' => '/characterization/run', 'label' => 'Baseline Characterization'],
+        'incidence_rate' => ['package' => 'CohortIncidence', 'endpoint' => '/cohort-incidence/run', 'label' => 'Incidence Rate'],
+        'pathway' => ['package' => 'TreatmentPatterns', 'endpoint' => '/treatment-patterns/run', 'label' => 'Treatment Pathways'],
+        'estimation' => ['package' => 'CohortMethod', 'endpoint' => '/estimation/run', 'label' => 'Population-Level Estimation'],
+        'prediction' => ['package' => 'PatientLevelPrediction', 'endpoint' => '/prediction/run', 'label' => 'Patient-Level Prediction'],
+        'sccs' => ['package' => 'SelfControlledCaseSeries', 'endpoint' => '/sccs/run', 'label' => 'Self-Controlled Case Series'],
+        'self_controlled_cohort' => ['package' => 'SelfControlledCohort', 'endpoint' => '/self-controlled-cohort/run', 'label' => 'Self-Controlled Cohort'],
+        'evidence_synthesis' => ['package' => 'EvidenceSynthesis', 'endpoint' => '/evidence-synthesis/run', 'label' => 'Evidence Synthesis'],
+    ];
+
+    public function __construct(
+        private readonly StudyAnalysisPlanVerifier $verifier,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return list<StudyDesignAsset>
+     */
+    public function draft(Study $study, StudyDesignSession $session, StudyDesignVersion $version, int $userId, array $options = []): array
+    {
+        $requestedTypes = collect($options['analysis_types'] ?? [])
+            ->filter(fn (mixed $type): bool => is_string($type) && isset(self::ANALYSIS_PACKAGES[$type]))
+            ->values()
+            ->all();
+        $capabilities = $this->hadesCapabilities();
+        $studyCohorts = $study->cohorts()->with('cohortDefinition')->orderBy('sort_order')->get();
+        $roleMap = $this->roleMap($studyCohorts);
+        $feasibility = $this->latestFeasibility($session, $version);
+        $spec = is_array($version->normalized_spec_json ?? null)
+            ? $version->normalized_spec_json
+            : ($version->spec_json ?? []);
+        $studyType = (string) (data_get($spec, 'study.study_type') ?: $study->study_type ?: '');
+
+        $candidateTypes = $requestedTypes !== []
+            ? $requestedTypes
+            : $this->recommendedTypes($studyType, $roleMap, $feasibility);
+
+        return collect($candidateTypes)
+            ->map(function (string $analysisType) use ($study, $session, $version, $userId, $roleMap, $feasibility, $capabilities, $spec): StudyDesignAsset {
+                $payload = $this->payload($analysisType, $study, $roleMap, $feasibility, $capabilities, is_array($spec) ? $spec : []);
+                $asset = StudyDesignAsset::create([
+                    'session_id' => $session->id,
+                    'version_id' => $version->id,
+                    'asset_type' => 'analysis_plan',
+                    'role' => null,
+                    'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+                    'draft_payload_json' => $payload,
+                    'provenance_json' => [
+                        'source' => 'study_designer_analysis_plan',
+                        'study_id' => $study->id,
+                        'version_id' => $version->id,
+                        'created_by' => $userId,
+                        'darkstar_capability_status' => $capabilities['status'] ?? 'unknown',
+                    ],
+                    'rank_score' => $this->rankScore($payload),
+                    'rank_score_json' => [
+                        'analysis_type' => $analysisType,
+                        'package_installed' => $payload['hades_capability']['installed'] ?? false,
+                        'feasibility_status' => $payload['feasibility']['status'] ?? null,
+                    ],
+                ]);
+
+                return $this->verifier->verify($asset);
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $roleMap
+     * @param  array<string, mixed>  $feasibility
+     * @return list<string>
+     */
+    private function recommendedTypes(string $studyType, array $roleMap, array $feasibility): array
+    {
+        $types = ['characterization'];
+        $hasTargetComparatorOutcome = isset($roleMap['target'], $roleMap['comparator'], $roleMap['outcome']);
+        $hasTargetOutcome = isset($roleMap['target'], $roleMap['outcome']);
+
+        if ($hasTargetComparatorOutcome || str_contains($studyType, 'comparative')) {
+            $types[] = 'estimation';
+        }
+
+        if ($hasTargetOutcome && (str_contains($studyType, 'prediction') || str_contains($studyType, 'risk'))) {
+            $types[] = 'prediction';
+        }
+
+        if ($hasTargetOutcome && (str_contains($studyType, 'safety') || str_contains($studyType, 'self') || str_contains($studyType, 'acute'))) {
+            $types[] = 'sccs';
+        }
+
+        if (str_contains($studyType, 'incidence') || str_contains($studyType, 'prevalence')) {
+            $types[] = 'incidence_rate';
+        }
+
+        if (str_contains($studyType, 'pathway') || str_contains($studyType, 'sequence') || isset($roleMap['comparator'])) {
+            $types[] = 'pathway';
+        }
+
+        if (($feasibility['ready_source_count'] ?? 0) > 1) {
+            $types[] = 'evidence_synthesis';
+        }
+
+        return array_values(array_unique($types));
+    }
+
+    /**
+     * @param  array<string, mixed>  $roleMap
+     * @param  array<string, mixed>  $feasibility
+     * @param  array<string, mixed>  $capabilities
+     * @param  array<string, mixed>  $spec
+     * @return array<string, mixed>
+     */
+    private function payload(string $analysisType, Study $study, array $roleMap, array $feasibility, array $capabilities, array $spec): array
+    {
+        $meta = self::ANALYSIS_PACKAGES[$analysisType];
+        $package = $meta['package'];
+        $packageCapability = $this->packageCapability($capabilities, $package);
+        $requiredRoles = $this->requiredRoles($analysisType);
+        $blockers = [];
+        $warnings = [];
+
+        foreach ($requiredRoles as $role) {
+            if (! isset($roleMap[$role])) {
+                $blockers[] = $this->issue('missing_'.$role.'_cohort', "Missing {$role} cohort for {$meta['label']}.", ['role' => $role]);
+            }
+        }
+
+        if (($feasibility['status'] ?? null) === null) {
+            $blockers[] = $this->issue('missing_feasibility', 'Run source feasibility before drafting executable analysis plans.');
+        } elseif (($feasibility['status'] ?? null) === 'blocked') {
+            $blockers[] = $this->issue('blocked_feasibility', 'Resolve source feasibility blockers before materializing analysis plans.');
+        } elseif (($feasibility['status'] ?? null) === 'limited') {
+            $warnings[] = $this->issue('limited_feasibility', 'Feasibility is limited to a subset of selected sources; review before execution.');
+        }
+
+        foreach ((array) ($feasibility['warnings'] ?? []) as $warning) {
+            if (is_array($warning)) {
+                $warnings[] = $this->issue(
+                    (string) ($warning['code'] ?? 'feasibility_warning'),
+                    (string) ($warning['message'] ?? 'Review source feasibility warning before execution.'),
+                    (array) ($warning['meta'] ?? []),
+                );
+            }
+        }
+
+        if (($packageCapability['installed'] ?? false) !== true) {
+            $blockers[] = $this->issue('missing_hades_package', "Darkstar does not report {$package} as installed.", ['package' => $package]);
+        }
+
+        return [
+            'schema_version' => 'study-analysis-plan.v1',
+            'title' => "{$study->title}: {$meta['label']}",
+            'analysis_type' => $analysisType,
+            'description' => $this->description($analysisType, $spec),
+            'hades_package' => $package,
+            'hades_endpoint' => $meta['endpoint'],
+            'hades_capability' => $packageCapability,
+            'required_roles' => $requiredRoles,
+            'cohort_role_map' => $roleMap,
+            'design_json' => $this->designJson($analysisType, $roleMap),
+            'feasibility' => [
+                'status' => $feasibility['status'] ?? null,
+                'ready_source_count' => $feasibility['ready_source_count'] ?? 0,
+                'source_count' => $feasibility['source_count'] ?? 0,
+                'ran_at' => $feasibility['ran_at'] ?? null,
+            ],
+            'blockers' => $blockers,
+            'warnings' => $warnings,
+            'materialization_target' => 'native_'.$analysisType.'_analysis',
+            'policy' => 'Study Designer analysis plans compile into native Parthenon analysis records backed by Darkstar HADES packages.',
+        ];
+    }
+
+    /**
+     * @param  array<int, StudyCohort>|iterable<int, StudyCohort>  $studyCohorts
+     * @return array<string, array<string, mixed>>
+     */
+    private function roleMap(iterable $studyCohorts): array
+    {
+        $roles = [];
+        foreach ($studyCohorts as $cohort) {
+            $role = $this->normalizeRole($cohort->role);
+            $roles[$role] ??= [
+                'study_cohort_id' => $cohort->id,
+                'cohort_definition_id' => $cohort->cohort_definition_id,
+                'cohort_definition_name' => $cohort->cohortDefinition?->name,
+                'label' => $cohort->label,
+            ];
+        }
+
+        return $roles;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function latestFeasibility(StudyDesignSession $session, StudyDesignVersion $version): array
+    {
+        $asset = $session->assets()
+            ->where('version_id', $version->id)
+            ->where('asset_type', 'feasibility_result')
+            ->orderByDesc('created_at')
+            ->first();
+
+        return is_array($asset?->draft_payload_json) ? $asset->draft_payload_json : [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function hadesCapabilities(): array
+    {
+        $url = rtrim(config('services.r_runtime.url', 'http://darkstar:8787'), '/');
+
+        try {
+            $payload = Http::timeout(8)->get("{$url}/hades/packages")->json();
+
+            return is_array($payload) ? $payload : ['status' => 'malformed', 'packages' => []];
+        } catch (\Throwable $e) {
+            Log::warning('Study analysis plan could not retrieve Darkstar HADES capabilities', [
+                'message' => $e->getMessage(),
+            ]);
+
+            return ['status' => 'unavailable', 'packages' => []];
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $capabilities
+     * @return array<string, mixed>
+     */
+    private function packageCapability(array $capabilities, string $package): array
+    {
+        $row = collect($capabilities['packages'] ?? [])
+            ->first(fn (mixed $candidate): bool => is_array($candidate) && ($candidate['package'] ?? null) === $package);
+
+        if (! is_array($row)) {
+            return ['package' => $package, 'installed' => false, 'status' => 'missing_from_inventory'];
+        }
+
+        return [
+            'package' => $package,
+            'installed' => (bool) ($row['installed'] ?? false),
+            'version' => $row['version'] ?? null,
+            'surface' => $row['surface'] ?? null,
+            'priority' => $row['priority'] ?? null,
+            'status' => (bool) ($row['installed'] ?? false) ? 'installed' : 'not_installed',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function requiredRoles(string $analysisType): array
+    {
+        return match ($analysisType) {
+            'estimation' => ['target', 'comparator', 'outcome'],
+            'prediction', 'sccs', 'self_controlled_cohort' => ['target', 'outcome'],
+            'pathway' => ['target', 'comparator'],
+            default => ['target'],
+        };
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $roleMap
+     * @return array<string, mixed>
+     */
+    private function designJson(string $analysisType, array $roleMap): array
+    {
+        $targetId = (int) ($roleMap['target']['cohort_definition_id'] ?? 0);
+        $comparatorId = (int) ($roleMap['comparator']['cohort_definition_id'] ?? 0);
+        $outcomeId = (int) ($roleMap['outcome']['cohort_definition_id'] ?? 0);
+
+        return match ($analysisType) {
+            'estimation' => [
+                'targetCohortId' => $targetId,
+                'comparatorCohortId' => $comparatorId,
+                'outcomeCohortIds' => array_values(array_filter([$outcomeId])),
+                'model' => ['type' => 'cox', 'timeAtRiskStart' => 1, 'timeAtRiskEnd' => 365, 'endAnchor' => 'cohort_start'],
+                'propensityScore' => ['enabled' => true, 'method' => 'matching'],
+                'covariateSettings' => ['useDemographicsGender' => true, 'useDemographicsAge' => true, 'useConditionOccurrenceLongTerm' => true],
+            ],
+            'prediction' => [
+                'targetCohortId' => $targetId,
+                'outcomeCohortId' => $outcomeId,
+                'model' => ['type' => 'lasso_logistic_regression'],
+                'timeAtRisk' => ['start' => 1, 'end' => 365, 'endAnchor' => 'cohort_start'],
+                'populationSettings' => ['washoutPeriod' => 365, 'removeSubjectsWithPriorOutcome' => true, 'firstExposureOnly' => true],
+            ],
+            'incidence_rate' => [
+                'targetCohortIds' => array_values(array_filter([$targetId])),
+                'outcomeCohortIds' => array_values(array_filter([$outcomeId])),
+                'timeAtRisk' => ['start' => 1, 'end' => 365],
+            ],
+            'pathway' => [
+                'targetCohortId' => $targetId,
+                'eventCohortIds' => array_values(array_filter([$comparatorId, $outcomeId])),
+                'periodPriorToIndex' => 0,
+                'minEraDuration' => 0,
+            ],
+            'sccs' => [
+                'targetCohortId' => $targetId,
+                'outcomeCohortId' => $outcomeId,
+                'riskWindows' => [['start' => 1, 'end' => 30, 'label' => 'primary']],
+                'controlInterval' => ['start' => -365, 'end' => -1],
+            ],
+            'self_controlled_cohort' => [
+                'exposureCohortId' => $targetId,
+                'outcomeCohortId' => $outcomeId,
+                'riskWindows' => [['start' => 1, 'end' => 30, 'label' => 'primary']],
+            ],
+            'evidence_synthesis' => [
+                'analysisIds' => [],
+                'method' => 'random_effects',
+                'input' => 'study_level_estimates',
+            ],
+            default => [
+                'targetCohortIds' => array_values(array_filter([$targetId])),
+                'comparatorCohortIds' => array_values(array_filter([$comparatorId])),
+                'featureTypes' => ['demographics', 'conditions', 'drugs', 'measurements'],
+                'stratifyByGender' => true,
+                'stratifyByAge' => true,
+                'topN' => 100,
+                'minCellCount' => 5,
+            ],
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $spec
+     */
+    private function description(string $analysisType, array $spec): string
+    {
+        $objective = trim((string) data_get($spec, 'study.primary_objective', ''));
+        $prefix = $objective !== '' ? "{$objective} " : '';
+
+        return $prefix.match ($analysisType) {
+            'estimation' => 'Estimate the target-comparator effect on linked outcomes using CohortMethod.',
+            'prediction' => 'Train and evaluate outcome risk models using PatientLevelPrediction.',
+            'incidence_rate' => 'Estimate source-specific incidence rates for linked cohorts.',
+            'pathway' => 'Describe treatment sequence patterns with TreatmentPatterns.',
+            'sccs' => 'Evaluate acute self-controlled exposure-outcome association with SCCS.',
+            'self_controlled_cohort' => 'Evaluate self-controlled cohort risk windows.',
+            'evidence_synthesis' => 'Prepare evidence synthesis for multi-source effect estimates.',
+            default => 'Describe baseline covariates and cohort characteristics before inferential analysis.',
+        };
+    }
+
+    private function rankScore(array $payload): float
+    {
+        $score = 50.0;
+        if (($payload['hades_capability']['installed'] ?? false) === true) {
+            $score += 25.0;
+        }
+        if (($payload['feasibility']['status'] ?? null) === 'ready') {
+            $score += 20.0;
+        }
+        if (($payload['blockers'] ?? []) === []) {
+            $score += 5.0;
+        }
+
+        return $score;
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return array<string, mixed>
+     */
+    private function issue(string $code, string $message, array $meta = []): array
+    {
+        return ['code' => $code, 'message' => $message, 'meta' => $meta];
+    }
+
+    private function normalizeRole(string $role): string
+    {
+        return match (trim(strtolower($role))) {
+            'population', 'exposure', 'intervention' => 'target',
+            'comparator', 'outcome', 'exclusion', 'subgroup', 'event' => trim(strtolower($role)),
+            default => 'target',
+        };
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyAnalysisPlanVerifier.php
+++ b/backend/app/Services/StudyDesign/StudyAnalysisPlanVerifier.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignVerificationStatus;
+use App\Models\App\StudyDesignAsset;
+
+class StudyAnalysisPlanVerifier
+{
+    public function verify(StudyDesignAsset $asset): StudyDesignAsset
+    {
+        $result = $this->verificationResult($asset);
+
+        $asset->update([
+            'verification_status' => $result['status'],
+            'verification_json' => $result,
+            'verified_at' => now(),
+        ]);
+
+        return $asset->fresh() ?? $asset;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function verificationResult(StudyDesignAsset $asset): array
+    {
+        $checks = [];
+        $payload = $asset->draft_payload_json ?? [];
+
+        if ($asset->asset_type !== 'analysis_plan') {
+            return $this->result($asset, [
+                $this->check('asset_type', 'fail', 'Blocked: this verifier only handles analysis plan assets.'),
+            ]);
+        }
+
+        if (! is_string($payload['analysis_type'] ?? null) || ($payload['analysis_type'] ?? '') === '') {
+            $checks[] = $this->check('analysis_type', 'fail', 'Blocked: analysis plan requires a native analysis type.');
+        }
+
+        if (! is_array($payload['design_json'] ?? null) || ($payload['design_json'] ?? []) === []) {
+            $checks[] = $this->check('design_json', 'fail', 'Blocked: analysis plan requires a native design JSON payload.');
+        }
+
+        foreach ((array) ($payload['blockers'] ?? []) as $blocker) {
+            $checks[] = $this->check((string) ($blocker['code'] ?? 'plan_blocker'), 'fail', (string) ($blocker['message'] ?? 'Blocked analysis plan prerequisite.'));
+        }
+
+        foreach ((array) ($payload['warnings'] ?? []) as $warning) {
+            $checks[] = $this->check((string) ($warning['code'] ?? 'plan_warning'), 'warn', (string) ($warning['message'] ?? 'Review analysis plan prerequisite.'));
+        }
+
+        if (($payload['hades_capability']['installed'] ?? false) === true) {
+            $checks[] = $this->check('hades_package', 'pass', 'Required Darkstar HADES package is installed.', [
+                'package' => $payload['hades_package'] ?? null,
+                'version' => $payload['hades_capability']['version'] ?? null,
+            ]);
+        } else {
+            $checks[] = $this->check('hades_package', 'fail', 'Blocked: required Darkstar HADES package is not reported as installed.', [
+                'package' => $payload['hades_package'] ?? null,
+            ]);
+        }
+
+        if (($payload['feasibility']['status'] ?? null) === 'ready') {
+            $checks[] = $this->check('feasibility', 'pass', 'Latest feasibility evidence is ready for analysis planning.');
+        } elseif (($payload['feasibility']['status'] ?? null) === 'limited') {
+            $checks[] = $this->check('feasibility', 'warn', 'Latest feasibility evidence is limited; review source-specific blockers before execution.');
+        } else {
+            $checks[] = $this->check('feasibility', 'fail', 'Blocked: run source feasibility and resolve blockers before materializing an analysis plan.');
+        }
+
+        return $this->result($asset, $checks);
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $checks
+     * @return array<string, mixed>
+     */
+    private function result(StudyDesignAsset $asset, array $checks): array
+    {
+        $statuses = collect($checks)->pluck('status');
+        $status = match (true) {
+            $statuses->contains('fail') => StudyDesignVerificationStatus::BLOCKED->value,
+            $statuses->contains('warn') => StudyDesignVerificationStatus::PARTIAL->value,
+            default => StudyDesignVerificationStatus::VERIFIED->value,
+        };
+        $canMaterialize = $status === StudyDesignVerificationStatus::VERIFIED->value;
+
+        return [
+            'status' => $status,
+            'verified_at' => now()->toIso8601String(),
+            'asset_type' => $asset->asset_type,
+            'eligibility' => [
+                'can_accept' => $canMaterialize,
+                'can_materialize' => $canMaterialize,
+                'reason' => $canMaterialize
+                    ? 'Analysis plan can be accepted and materialized into a native HADES-compatible analysis.'
+                    : 'Resolve blocking checks or review warnings before materializing this analysis plan.',
+            ],
+            'checks' => $checks,
+            'blocking_reasons' => collect($checks)->where('status', 'fail')->pluck('message')->values()->all(),
+            'warnings' => collect($checks)->where('status', 'warn')->pluck('message')->values()->all(),
+            'source_summary' => [
+                'source' => $asset->provenance_json['source'] ?? 'study_designer_analysis_plan',
+            ],
+            'canonical_summary' => null,
+            'accepted_downstream_actions' => $canMaterialize ? ['materialize_native_analysis'] : ['defer', 'reject'],
+            'acceptance_policy' => 'Only verified analysis plans may be accepted and materialized.',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return array<string, mixed>
+     */
+    private function check(string $name, string $status, string $message, array $meta = []): array
+    {
+        return $meta === []
+            ? ['name' => $name, 'status' => $status, 'message' => $message]
+            : ['name' => $name, 'status' => $status, 'message' => $message, 'meta' => $meta];
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyCohortDraftService.php
+++ b/backend/app/Services/StudyDesign/StudyCohortDraftService.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignAssetStatus;
+use App\Models\App\ConceptSet;
+use App\Models\App\ConceptSetItem;
+use App\Models\App\StudyDesignAsset;
+use App\Models\App\StudyDesignSession;
+use App\Models\App\StudyDesignVersion;
+use App\Models\Vocabulary\Concept;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class StudyCohortDraftService
+{
+    public function __construct(
+        private readonly StudyCohortDraftVerifier $verifier,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return Collection<int, StudyDesignAsset>
+     */
+    public function draft(StudyDesignSession $session, StudyDesignVersion $version, array $options = []): Collection
+    {
+        $fallbackRole = isset($options['role']) && is_string($options['role'])
+            ? $this->normalizeRole($options['role'])
+            : null;
+
+        $conceptSetDrafts = $session->assets()
+            ->where('version_id', $version->id)
+            ->where('asset_type', 'concept_set_draft')
+            ->where('status', StudyDesignAssetStatus::MATERIALIZED->value)
+            ->where('materialized_type', ConceptSet::class)
+            ->get();
+
+        $candidates = $conceptSetDrafts
+            ->map(fn (StudyDesignAsset $asset) => $this->candidateFromConceptSetDraft($asset, $fallbackRole))
+            ->filter()
+            ->values();
+
+        return DB::transaction(function () use ($session, $version, $candidates): Collection {
+            $session->assets()
+                ->where('version_id', $version->id)
+                ->where('asset_type', 'cohort_draft')
+                ->where('status', StudyDesignAssetStatus::NEEDS_REVIEW->value)
+                ->delete();
+
+            return $candidates
+                ->map(function (array $candidate) use ($session, $version): StudyDesignAsset {
+                    $asset = StudyDesignAsset::create([
+                        'session_id' => $session->id,
+                        'version_id' => $version->id,
+                        'asset_type' => 'cohort_draft',
+                        'role' => $candidate['role'],
+                        'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+                        'draft_payload_json' => $candidate,
+                        'provenance_json' => [
+                            'source' => 'study_designer_concept_sets',
+                            'source_asset_ids' => $candidate['source_asset_ids'] ?? [],
+                        ],
+                    ]);
+
+                    return $this->verifier->verify($asset);
+                })
+                ->values();
+        });
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function candidateFromConceptSetDraft(StudyDesignAsset $asset, ?string $fallbackRole): ?array
+    {
+        if ($asset->materialized_id === null) {
+            return null;
+        }
+
+        $conceptSet = ConceptSet::with('items')->find($asset->materialized_id);
+        if (! $conceptSet instanceof ConceptSet || $conceptSet->items->isEmpty()) {
+            return null;
+        }
+
+        $role = $this->normalizeRole((string) ($asset->role ?? $fallbackRole ?? 'target'));
+        $codesetId = 0;
+        $conceptSetExpression = $this->conceptSetExpression($conceptSet, $codesetId);
+        $domainKey = $this->domainKey($role, $conceptSet);
+
+        return [
+            'title' => $this->titleForRole($role, $conceptSet->name),
+            'role' => $role,
+            'logic_description' => 'Entry event cohort generated from a verified Study Designer concept set draft.',
+            'concept_set_ids' => [$conceptSet->id],
+            'source_asset_ids' => [$asset->id],
+            'expression_json' => [
+                'ConceptSets' => [$conceptSetExpression],
+                'PrimaryCriteria' => [
+                    'CriteriaList' => [[
+                        $domainKey => [
+                            'First' => true,
+                            'CodesetId' => $codesetId,
+                        ],
+                    ]],
+                    'ObservationWindow' => [
+                        'PriorDays' => 365,
+                        'PostDays' => 0,
+                    ],
+                    'PrimaryCriteriaLimit' => [
+                        'Type' => 'First',
+                    ],
+                ],
+                'QualifiedLimit' => ['Type' => 'First'],
+                'ExpressionLimit' => ['Type' => 'First'],
+                'InclusionRules' => [],
+                'CensoringCriteria' => [],
+                'CollapseSettings' => ['CollapseType' => 'ERA', 'EraPad' => 0],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function conceptSetExpression(ConceptSet $conceptSet, int $codesetId): array
+    {
+        $conceptIds = $conceptSet->items->pluck('concept_id')->unique()->values()->all();
+        $vocabularyConcepts = Concept::query()
+            ->whereIn('concept_id', $conceptIds)
+            ->get(['concept_id', 'concept_name', 'domain_id', 'vocabulary_id', 'concept_class_id', 'standard_concept', 'concept_code', 'invalid_reason'])
+            ->keyBy('concept_id');
+
+        return [
+            'id' => $codesetId,
+            'name' => $conceptSet->name,
+            'expression' => [
+                'items' => $conceptSet->items
+                    ->map(function (ConceptSetItem $item) use ($vocabularyConcepts): array {
+                        $concept = $vocabularyConcepts->get($item->concept_id);
+
+                        return [
+                            'concept' => [
+                                'CONCEPT_ID' => $item->concept_id,
+                                'CONCEPT_NAME' => $concept?->concept_name ?? '',
+                                'DOMAIN_ID' => $concept?->domain_id ?? '',
+                                'VOCABULARY_ID' => $concept?->vocabulary_id ?? '',
+                                'CONCEPT_CLASS_ID' => $concept?->concept_class_id ?? '',
+                                'STANDARD_CONCEPT' => $concept?->standard_concept,
+                                'CONCEPT_CODE' => $concept?->concept_code ?? '',
+                                'INVALID_REASON' => $concept?->invalid_reason,
+                            ],
+                            'isExcluded' => $item->is_excluded,
+                            'includeDescendants' => $item->include_descendants,
+                            'includeMapped' => $item->include_mapped,
+                        ];
+                    })
+                    ->values()
+                    ->all(),
+            ],
+        ];
+    }
+
+    private function domainKey(string $role, ConceptSet $conceptSet): string
+    {
+        if ($role === 'comparator') {
+            return 'DrugExposure';
+        }
+
+        $firstConceptId = $conceptSet->items->first()?->concept_id;
+        $domain = $firstConceptId ? Concept::query()->where('concept_id', $firstConceptId)->value('domain_id') : null;
+
+        return $domain === 'Drug' ? 'DrugExposure' : 'ConditionOccurrence';
+    }
+
+    private function titleForRole(string $role, string $conceptSetName): string
+    {
+        return str($role)->headline().': '.$conceptSetName;
+    }
+
+    private function normalizeRole(string $role): string
+    {
+        return match (trim(strtolower($role))) {
+            'population', 'exposure', 'intervention' => 'target',
+            'comparator', 'outcome', 'exclusion', 'subgroup', 'event' => trim(strtolower($role)),
+            default => 'target',
+        };
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyCohortDraftVerifier.php
+++ b/backend/app/Services/StudyDesign/StudyCohortDraftVerifier.php
@@ -22,8 +22,8 @@ class StudyCohortDraftVerifier
 
         return [
             'verification_status' => $ready
-                ? StudyDesignVerificationStatus::Verified->value
-                : StudyDesignVerificationStatus::Blocked->value,
+                ? StudyDesignVerificationStatus::VERIFIED->value
+                : StudyDesignVerificationStatus::BLOCKED->value,
             'verified_at' => $ready ? now() : null,
             'verification_json' => [
                 'checks' => [
@@ -90,7 +90,7 @@ class StudyCohortDraftVerifier
 
         $verifiedAssets = $relatedAssets->filter(fn (StudyDesignAsset $related) => $related->materialized_type === ConceptSet::class
             && $related->materialized_id !== null
-            && $this->verificationValue($related) === StudyDesignVerificationStatus::Verified->value);
+            && $this->verificationValue($related) === StudyDesignVerificationStatus::VERIFIED->value);
 
         $existingConceptSetIds = ConceptSet::query()
             ->whereIn('id', $conceptSetIds)
@@ -101,7 +101,7 @@ class StudyCohortDraftVerifier
         return [
             'ready' => $verifiedAssets->isNotEmpty(),
             'verified_asset_count' => $verifiedAssets->count(),
-            'blocked_asset_count' => $relatedAssets->filter(fn (StudyDesignAsset $related) => $this->verificationValue($related) === StudyDesignVerificationStatus::Blocked->value)->count(),
+            'blocked_asset_count' => $relatedAssets->filter(fn (StudyDesignAsset $related) => $this->verificationValue($related) === StudyDesignVerificationStatus::BLOCKED->value)->count(),
             'existing_concept_set_count' => count($existingConceptSetIds),
             'missing_concept_set_ids' => array_values(array_diff($conceptSetIds->all(), $existingConceptSetIds)),
         ];

--- a/backend/app/Services/StudyDesign/StudyCohortMaterializer.php
+++ b/backend/app/Services/StudyDesign/StudyCohortMaterializer.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignAssetStatus;
+use App\Enums\StudyDesignVerificationStatus;
+use App\Models\App\CohortDefinition;
+use App\Models\App\StudyDesignAsset;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class StudyCohortMaterializer
+{
+    public function __construct(
+        private readonly StudyCohortDraftVerifier $verifier,
+    ) {}
+
+    public function materialize(StudyDesignAsset $asset, int $userId): CohortDefinition
+    {
+        if ($asset->asset_type !== 'cohort_draft') {
+            throw ValidationException::withMessages([
+                'asset' => 'Only cohort draft assets can be materialized as cohort definitions.',
+            ]);
+        }
+
+        if ($asset->materialized_type !== null || $asset->materialized_id !== null) {
+            throw ValidationException::withMessages([
+                'asset' => 'This cohort draft has already been materialized.',
+            ]);
+        }
+
+        if ($asset->verification_status === StudyDesignVerificationStatus::UNVERIFIED->value) {
+            $asset = $this->verifier->verify($asset);
+        }
+
+        if ($asset->verification_status !== StudyDesignVerificationStatus::VERIFIED->value) {
+            throw ValidationException::withMessages([
+                'verification' => 'Only verified cohort drafts can be materialized.',
+            ]);
+        }
+
+        if ($asset->status !== StudyDesignAssetStatus::ACCEPTED->value) {
+            throw ValidationException::withMessages([
+                'asset' => 'Accept the verified cohort draft before materializing it.',
+            ]);
+        }
+
+        return DB::transaction(function () use ($asset, $userId): CohortDefinition {
+            $payload = $asset->draft_payload_json ?? [];
+
+            $cohort = CohortDefinition::create([
+                'name' => (string) ($payload['title'] ?? 'Study Designer cohort draft'),
+                'description' => $payload['logic_description'] ?? null,
+                'expression_json' => $payload['expression_json'] ?? [],
+                'author_id' => $userId,
+                'is_public' => false,
+                'tags' => ['study-designer'],
+            ]);
+
+            $asset->update([
+                'status' => StudyDesignAssetStatus::MATERIALIZED->value,
+                'materialized_type' => CohortDefinition::class,
+                'materialized_id' => $cohort->id,
+                'materialized_at' => now(),
+            ]);
+
+            return $cohort->fresh('author:id,name,email') ?? $cohort;
+        });
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyCohortReadinessService.php
+++ b/backend/app/Services/StudyDesign/StudyCohortReadinessService.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignAssetStatus;
+use App\Enums\StudyDesignVerificationStatus;
+use App\Models\App\Study;
+use App\Models\App\StudyCohort;
+use App\Models\App\StudyDesignAsset;
+use App\Models\App\StudyDesignSession;
+use App\Models\App\StudyDesignVersion;
+use Illuminate\Support\Collection;
+
+class StudyCohortReadinessService
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function summarize(Study $study, StudyDesignSession $session, StudyDesignVersion $version): array
+    {
+        $spec = $version->normalized_spec_json ?? $version->spec_json ?? [];
+        $requiredRoles = $this->requiredRoles($study, is_array($spec) ? $spec : []);
+
+        $studyCohorts = $study->cohorts()
+            ->with('cohortDefinition')
+            ->orderBy('sort_order')
+            ->get()
+            ->map(function (StudyCohort $cohort): StudyCohort {
+                $cohort->role = $this->normalizeRole($cohort->role);
+
+                return $cohort;
+            });
+
+        $cohortDrafts = $session->assets()
+            ->where('version_id', $version->id)
+            ->where('asset_type', 'cohort_draft')
+            ->orderByDesc('created_at')
+            ->get();
+
+        $blockers = [];
+        $warnings = [];
+        $presentRoles = $studyCohorts
+            ->groupBy('role')
+            ->map(fn (Collection $cohorts): int => $cohorts->count())
+            ->all();
+
+        foreach ($requiredRoles as $role) {
+            if (($presentRoles[$role] ?? 0) === 0) {
+                $blockers[] = $this->issue(
+                    'missing_'.$role.'_cohort',
+                    "Add a {$role} cohort before running feasibility or analysis.",
+                    ['role' => $role],
+                );
+            }
+        }
+
+        foreach (['target', 'comparator'] as $singleRole) {
+            if (($presentRoles[$singleRole] ?? 0) > 1) {
+                $warnings[] = $this->issue(
+                    'multiple_'.$singleRole.'_cohorts',
+                    "Multiple {$singleRole} cohorts are linked. Confirm which one should drive the primary estimand.",
+                    ['role' => $singleRole, 'count' => $presentRoles[$singleRole]],
+                );
+            }
+        }
+
+        $deprecatedIds = $studyCohorts
+            ->filter(fn (StudyCohort $cohort): bool => $cohort->cohortDefinition?->isDeprecated() === true)
+            ->pluck('cohort_definition_id')
+            ->values()
+            ->all();
+        if ($deprecatedIds !== []) {
+            $blockers[] = $this->issue(
+                'deprecated_cohort_definitions',
+                'Replace deprecated cohort definitions before running feasibility or analysis.',
+                ['cohort_definition_ids' => $deprecatedIds],
+            );
+        }
+
+        foreach ($studyCohorts as $cohort) {
+            if (! is_array($cohort->concept_set_ids) || $cohort->concept_set_ids === []) {
+                $warnings[] = $this->issue(
+                    'missing_concept_set_traceability',
+                    'A linked cohort is missing concept set traceability.',
+                    ['study_cohort_id' => $cohort->id, 'role' => $cohort->role],
+                );
+            }
+        }
+
+        $this->addRoleConflictIssues($studyCohorts, $blockers, $warnings);
+        $this->addDraftIssues($cohortDrafts, $warnings);
+
+        return [
+            'status' => $blockers === [] ? 'ready' : 'blocked',
+            'ready_for_feasibility' => $blockers === [],
+            'required_roles' => $requiredRoles,
+            'present_roles' => $presentRoles,
+            'linked_cohorts' => $studyCohorts
+                ->map(fn (StudyCohort $cohort): array => [
+                    'id' => $cohort->id,
+                    'role' => $cohort->role,
+                    'label' => $cohort->label,
+                    'cohort_definition_id' => $cohort->cohort_definition_id,
+                    'cohort_definition_name' => $cohort->cohortDefinition?->name,
+                    'concept_set_ids' => $cohort->concept_set_ids ?? [],
+                ])
+                ->values()
+                ->all(),
+            'drafts' => [
+                'total' => $cohortDrafts->count(),
+                'verified' => $cohortDrafts->where('verification_status', StudyDesignVerificationStatus::VERIFIED->value)->count(),
+                'materialized' => $cohortDrafts->where('status', StudyDesignAssetStatus::MATERIALIZED->value)->count(),
+                'linked' => $cohortDrafts
+                    ->filter(fn (StudyDesignAsset $asset): bool => is_numeric(data_get($asset->provenance_json, 'study_cohort_id')))
+                    ->count(),
+                'unlinked_materialized' => $cohortDrafts
+                    ->filter(fn (StudyDesignAsset $asset): bool => $asset->status === StudyDesignAssetStatus::MATERIALIZED->value
+                        && ! is_numeric(data_get($asset->provenance_json, 'study_cohort_id')))
+                    ->count(),
+            ],
+            'blockers' => $blockers,
+            'warnings' => $warnings,
+            'policy' => 'A study is ready for feasibility when required OHDSI cohort roles are linked to native, non-deprecated cohort definitions.',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $spec
+     * @return list<string>
+     */
+    private function requiredRoles(Study $study, array $spec): array
+    {
+        $studyType = (string) (data_get($spec, 'study.study_type') ?: $study->study_type);
+        $roles = ['target'];
+        $comparatorSummary = trim((string) data_get($spec, 'pico.comparator.summary', ''));
+        $outcomes = (array) data_get($spec, 'pico.outcomes', []);
+
+        if ($comparatorSummary !== '' || in_array($studyType, ['comparative_effectiveness', 'comparative_safety'], true)) {
+            $roles[] = 'comparator';
+        }
+
+        if ($outcomes !== [] || in_array($studyType, ['comparative_effectiveness', 'comparative_safety', 'population_level_estimation'], true)) {
+            $roles[] = 'outcome';
+        }
+
+        return array_values(array_unique($roles));
+    }
+
+    /**
+     * @param  Collection<int, StudyCohort>  $studyCohorts
+     * @param  list<array<string, mixed>>  $blockers
+     * @param  list<array<string, mixed>>  $warnings
+     */
+    private function addRoleConflictIssues(Collection $studyCohorts, array &$blockers, array &$warnings): void
+    {
+        $byRole = $studyCohorts->groupBy('role');
+        $targetCohortIds = $byRole->get('target', collect())->pluck('cohort_definition_id')->all();
+        $comparatorCohortIds = $byRole->get('comparator', collect())->pluck('cohort_definition_id')->all();
+        $outcomeCohortIds = $byRole->get('outcome', collect())->pluck('cohort_definition_id')->all();
+
+        $sameTargetComparator = array_values(array_intersect($targetCohortIds, $comparatorCohortIds));
+        if ($sameTargetComparator !== []) {
+            $blockers[] = $this->issue(
+                'target_comparator_same_cohort',
+                'Target and comparator roles cannot use the same cohort definition.',
+                ['cohort_definition_ids' => $sameTargetComparator],
+            );
+        }
+
+        $sameTargetOutcome = array_values(array_intersect($targetCohortIds, $outcomeCohortIds));
+        if ($sameTargetOutcome !== []) {
+            $warnings[] = $this->issue(
+                'target_outcome_same_cohort',
+                'Target and outcome roles use the same cohort definition. Confirm recurrence and index-date semantics.',
+                ['cohort_definition_ids' => $sameTargetOutcome],
+            );
+        }
+
+        $targetConceptSetIds = $this->conceptSetIdsForRole($byRole, 'target');
+        $comparatorConceptSetIds = $this->conceptSetIdsForRole($byRole, 'comparator');
+        $outcomeConceptSetIds = $this->conceptSetIdsForRole($byRole, 'outcome');
+
+        $targetComparatorOverlap = array_values(array_intersect($targetConceptSetIds, $comparatorConceptSetIds));
+        if ($targetComparatorOverlap !== []) {
+            $warnings[] = $this->issue(
+                'target_comparator_concept_overlap',
+                'Target and comparator cohorts share concept sets. Confirm this is intentional before estimation.',
+                ['concept_set_ids' => $targetComparatorOverlap],
+            );
+        }
+
+        $targetOutcomeOverlap = array_values(array_intersect($targetConceptSetIds, $outcomeConceptSetIds));
+        if ($targetOutcomeOverlap !== []) {
+            $warnings[] = $this->issue(
+                'target_outcome_concept_overlap',
+                'Target and outcome cohorts share concept sets. Confirm this is intentional and avoids immortal-time or recurrence ambiguity.',
+                ['concept_set_ids' => $targetOutcomeOverlap],
+            );
+        }
+    }
+
+    /**
+     * @param  Collection<int, StudyDesignAsset>  $cohortDrafts
+     * @param  list<array<string, mixed>>  $warnings
+     */
+    private function addDraftIssues(Collection $cohortDrafts, array &$warnings): void
+    {
+        $unlinkedMaterialized = $cohortDrafts
+            ->filter(fn (StudyDesignAsset $asset): bool => $asset->status === StudyDesignAssetStatus::MATERIALIZED->value
+                && ! is_numeric(data_get($asset->provenance_json, 'study_cohort_id')))
+            ->pluck('id')
+            ->values()
+            ->all();
+
+        if ($unlinkedMaterialized !== []) {
+            $warnings[] = $this->issue(
+                'unlinked_materialized_drafts',
+                'Materialized cohort drafts are not yet linked to study roles.',
+                ['asset_ids' => $unlinkedMaterialized],
+            );
+        }
+
+        $blockedDrafts = $cohortDrafts
+            ->where('verification_status', StudyDesignVerificationStatus::BLOCKED->value)
+            ->pluck('id')
+            ->values()
+            ->all();
+        if ($blockedDrafts !== []) {
+            $warnings[] = $this->issue(
+                'blocked_cohort_drafts',
+                'Blocked cohort drafts remain in this version and should be corrected or rejected.',
+                ['asset_ids' => $blockedDrafts],
+            );
+        }
+    }
+
+    /**
+     * @param  Collection<string, Collection<int, StudyCohort>>  $byRole
+     * @return list<int>
+     */
+    private function conceptSetIdsForRole(Collection $byRole, string $role): array
+    {
+        return $byRole
+            ->get($role, collect())
+            ->flatMap(fn (StudyCohort $cohort): array => is_array($cohort->concept_set_ids) ? $cohort->concept_set_ids : [])
+            ->filter(fn (mixed $id): bool => is_numeric($id))
+            ->map(fn (mixed $id): int => (int) $id)
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return array<string, mixed>
+     */
+    private function issue(string $code, string $message, array $meta = []): array
+    {
+        return [
+            'code' => $code,
+            'message' => $message,
+            'meta' => $meta,
+        ];
+    }
+
+    private function normalizeRole(string $role): string
+    {
+        return match (trim(strtolower($role))) {
+            'population', 'exposure', 'intervention' => 'target',
+            'comparator', 'outcome', 'exclusion', 'subgroup', 'event' => trim(strtolower($role)),
+            default => 'target',
+        };
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyCohortRoleLinker.php
+++ b/backend/app/Services/StudyDesign/StudyCohortRoleLinker.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignAssetStatus;
+use App\Models\App\CohortDefinition;
+use App\Models\App\Study;
+use App\Models\App\StudyCohort;
+use App\Models\App\StudyDesignAsset;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class StudyCohortRoleLinker
+{
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function link(Study $study, StudyDesignAsset $asset, array $options = []): StudyCohort
+    {
+        if ($asset->asset_type !== 'cohort_draft') {
+            throw ValidationException::withMessages([
+                'asset' => 'Only cohort draft assets can be linked to a study cohort role.',
+            ]);
+        }
+
+        if ($asset->status !== StudyDesignAssetStatus::MATERIALIZED->value || $asset->materialized_type !== CohortDefinition::class || $asset->materialized_id === null) {
+            throw ValidationException::withMessages([
+                'asset' => 'Materialize this cohort draft before linking it to the study.',
+            ]);
+        }
+
+        $cohortDefinition = CohortDefinition::find($asset->materialized_id);
+        if (! $cohortDefinition instanceof CohortDefinition) {
+            throw ValidationException::withMessages([
+                'asset' => 'The materialized cohort definition could not be found.',
+            ]);
+        }
+
+        if ($cohortDefinition->isDeprecated()) {
+            throw ValidationException::withMessages([
+                'cohort_definition' => 'Deprecated cohort definitions cannot be linked to a study.',
+            ]);
+        }
+
+        $payload = $asset->draft_payload_json ?? [];
+        $role = $this->normalizeRole((string) ($options['role'] ?? $payload['role'] ?? $asset->role ?? 'target'));
+
+        return DB::transaction(function () use ($study, $asset, $cohortDefinition, $payload, $role, $options): StudyCohort {
+            $studyCohort = StudyCohort::updateOrCreate(
+                [
+                    'study_id' => $study->id,
+                    'cohort_definition_id' => $cohortDefinition->id,
+                    'role' => $role,
+                ],
+                [
+                    'label' => (string) ($options['label'] ?? $payload['title'] ?? $cohortDefinition->name),
+                    'description' => $options['description'] ?? $payload['logic_description'] ?? $cohortDefinition->description,
+                    'json_definition' => $payload['expression_json'] ?? $cohortDefinition->expression_json,
+                    'concept_set_ids' => $payload['concept_set_ids'] ?? null,
+                    'sort_order' => StudyCohort::query()
+                        ->where('study_id', $study->id)
+                        ->where('role', $role)
+                        ->count(),
+                ],
+            );
+
+            $provenance = is_array($asset->provenance_json) ? $asset->provenance_json : [];
+            $asset->update([
+                'provenance_json' => [
+                    ...$provenance,
+                    'study_cohort_id' => $studyCohort->id,
+                    'study_cohort_role' => $role,
+                    'linked_at' => now()->toIso8601String(),
+                ],
+            ]);
+
+            return $studyCohort->fresh('cohortDefinition') ?? $studyCohort;
+        });
+    }
+
+    private function normalizeRole(string $role): string
+    {
+        return match (trim(strtolower($role))) {
+            'population' => 'target',
+            'exposure', 'intervention' => 'target',
+            default => trim(strtolower($role)),
+        };
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyConceptSetDraftService.php
+++ b/backend/app/Services/StudyDesign/StudyConceptSetDraftService.php
@@ -1,0 +1,353 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignAssetStatus;
+use App\Models\App\CohortDefinition;
+use App\Models\App\ConceptSet;
+use App\Models\App\ConceptSetItem;
+use App\Models\App\PhenotypeLibraryEntry;
+use App\Models\App\StudyDesignAsset;
+use App\Models\App\StudyDesignSession;
+use App\Models\App\StudyDesignVersion;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class StudyConceptSetDraftService
+{
+    public function __construct(
+        private readonly StudyConceptSetDraftVerifier $verifier,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return Collection<int, StudyDesignAsset>
+     */
+    public function draft(StudyDesignSession $session, StudyDesignVersion $version, array $options = []): Collection
+    {
+        $role = isset($options['role']) ? (string) $options['role'] : null;
+        $assetIds = collect($options['asset_ids'] ?? [])
+            ->filter(fn (mixed $id) => is_numeric($id))
+            ->map(fn (mixed $id) => (int) $id)
+            ->values()
+            ->all();
+
+        $manualDrafts = collect($options['drafts'] ?? [])
+            ->filter(fn (mixed $draft) => is_array($draft))
+            ->map(fn (array $draft) => $this->manualCandidate($draft, $role))
+            ->filter()
+            ->values();
+
+        $acceptedAssets = $session->assets()
+            ->where('version_id', $version->id)
+            ->where('status', StudyDesignAssetStatus::ACCEPTED->value)
+            ->whereIn('asset_type', ['phenotype_recommendation', 'local_cohort', 'local_concept_set'])
+            ->when($assetIds !== [], fn ($query) => $query->whereIn('id', $assetIds))
+            ->get();
+
+        $candidates = $acceptedAssets
+            ->flatMap(fn (StudyDesignAsset $asset) => $this->candidatesFromAsset($asset, $role))
+            ->merge($manualDrafts)
+            ->unique(fn (array $candidate) => ($candidate['role'] ?? '').':'.($candidate['title'] ?? '').':'.json_encode(collect($candidate['concepts'] ?? [])->pluck('concept_id')->all()))
+            ->values();
+
+        return DB::transaction(function () use ($session, $version, $candidates): Collection {
+            $session->assets()
+                ->where('version_id', $version->id)
+                ->where('asset_type', 'concept_set_draft')
+                ->where('status', StudyDesignAssetStatus::NEEDS_REVIEW->value)
+                ->delete();
+
+            return $candidates
+                ->map(function (array $candidate) use ($session, $version): StudyDesignAsset {
+                    $asset = StudyDesignAsset::create([
+                        'session_id' => $session->id,
+                        'version_id' => $version->id,
+                        'asset_type' => 'concept_set_draft',
+                        'role' => $candidate['role'] ?? null,
+                        'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+                        'draft_payload_json' => [
+                            'title' => $candidate['title'],
+                            'role' => $candidate['role'] ?? null,
+                            'domain' => $candidate['domain'] ?? null,
+                            'clinical_rationale' => $candidate['clinical_rationale'] ?? null,
+                            'search_terms' => $candidate['search_terms'] ?? [],
+                            'concepts' => $candidate['concepts'],
+                            'source_concept_set_references' => $candidate['source_concept_set_references'] ?? [],
+                        ],
+                        'provenance_json' => $candidate['provenance'] ?? ['source' => 'study_designer'],
+                    ]);
+
+                    return $this->verifier->verify($asset);
+                })
+                ->values();
+        });
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function candidatesFromAsset(StudyDesignAsset $asset, ?string $role): array
+    {
+        return match ($asset->asset_type) {
+            'local_concept_set' => $this->localConceptSetCandidate($asset, $role),
+            'local_cohort' => $this->cohortExpressionCandidates($asset, $role),
+            'phenotype_recommendation' => $this->phenotypeCandidates($asset, $role),
+            default => [],
+        };
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function localConceptSetCandidate(StudyDesignAsset $asset, ?string $role): array
+    {
+        if ($asset->canonical_type !== ConceptSet::class || $asset->canonical_id === null) {
+            return [];
+        }
+
+        $conceptSet = ConceptSet::with('items')->find($asset->canonical_id);
+        if (! $conceptSet instanceof ConceptSet) {
+            return [];
+        }
+
+        $items = $conceptSet->items
+            ->map(fn (ConceptSetItem $item) => $this->conceptItem($item->concept_id, $item->is_excluded, $item->include_descendants, $item->include_mapped))
+            ->values()
+            ->all();
+
+        if ($items === []) {
+            return [];
+        }
+
+        return [[
+            'title' => $conceptSet->name,
+            'role' => $role ?? $asset->role,
+            'clinical_rationale' => $asset->draft_payload_json['rationale'] ?? $conceptSet->description,
+            'search_terms' => array_values(array_filter([(string) ($asset->provenance_json['matched_term'] ?? '')])),
+            'concepts' => $items,
+            'source_concept_set_references' => [['type' => ConceptSet::class, 'id' => $conceptSet->id, 'name' => $conceptSet->name]],
+            'provenance' => [
+                'source' => 'local_concept_set',
+                'source_asset_id' => $asset->id,
+                'canonical_type' => ConceptSet::class,
+                'canonical_id' => $conceptSet->id,
+            ],
+        ]];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function cohortExpressionCandidates(StudyDesignAsset $asset, ?string $role): array
+    {
+        if ($asset->canonical_type !== CohortDefinition::class || $asset->canonical_id === null) {
+            return [];
+        }
+
+        $cohort = CohortDefinition::find($asset->canonical_id);
+        if (! $cohort instanceof CohortDefinition) {
+            return [];
+        }
+
+        return $this->conceptSetCandidatesFromExpression(
+            $cohort->expression_json ?? [],
+            $role ?? $asset->role,
+            'local_cohort_expression',
+            $asset,
+            $cohort->name,
+        );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function phenotypeCandidates(StudyDesignAsset $asset, ?string $role): array
+    {
+        $payload = $asset->draft_payload_json ?? [];
+        $conceptIds = $this->extractConceptIds($payload);
+
+        if ($conceptIds !== []) {
+            return [[
+                'title' => (string) ($payload['title'] ?? 'Study Designer concept set draft'),
+                'role' => $role ?? $asset->role,
+                'domain' => $payload['domain'] ?? null,
+                'clinical_rationale' => $payload['rationale'] ?? $payload['logic_description'] ?? null,
+                'search_terms' => array_values(array_filter([(string) ($asset->provenance_json['matched_term'] ?? '')])),
+                'concepts' => collect($conceptIds)->map(fn (int $id) => $this->conceptItem($id))->all(),
+                'source_concept_set_references' => [],
+                'provenance' => [
+                    'source' => 'phenotype_recommendation_payload',
+                    'source_asset_id' => $asset->id,
+                    'canonical_type' => $asset->canonical_type,
+                    'canonical_id' => $asset->canonical_id,
+                ],
+            ]];
+        }
+
+        if ($asset->canonical_type !== PhenotypeLibraryEntry::class || $asset->canonical_id === null) {
+            return [];
+        }
+
+        $entry = PhenotypeLibraryEntry::find($asset->canonical_id);
+        if (! $entry instanceof PhenotypeLibraryEntry) {
+            return [];
+        }
+
+        return $this->conceptSetCandidatesFromExpression(
+            $entry->expression_json ?? [],
+            $role ?? $asset->role,
+            'phenotype_library_expression',
+            $asset,
+            $entry->cohort_name,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $expression
+     * @return list<array<string, mixed>>
+     */
+    private function conceptSetCandidatesFromExpression(array $expression, ?string $role, string $source, StudyDesignAsset $asset, string $fallbackTitle): array
+    {
+        return collect($expression['ConceptSets'] ?? [])
+            ->filter(fn (mixed $conceptSet) => is_array($conceptSet))
+            ->map(function (array $conceptSet) use ($role, $source, $asset, $fallbackTitle): ?array {
+                $items = collect(data_get($conceptSet, 'expression.items', []))
+                    ->filter(fn (mixed $item) => is_array($item))
+                    ->map(fn (array $item) => $this->conceptItemFromExpression($item))
+                    ->filter()
+                    ->values()
+                    ->all();
+
+                if ($items === []) {
+                    return null;
+                }
+
+                return [
+                    'title' => (string) ($conceptSet['name'] ?? $fallbackTitle),
+                    'role' => $role,
+                    'clinical_rationale' => $asset->draft_payload_json['rationale'] ?? null,
+                    'search_terms' => array_values(array_filter([(string) ($asset->provenance_json['matched_term'] ?? '')])),
+                    'concepts' => $items,
+                    'source_concept_set_references' => [[
+                        'type' => $asset->canonical_type,
+                        'id' => $asset->canonical_id,
+                        'name' => $conceptSet['name'] ?? $fallbackTitle,
+                    ]],
+                    'provenance' => [
+                        'source' => $source,
+                        'source_asset_id' => $asset->id,
+                        'canonical_type' => $asset->canonical_type,
+                        'canonical_id' => $asset->canonical_id,
+                    ],
+                ];
+            })
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $draft
+     * @return array<string, mixed>|null
+     */
+    private function manualCandidate(array $draft, ?string $fallbackRole): ?array
+    {
+        $items = collect($draft['concepts'] ?? [])
+            ->filter(fn (mixed $item) => is_array($item))
+            ->map(fn (array $item) => $this->conceptItem(
+                (int) ($item['concept_id'] ?? 0),
+                (bool) ($item['is_excluded'] ?? false),
+                (bool) ($item['include_descendants'] ?? true),
+                (bool) ($item['include_mapped'] ?? false),
+                $item['rationale'] ?? null,
+            ))
+            ->values()
+            ->all();
+
+        if ($items === []) {
+            return null;
+        }
+
+        return [
+            'title' => (string) $draft['title'],
+            'role' => $draft['role'] ?? $fallbackRole,
+            'domain' => $draft['domain'] ?? null,
+            'clinical_rationale' => $draft['clinical_rationale'] ?? null,
+            'search_terms' => $draft['search_terms'] ?? [],
+            'concepts' => $items,
+            'source_concept_set_references' => [],
+            'provenance' => ['source' => 'manual_study_designer_draft'],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>|null
+     */
+    private function conceptItemFromExpression(array $item): ?array
+    {
+        $concept = (array) ($item['concept'] ?? []);
+        $conceptId = $concept['CONCEPT_ID'] ?? $concept['concept_id'] ?? $item['concept_id'] ?? null;
+
+        if (! is_numeric($conceptId)) {
+            return null;
+        }
+
+        return $this->conceptItem(
+            (int) $conceptId,
+            (bool) ($item['isExcluded'] ?? $item['is_excluded'] ?? false),
+            (bool) ($item['includeDescendants'] ?? $item['include_descendants'] ?? true),
+            (bool) ($item['includeMapped'] ?? $item['include_mapped'] ?? false),
+            $item['rationale'] ?? null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function conceptItem(int $conceptId, bool $isExcluded = false, bool $includeDescendants = true, bool $includeMapped = false, mixed $rationale = null): array
+    {
+        return [
+            'concept_id' => $conceptId,
+            'is_excluded' => $isExcluded,
+            'include_descendants' => $includeDescendants,
+            'include_mapped' => $includeMapped,
+            'rationale' => is_string($rationale) ? $rationale : null,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<int>
+     */
+    private function extractConceptIds(array $payload): array
+    {
+        $ids = [];
+        $walk = function (mixed $value, ?string $key = null) use (&$walk, &$ids): void {
+            $normalizedKey = $key ? strtolower((string) preg_replace('/[^a-zA-Z0-9]/', '', $key)) : '';
+
+            if (in_array($normalizedKey, ['conceptid', 'conceptids'], true)) {
+                foreach ((array) $value as $candidate) {
+                    if (is_numeric($candidate)) {
+                        $ids[] = (int) $candidate;
+                    }
+                }
+            }
+
+            if (is_array($value)) {
+                foreach ($value as $childKey => $childValue) {
+                    $walk($childValue, is_string($childKey) ? $childKey : null);
+                }
+            }
+        };
+
+        $walk($payload);
+
+        return collect($ids)
+            ->filter(fn (int $id) => $id > 0)
+            ->unique()
+            ->values()
+            ->all();
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyConceptSetDraftVerifier.php
+++ b/backend/app/Services/StudyDesign/StudyConceptSetDraftVerifier.php
@@ -8,6 +8,32 @@ use Illuminate\Support\Facades\DB;
 class StudyConceptSetDraftVerifier
 {
     /**
+     * Normalize a raw list of concept entries (from various API shapes) into
+     * a stable internal schema used by both the materializer and the verifier.
+     *
+     * @param  list<array<string, mixed>>  $items
+     * @return list<array<string, mixed>>
+     */
+    public function normalizeConcepts(array $items): array
+    {
+        return collect($items)
+            ->map(function (array $item): array {
+                $rawConcept = (array) ($item['concept'] ?? []);
+                $conceptId = $item['concept_id'] ?? $rawConcept['concept_id'] ?? $rawConcept['CONCEPT_ID'] ?? null;
+
+                return [
+                    'concept_id' => is_numeric($conceptId) ? (int) $conceptId : null,
+                    'is_excluded' => (bool) ($item['is_excluded'] ?? $item['isExcluded'] ?? false),
+                    'include_descendants' => (bool) ($item['include_descendants'] ?? $item['includeDescendants'] ?? true),
+                    'include_mapped' => (bool) ($item['include_mapped'] ?? $item['includeMapped'] ?? false),
+                    'rationale' => $item['rationale'] ?? null,
+                ];
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
      * @param  array<string, mixed>  $payload
      * @return array{verification_status:string,verified_at:mixed,verification_json:array<string,mixed>}
      */
@@ -21,8 +47,8 @@ class StudyConceptSetDraftVerifier
 
         return [
             'verification_status' => $blocked
-                ? StudyDesignVerificationStatus::Blocked->value
-                : StudyDesignVerificationStatus::Verified->value,
+                ? StudyDesignVerificationStatus::BLOCKED->value
+                : StudyDesignVerificationStatus::VERIFIED->value,
             'verified_at' => $blocked ? null : now(),
             'verification_json' => [
                 'checks' => [

--- a/backend/app/Services/StudyDesign/StudyConceptSetMaterializer.php
+++ b/backend/app/Services/StudyDesign/StudyConceptSetMaterializer.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignAssetStatus;
+use App\Enums\StudyDesignVerificationStatus;
+use App\Models\App\ConceptSet;
+use App\Models\App\StudyDesignAsset;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class StudyConceptSetMaterializer
+{
+    public function __construct(
+        private readonly StudyConceptSetDraftVerifier $verifier,
+    ) {}
+
+    public function materialize(StudyDesignAsset $asset, int $userId): ConceptSet
+    {
+        if ($asset->asset_type !== 'concept_set_draft') {
+            throw ValidationException::withMessages([
+                'asset' => 'Only concept set draft assets can be materialized as concept sets.',
+            ]);
+        }
+
+        if ($asset->materialized_type !== null || $asset->materialized_id !== null) {
+            throw ValidationException::withMessages([
+                'asset' => 'This concept set draft has already been materialized.',
+            ]);
+        }
+
+        if ($asset->verification_status === StudyDesignVerificationStatus::UNVERIFIED->value) {
+            $asset = $this->verifier->verify($asset);
+        }
+
+        if ($asset->verification_status !== StudyDesignVerificationStatus::VERIFIED->value) {
+            throw ValidationException::withMessages([
+                'verification' => 'Only verified concept set drafts can be materialized.',
+            ]);
+        }
+
+        if ($asset->status !== StudyDesignAssetStatus::ACCEPTED->value) {
+            throw ValidationException::withMessages([
+                'asset' => 'Accept the verified concept set draft before materializing it.',
+            ]);
+        }
+
+        return DB::transaction(function () use ($asset, $userId): ConceptSet {
+            $payload = $asset->draft_payload_json ?? [];
+            $concepts = $this->verifier->normalizeConcepts((array) ($payload['concepts'] ?? []));
+
+            $conceptSet = ConceptSet::create([
+                'name' => (string) ($payload['title'] ?? 'Study Designer concept set'),
+                'description' => $payload['clinical_rationale'] ?? null,
+                'expression_json' => $this->expressionJson($payload, $concepts),
+                'author_id' => $userId,
+                'is_public' => false,
+                'tags' => ['study-designer'],
+            ]);
+
+            foreach ($concepts as $concept) {
+                $conceptId = $concept['concept_id'] ?? null;
+                if (! is_int($conceptId)) {
+                    continue;
+                }
+
+                $conceptSet->items()->create([
+                    'concept_id' => $conceptId,
+                    'is_excluded' => (bool) ($concept['is_excluded'] ?? false),
+                    'include_descendants' => (bool) ($concept['include_descendants'] ?? true),
+                    'include_mapped' => (bool) ($concept['include_mapped'] ?? false),
+                ]);
+            }
+
+            $asset->update([
+                'status' => StudyDesignAssetStatus::MATERIALIZED->value,
+                'materialized_type' => ConceptSet::class,
+                'materialized_id' => $conceptSet->id,
+                'materialized_at' => now(),
+            ]);
+
+            return $conceptSet->fresh(['items', 'author']) ?? $conceptSet;
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  list<array<string, mixed>>  $concepts
+     * @return array<string, mixed>
+     */
+    private function expressionJson(array $payload, array $concepts): array
+    {
+        return [
+            'items' => collect($concepts)
+                ->map(fn (array $concept) => [
+                    'concept' => [
+                        'CONCEPT_ID' => $concept['concept_id'] ?? null,
+                    ],
+                    'isExcluded' => (bool) ($concept['is_excluded'] ?? false),
+                    'includeDescendants' => (bool) ($concept['include_descendants'] ?? true),
+                    'includeMapped' => (bool) ($concept['include_mapped'] ?? false),
+                ])
+                ->values()
+                ->all(),
+            'study_designer' => [
+                'role' => $payload['role'] ?? null,
+                'source_concept_set_references' => $payload['source_concept_set_references'] ?? [],
+                'materialized_at' => now()->toIso8601String(),
+            ],
+        ];
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyDesignAssetVerificationService.php
+++ b/backend/app/Services/StudyDesign/StudyDesignAssetVerificationService.php
@@ -1,0 +1,425 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignVerificationStatus;
+use App\Models\App\CohortDefinition;
+use App\Models\App\ConceptSet;
+use App\Models\App\PhenotypeLibraryEntry;
+use App\Models\App\StudyDesignAsset;
+use App\Models\Vocabulary\Concept;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+class StudyDesignAssetVerificationService
+{
+    public function verify(StudyDesignAsset $asset): StudyDesignAsset
+    {
+        $result = match ($asset->asset_type) {
+            'phenotype_recommendation' => $this->verifyPhenotypeRecommendation($asset),
+            'local_cohort' => $this->verifyLocalCohort($asset),
+            'local_concept_set' => $this->verifyLocalConceptSet($asset),
+            default => $this->unsupportedAsset($asset),
+        };
+
+        $asset->update([
+            'verification_status' => $result['status'],
+            'verification_json' => $result,
+            'verified_at' => now(),
+        ]);
+
+        return $asset->fresh() ?? $asset;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function verifyPhenotypeRecommendation(StudyDesignAsset $asset): array
+    {
+        $checks = [];
+        $payload = $asset->draft_payload_json ?? [];
+        $entry = $this->canonicalRecord($asset, PhenotypeLibraryEntry::class);
+
+        if (! $entry instanceof PhenotypeLibraryEntry) {
+            $checks[] = $this->check('source_record', 'fail', 'Blocked: phenotype recommendation did not resolve to a local Phenotype Library entry.');
+
+            return $this->result($checks, $asset);
+        }
+
+        $checks[] = $this->check('source_record', 'pass', 'Resolved to a local Phenotype Library entry.', [
+            'phenotype_library_entry_id' => $entry->id,
+            'cohort_id' => $entry->cohort_id,
+        ]);
+
+        if (isset($payload['external_id']) && (int) $payload['external_id'] !== (int) $entry->cohort_id) {
+            $checks[] = $this->check('external_id', 'fail', 'Blocked: suggested OHDSI cohort ID does not match the local source record.', [
+                'suggested' => $payload['external_id'],
+                'canonical' => $entry->cohort_id,
+            ]);
+        } else {
+            $checks[] = $this->check('external_id', 'pass', 'Suggested cohort ID matches the local source record.');
+        }
+
+        $checks[] = $this->titleCheck((string) ($payload['title'] ?? ''), (string) $entry->cohort_name, 'cohort_name');
+        $checks[] = $this->expressionCheck((bool) ($payload['has_expression'] ?? false), $entry->expression_json, 'phenotype_expression');
+
+        if (isset($payload['domain']) && $entry->domain !== null && (string) $payload['domain'] !== (string) $entry->domain) {
+            $checks[] = $this->check('domain', 'fail', 'Blocked: suggested domain does not match the local Phenotype Library metadata.', [
+                'suggested' => $payload['domain'],
+                'canonical' => $entry->domain,
+            ]);
+        }
+
+        if ($entry->is_imported && $entry->imported_cohort_id === null) {
+            $checks[] = $this->check('imported_cohort', 'warn', 'Phenotype is marked imported but has no linked local cohort definition.');
+        }
+
+        return $this->result([...$checks, ...$this->conceptChecks($payload)], $asset);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function verifyLocalCohort(StudyDesignAsset $asset): array
+    {
+        $checks = [];
+        $payload = $asset->draft_payload_json ?? [];
+        $cohort = $this->canonicalRecord($asset, CohortDefinition::class);
+
+        if (! $cohort instanceof CohortDefinition) {
+            $checks[] = $this->check('source_record', 'fail', 'Blocked: local cohort recommendation did not resolve to an existing cohort definition.');
+
+            return $this->result($checks, $asset);
+        }
+
+        $checks[] = $this->check('source_record', 'pass', 'Resolved to an existing local cohort definition.', [
+            'cohort_definition_id' => $cohort->id,
+        ]);
+        $checks[] = $this->titleCheck((string) ($payload['title'] ?? ''), (string) $cohort->name, 'cohort_name');
+        $checks[] = $this->expressionCheck((bool) ($payload['has_expression'] ?? false), $cohort->expression_json, 'cohort_expression');
+
+        if ($cohort->isDeprecated()) {
+            $checks[] = $this->check('active_status', 'fail', 'Blocked: local cohort is deprecated and cannot be accepted as a verified recommendation.');
+        } else {
+            $checks[] = $this->check('active_status', 'pass', 'Local cohort is active.');
+        }
+
+        return $this->result([...$checks, ...$this->conceptChecks($payload)], $asset);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function verifyLocalConceptSet(StudyDesignAsset $asset): array
+    {
+        $checks = [];
+        $payload = $asset->draft_payload_json ?? [];
+        $conceptSet = $this->canonicalRecord($asset, ConceptSet::class);
+
+        if (! $conceptSet instanceof ConceptSet) {
+            $checks[] = $this->check('source_record', 'fail', 'Blocked: local concept set recommendation did not resolve to an existing concept set.');
+
+            return $this->result($checks, $asset);
+        }
+
+        $checks[] = $this->check('source_record', 'pass', 'Resolved to an existing local concept set.', [
+            'concept_set_id' => $conceptSet->id,
+        ]);
+        $checks[] = $this->titleCheck((string) ($payload['title'] ?? ''), (string) $conceptSet->name, 'concept_set_name');
+        $checks[] = $this->expressionCheck((bool) ($payload['has_expression'] ?? false), $conceptSet->expression_json, 'concept_set_expression');
+
+        return $this->result([...$checks, ...$this->conceptChecks($payload)], $asset);
+    }
+
+    /**
+     * @param  class-string<Model>  $expectedType
+     */
+    private function canonicalRecord(StudyDesignAsset $asset, string $expectedType): ?Model
+    {
+        if ($asset->canonical_type !== $expectedType || $asset->canonical_id === null) {
+            return null;
+        }
+
+        /** @var Model|null $record */
+        $record = $expectedType::query()->find($asset->canonical_id);
+
+        return $record;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<array<string, mixed>>
+     */
+    private function conceptChecks(array $payload): array
+    {
+        $conceptIds = $this->extractConceptIds($payload);
+
+        if ($conceptIds === []) {
+            return [$this->check('omop_concepts', 'info', 'No explicit OMOP concept IDs were present in this recommendation payload.')];
+        }
+
+        $concepts = Concept::query()
+            ->whereIn('concept_id', $conceptIds)
+            ->get(['concept_id', 'concept_name', 'domain_id', 'standard_concept', 'invalid_reason'])
+            ->keyBy('concept_id');
+
+        $missing = collect($conceptIds)->reject(fn (int $id) => $concepts->has($id))->values()->all();
+        $invalid = $concepts
+            ->filter(fn (Concept $concept) => filled($concept->invalid_reason))
+            ->map(fn (Concept $concept) => [
+                'concept_id' => $concept->concept_id,
+                'concept_name' => $concept->concept_name,
+                'invalid_reason' => $concept->invalid_reason,
+            ])
+            ->values()
+            ->all();
+
+        if ($missing !== [] || $invalid !== []) {
+            return [$this->check('omop_concepts', 'fail', 'Blocked: one or more explicit OMOP concept IDs could not be verified as valid vocabulary concepts.', [
+                'missing_concept_ids' => $missing,
+                'invalid_concepts' => $invalid,
+            ])];
+        }
+
+        return [$this->check('omop_concepts', 'pass', 'Explicit OMOP concept IDs resolved to valid vocabulary concepts.', [
+            'concept_count' => count($conceptIds),
+        ])];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<int>
+     */
+    private function extractConceptIds(array $payload): array
+    {
+        $ids = [];
+        $walk = function (mixed $value, ?string $key = null) use (&$walk, &$ids): void {
+            $normalizedKey = $key ? strtolower((string) preg_replace('/[^a-zA-Z0-9]/', '', $key)) : '';
+
+            if (in_array($normalizedKey, ['conceptid', 'conceptids'], true)) {
+                foreach ((array) $value as $candidate) {
+                    if (is_numeric($candidate)) {
+                        $ids[] = (int) $candidate;
+                    }
+                }
+            }
+
+            if (is_array($value)) {
+                foreach ($value as $childKey => $childValue) {
+                    $walk($childValue, is_string($childKey) ? $childKey : null);
+                }
+            }
+        };
+
+        $walk($payload);
+
+        return collect($ids)
+            ->filter(fn (int $id) => $id > 0)
+            ->unique()
+            ->take(100)
+            ->values()
+            ->all();
+    }
+
+    private function titleCheck(string $suggested, string $canonical, string $field): array
+    {
+        if ($suggested === '') {
+            return $this->check($field, 'warn', 'Recommendation payload has no title to compare with the source record.');
+        }
+
+        if ($this->textMatches($suggested, $canonical)) {
+            return $this->check($field, 'pass', 'Recommendation title matches the source record.');
+        }
+
+        return $this->check($field, 'fail', 'Blocked: recommendation title does not match the source record.', [
+            'suggested' => $suggested,
+            'canonical' => $canonical,
+        ]);
+    }
+
+    private function expressionCheck(bool $payloadClaimsExpression, mixed $expression, string $name): array
+    {
+        $hasExpression = $expression !== null && $expression !== [] && $expression !== '';
+
+        if ($payloadClaimsExpression && ! $hasExpression) {
+            return $this->check($name, 'fail', 'Blocked: recommendation claims a computable expression, but the source record has none.');
+        }
+
+        if ($hasExpression) {
+            return $this->check($name, 'pass', 'Source record has a computable expression.');
+        }
+
+        return $this->check($name, 'warn', 'Source record has no computable expression yet.');
+    }
+
+    private function textMatches(string $left, string $right): bool
+    {
+        $leftNorm = $this->normalizeText($left);
+        $rightNorm = $this->normalizeText($right);
+
+        if ($leftNorm === '' || $rightNorm === '') {
+            return false;
+        }
+
+        if ($leftNorm === $rightNorm || str_contains($leftNorm, $rightNorm) || str_contains($rightNorm, $leftNorm)) {
+            return true;
+        }
+
+        $leftTokens = $this->tokens($leftNorm);
+        $rightTokens = $this->tokens($rightNorm);
+
+        if ($leftTokens->isEmpty() || $rightTokens->isEmpty()) {
+            return false;
+        }
+
+        $overlap = $leftTokens->intersect($rightTokens)->count();
+        $smaller = min($leftTokens->count(), $rightTokens->count());
+
+        return $smaller > 0 && ($overlap / $smaller) >= 0.6;
+    }
+
+    private function normalizeText(string $value): string
+    {
+        return trim((string) preg_replace('/\s+/', ' ', mb_strtolower((string) preg_replace('/[^[:alnum:]\s]/u', ' ', $value))));
+    }
+
+    /**
+     * @return Collection<int, string>
+     */
+    private function tokens(string $value): Collection
+    {
+        return collect(preg_split('/\s+/', $value) ?: [])
+            ->filter(fn (string $token) => mb_strlen($token) > 2)
+            ->unique()
+            ->values();
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $checks
+     * @return array<string, mixed>
+     */
+    private function result(array $checks, StudyDesignAsset $asset): array
+    {
+        $statuses = collect($checks)->pluck('status');
+
+        $status = match (true) {
+            $statuses->contains('fail') => StudyDesignVerificationStatus::BLOCKED->value,
+            $statuses->contains('warn') => StudyDesignVerificationStatus::PARTIAL->value,
+            default => StudyDesignVerificationStatus::VERIFIED->value,
+        };
+
+        $blockingReasons = collect($checks)
+            ->where('status', 'fail')
+            ->pluck('message')
+            ->values()
+            ->all();
+        $warnings = collect($checks)
+            ->where('status', 'warn')
+            ->pluck('message')
+            ->values()
+            ->all();
+        $canAccept = $status === StudyDesignVerificationStatus::VERIFIED->value;
+
+        return [
+            'status' => $status,
+            'verified_at' => now()->toIso8601String(),
+            'asset_type' => $asset->asset_type,
+            'canonical_type' => $asset->canonical_type,
+            'canonical_id' => $asset->canonical_id,
+            'eligibility' => [
+                'can_accept' => $canAccept,
+                'can_materialize' => false,
+                'reason' => $canAccept
+                    ? 'Recommendation can be accepted for downstream Study Designer drafting.'
+                    : 'Recommendation must be corrected, replaced, deferred, or rejected before downstream drafting.',
+            ],
+            'checks' => $checks,
+            'blocking_reasons' => $blockingReasons,
+            'warnings' => $warnings,
+            'source_summary' => $this->sourceSummary($asset),
+            'canonical_summary' => $this->canonicalSummary($asset),
+            'accepted_downstream_actions' => $canAccept
+                ? ['accept_recommendation', 'draft_concept_sets']
+                : ['defer', 'reject'],
+            'acceptance_policy' => 'Only verified assets may be accepted for downstream study design work.',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function unsupportedAsset(StudyDesignAsset $asset): array
+    {
+        return $this->result([
+            $this->check('asset_type', 'fail', "Blocked: no deterministic verifier is registered for {$asset->asset_type}."),
+        ], $asset);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sourceSummary(StudyDesignAsset $asset): array
+    {
+        $provenance = $asset->provenance_json ?? [];
+
+        return [
+            'source' => $provenance['source'] ?? 'unknown',
+            'matched_term' => $provenance['matched_term'] ?? null,
+            'retrieved_at' => $provenance['retrieved_at'] ?? null,
+            'ai_suggested' => ($provenance['source'] ?? null) === 'study-agent',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function canonicalSummary(StudyDesignAsset $asset): ?array
+    {
+        if ($asset->canonical_type === null || $asset->canonical_id === null) {
+            return null;
+        }
+
+        if (! is_subclass_of($asset->canonical_type, Model::class)) {
+            return null;
+        }
+
+        /** @var class-string<Model> $canonicalType */
+        $canonicalType = $asset->canonical_type;
+        $record = $canonicalType::query()->find($asset->canonical_id);
+        if (! $record instanceof Model) {
+            return null;
+        }
+
+        $title = match (true) {
+            $record instanceof PhenotypeLibraryEntry => $record->cohort_name,
+            $record instanceof CohortDefinition => $record->name,
+            $record instanceof ConceptSet => $record->name,
+            default => null,
+        };
+
+        return [
+            'type' => $asset->canonical_type,
+            'id' => $asset->canonical_id,
+            'title' => $title,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return array<string, mixed>
+     */
+    private function check(string $name, string $status, string $message, array $meta = []): array
+    {
+        $check = [
+            'name' => $name,
+            'status' => $status,
+            'message' => $message,
+        ];
+
+        if ($meta !== []) {
+            $check['meta'] = $meta;
+        }
+
+        return $check;
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyDesignCritiqueService.php
+++ b/backend/app/Services/StudyDesign/StudyDesignCritiqueService.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignAssetStatus;
+use App\Enums\StudyDesignVerificationStatus;
+use App\Models\App\Study;
+use App\Models\App\StudyAnalysis;
+use App\Models\App\StudyDesignAiEvent;
+use App\Models\App\StudyDesignAsset;
+use App\Models\App\StudyDesignSession;
+use App\Models\App\StudyDesignVersion;
+
+class StudyDesignCritiqueService
+{
+    /**
+     * @return list<StudyDesignAsset>
+     */
+    public function critique(Study $study, StudyDesignSession $session, StudyDesignVersion $version, int $userId): array
+    {
+        $findings = [
+            ...$this->picoFindings($version),
+            ...$this->cohortFindings($study),
+            ...$this->feasibilityFindings($session, $version),
+            ...$this->analysisFindings($study),
+        ];
+
+        StudyDesignAiEvent::create([
+            'session_id' => $session->id,
+            'version_id' => $version->id,
+            'created_by' => $userId,
+            'event_type' => 'design_critique',
+            'provider' => 'deterministic',
+            'model' => null,
+            'prompt_template_version' => 'study-design-critique-v1',
+            'input_summary_json' => [
+                'study_id' => $study->id,
+                'version_id' => $version->id,
+                'cohort_count' => $study->cohorts()->count(),
+                'analysis_count' => $study->analyses()->count(),
+            ],
+            'output_json' => [
+                'finding_count' => count($findings),
+                'findings' => $findings,
+            ],
+            'safety_flags_json' => [[
+                'type' => 'no_patient_data',
+                'message' => 'Critique used study metadata, design assets, cohort definitions, and analysis metadata only.',
+            ]],
+            'latency_ms' => null,
+        ]);
+
+        return collect($findings)
+            ->map(fn (array $finding): StudyDesignAsset => $this->storeFinding($session, $version, $finding))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function picoFindings(StudyDesignVersion $version): array
+    {
+        $findings = [];
+        $lintIssues = (array) data_get($version->lint_results_json, 'issues', []);
+        foreach ($lintIssues as $issue) {
+            if (! is_array($issue)) {
+                continue;
+            }
+
+            $findings[] = $this->finding(
+                'pico_gap',
+                (string) ($issue['severity'] ?? 'review'),
+                (string) ($issue['message'] ?? 'Review missing PICO information.'),
+                [
+                    'field' => $issue['field'] ?? null,
+                    'source' => 'study_design_lint',
+                ],
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function cohortFindings(Study $study): array
+    {
+        $findings = [];
+        $studyCohorts = $study->cohorts()->with('cohortDefinition')->orderBy('sort_order')->get();
+        $roles = $studyCohorts
+            ->pluck('role')
+            ->map(fn (string $role): string => $this->normalizeRole($role))
+            ->unique()
+            ->values()
+            ->all();
+
+        if (! in_array('target', $roles, true)) {
+            $findings[] = $this->finding('missing_target_cohort', 'blocking', 'Add or map a target cohort before feasibility and analysis.', [
+                'roles' => $roles,
+            ]);
+        }
+
+        if (str_contains((string) $study->study_type, 'comparative') && ! in_array('comparator', $roles, true)) {
+            $findings[] = $this->finding('missing_comparator_cohort', 'review', 'Comparative studies usually need a comparator cohort.', [
+                'study_type' => $study->study_type,
+            ]);
+        }
+
+        foreach ($studyCohorts as $cohort) {
+            if ($cohort->cohortDefinition?->isDeprecated() === true) {
+                $findings[] = $this->finding('deprecated_cohort', 'blocking', 'Replace deprecated cohort definitions before lock or execution.', [
+                    'study_cohort_id' => $cohort->id,
+                    'cohort_definition_id' => $cohort->cohort_definition_id,
+                ]);
+            }
+
+            if (($cohort->concept_set_ids ?? []) === []) {
+                $findings[] = $this->finding('missing_concept_metadata', 'review', 'A linked study cohort is missing concept set traceability.', [
+                    'study_cohort_id' => $cohort->id,
+                    'cohort_definition_id' => $cohort->cohort_definition_id,
+                    'role' => $this->normalizeRole($cohort->role),
+                ]);
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function feasibilityFindings(StudyDesignSession $session, StudyDesignVersion $version): array
+    {
+        $latest = $session->assets()
+            ->where('version_id', $version->id)
+            ->where('asset_type', 'feasibility_result')
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->first();
+        $payload = is_array($latest?->draft_payload_json) ? $latest->draft_payload_json : [];
+
+        if ($latest === null) {
+            return [$this->finding('missing_feasibility_evidence', 'blocking', 'Run source-aware feasibility before analysis planning or lock.', [])];
+        }
+
+        if (($payload['status'] ?? null) !== 'ready') {
+            return [$this->finding('feasibility_not_ready', 'blocking', 'Resolve feasibility blockers before analysis planning or lock.', [
+                'asset_id' => $latest->id,
+                'status' => $payload['status'] ?? 'unknown',
+            ])];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function analysisFindings(Study $study): array
+    {
+        $findings = [];
+        $roles = $study->cohorts()
+            ->pluck('role')
+            ->map(fn (string $role): string => $this->normalizeRole($role))
+            ->unique()
+            ->values()
+            ->all();
+
+        $study->analyses()
+            ->orderBy('id')
+            ->get()
+            ->each(function (StudyAnalysis $analysis) use (&$findings, $roles): void {
+                $type = (string) ($analysis->toArray()['analysis_type'] ?? 'unknown');
+                $required = match ($type) {
+                    'estimation' => ['target', 'comparator', 'outcome'],
+                    'prediction', 'sccs', 'self_controlled_cohort' => ['target', 'outcome'],
+                    'pathway' => ['target', 'comparator'],
+                    default => ['target'],
+                };
+                $missing = array_values(array_diff($required, $roles));
+
+                if ($missing !== []) {
+                    $findings[] = $this->finding('analysis_missing_required_roles', 'blocking', 'A native analysis is missing required study cohort roles.', [
+                        'study_analysis_id' => $analysis->id,
+                        'analysis_type' => $type,
+                        'missing_roles' => $missing,
+                    ]);
+                }
+            });
+
+        return $findings;
+    }
+
+    /**
+     * @param  array<string, mixed>  $finding
+     */
+    private function storeFinding(StudyDesignSession $session, StudyDesignVersion $version, array $finding): StudyDesignAsset
+    {
+        $severity = (string) ($finding['severity'] ?? 'review');
+
+        return StudyDesignAsset::create([
+            'session_id' => $session->id,
+            'version_id' => $version->id,
+            'asset_type' => 'design_critique',
+            'role' => $finding['meta']['role'] ?? null,
+            'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+            'draft_payload_json' => $finding,
+            'provenance_json' => [
+                'source' => 'study_designer_critique',
+                'generated_at' => now()->toIso8601String(),
+            ],
+            'verification_status' => StudyDesignVerificationStatus::VERIFIED->value,
+            'verification_json' => [
+                'status' => StudyDesignVerificationStatus::VERIFIED->value,
+                'eligibility' => [
+                    'can_accept' => true,
+                    'can_materialize' => false,
+                    'reason' => 'Critique findings are reviewable suggestions and never mutate canonical study assets directly.',
+                ],
+                'blocking_reasons' => [],
+                'warnings' => $severity === 'blocking' ? [] : [$finding['message']],
+                'checks' => [[
+                    'name' => (string) ($finding['code'] ?? 'design_critique'),
+                    'status' => $severity === 'blocking' ? 'warn' : 'info',
+                    'message' => (string) ($finding['message'] ?? 'Review this design critique.'),
+                    'meta' => (array) ($finding['meta'] ?? []),
+                ]],
+                'accepted_downstream_actions' => ['acknowledge', 'create_superseding_version'],
+                'acceptance_policy' => 'Accepted critique assets document reviewer acknowledgement only.',
+            ],
+            'verified_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return array<string, mixed>
+     */
+    private function finding(string $code, string $severity, string $message, array $meta): array
+    {
+        return [
+            'code' => $code,
+            'severity' => $severity,
+            'message' => $message,
+            'meta' => $meta,
+            'policy' => 'Bottom-up critique creates reviewable design findings without changing existing cohorts, analyses, or study metadata.',
+        ];
+    }
+
+    private function normalizeRole(string $role): string
+    {
+        return match (trim(strtolower($role))) {
+            'population', 'exposure', 'intervention' => 'target',
+            'comparator', 'outcome', 'exclusion', 'subgroup', 'event' => trim(strtolower($role)),
+            default => 'target',
+        };
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyDesignImportService.php
+++ b/backend/app/Services/StudyDesign/StudyDesignImportService.php
@@ -1,0 +1,367 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignAssetStatus;
+use App\Enums\StudyDesignVerificationStatus;
+use App\Models\App\CohortDefinition;
+use App\Models\App\ConceptSet;
+use App\Models\App\Study;
+use App\Models\App\StudyAnalysis;
+use App\Models\App\StudyCohort;
+use App\Models\App\StudyDesignAsset;
+use App\Models\App\StudyDesignSession;
+use App\Models\App\StudyDesignVersion;
+use Illuminate\Support\Facades\DB;
+
+class StudyDesignImportService
+{
+    public function __construct(
+        private readonly StudyDesignSpecValidator $validator,
+    ) {}
+
+    /**
+     * @return array{version: StudyDesignVersion, assets: list<StudyDesignAsset>}
+     */
+    public function importExistingStudy(Study $study, StudyDesignSession $session, int $userId): array
+    {
+        return DB::transaction(function () use ($study, $session, $userId): array {
+            $studyCohorts = $study->cohorts()
+                ->with('cohortDefinition')
+                ->orderBy('sort_order')
+                ->orderBy('id')
+                ->get();
+            $studyAnalyses = $study->analyses()
+                ->with('analysis')
+                ->orderBy('id')
+                ->get();
+
+            $researchQuestion = $this->researchQuestion($study);
+            $normalized = $this->validator->normalize(
+                $this->specFromCurrentStudy($study, $studyCohorts, $studyAnalyses, $researchQuestion),
+                $study,
+                $researchQuestion,
+            );
+            $versionNumber = ((int) $session->versions()->max('version_number')) + 1;
+
+            $version = $session->versions()->create([
+                'version_number' => $versionNumber,
+                'status' => ($normalized['lint']['status'] ?? 'needs_review') === 'ready' ? 'review_ready' : 'draft',
+                'spec_json' => $normalized['spec'],
+                'normalized_spec_json' => $normalized['spec'],
+                'lint_results_json' => $normalized['lint'],
+                'ai_model_metadata_json' => [
+                    'provider' => 'manual_import',
+                    'model' => null,
+                    'prompt_template_version' => null,
+                ],
+                'created_by' => $userId,
+            ]);
+
+            $session->update([
+                'active_version_id' => $version->id,
+                'status' => 'reviewing',
+            ]);
+
+            $assets = [
+                ...$this->importConceptSets($session, $version, $studyCohorts),
+                ...$this->importStudyCohorts($session, $version, $studyCohorts),
+                ...$this->importStudyAnalyses($session, $version, $studyAnalyses),
+            ];
+
+            return [
+                'version' => $version->fresh(['creator:id,name,email', 'acceptedBy:id,name,email']) ?? $version,
+                'assets' => collect($assets)
+                    ->map(fn (StudyDesignAsset $asset): StudyDesignAsset => $asset->fresh('reviewer:id,name,email') ?? $asset)
+                    ->values()
+                    ->all(),
+            ];
+        });
+    }
+
+    private function researchQuestion(Study $study): string
+    {
+        foreach ([$study->primary_objective, $study->hypothesis, $study->description, $study->title] as $candidate) {
+            $value = trim((string) $candidate);
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return 'Review the current manually assembled study design.';
+    }
+
+    /**
+     * @param  iterable<int, StudyCohort>  $studyCohorts
+     * @param  iterable<int, StudyAnalysis>  $studyAnalyses
+     * @return array<string, mixed>
+     */
+    private function specFromCurrentStudy(Study $study, iterable $studyCohorts, iterable $studyAnalyses, string $researchQuestion): array
+    {
+        $byRole = collect($studyCohorts)->groupBy(fn (StudyCohort $cohort): string => $this->normalizeRole($cohort->role));
+        $target = $byRole->get('target', collect())->first();
+        $comparator = $byRole->get('comparator', collect())->first();
+        $outcomes = $byRole->get('outcome', collect());
+
+        return [
+            'schema_version' => '1.0',
+            'study' => [
+                'title' => $study->title,
+                'short_title' => $study->short_title,
+                'research_question' => $researchQuestion,
+                'scientific_rationale' => $study->scientific_rationale ?? '',
+                'hypothesis' => $study->hypothesis ?? '',
+                'primary_objective' => $study->primary_objective ?: $researchQuestion,
+                'secondary_objectives' => $study->secondary_objectives ?? [],
+                'study_design' => $study->study_design ?? 'observational',
+                'study_type' => $study->study_type ?? 'custom',
+                'target_population_summary' => $this->cohortLabel($target),
+            ],
+            'pico' => [
+                'population' => ['summary' => $this->cohortLabel($target)],
+                'intervention_or_exposure' => ['summary' => $this->cohortLabel($target)],
+                'comparator' => ['summary' => $this->cohortLabel($comparator)],
+                'outcomes' => $outcomes
+                    ->map(fn (StudyCohort $cohort, int $index): array => [
+                        'summary' => $this->cohortLabel($cohort),
+                        'primary' => $index === 0,
+                    ])
+                    ->values()
+                    ->all(),
+                'time' => ['summary' => 'Review imported study time-at-risk assumptions.'],
+            ],
+            'cohort_roles' => collect($studyCohorts)
+                ->map(fn (StudyCohort $cohort): array => [
+                    'role' => $this->normalizeRole($cohort->role),
+                    'study_cohort_id' => $cohort->id,
+                    'cohort_definition_id' => $cohort->cohort_definition_id,
+                    'label' => $cohort->label,
+                    'concept_set_ids' => $cohort->concept_set_ids ?? [],
+                ])
+                ->values()
+                ->all(),
+            'analysis_plan' => collect($studyAnalyses)
+                ->map(fn (StudyAnalysis $analysis): array => [
+                    'study_analysis_id' => $analysis->id,
+                    'analysis_type' => $analysis->toArray()['analysis_type'] ?? 'unknown',
+                    'analysis_id' => $analysis->analysis_id,
+                ])
+                ->values()
+                ->all(),
+            'provenance' => [
+                'source' => 'bottom_up_import',
+                'imported_at' => now()->toIso8601String(),
+            ],
+        ];
+    }
+
+    private function cohortLabel(?StudyCohort $cohort): string
+    {
+        if (! $cohort instanceof StudyCohort) {
+            return '';
+        }
+
+        return trim((string) ($cohort->label ?: $cohort->cohortDefinition?->name ?: "Cohort {$cohort->cohort_definition_id}"));
+    }
+
+    /**
+     * @param  iterable<int, StudyCohort>  $studyCohorts
+     * @return list<StudyDesignAsset>
+     */
+    private function importConceptSets(StudyDesignSession $session, StudyDesignVersion $version, iterable $studyCohorts): array
+    {
+        $roleByConceptSet = [];
+        $conceptSetIds = [];
+        foreach ($studyCohorts as $cohort) {
+            foreach ((array) ($cohort->concept_set_ids ?? []) as $conceptSetId) {
+                if (is_numeric($conceptSetId)) {
+                    $id = (int) $conceptSetId;
+                    $conceptSetIds[] = $id;
+                    $roleByConceptSet[$id] ??= $this->normalizeRole($cohort->role);
+                }
+            }
+        }
+
+        if ($conceptSetIds === []) {
+            return [];
+        }
+
+        return ConceptSet::query()
+            ->whereIn('id', array_values(array_unique($conceptSetIds)))
+            ->orderBy('id')
+            ->get()
+            ->map(fn (ConceptSet $conceptSet): StudyDesignAsset => StudyDesignAsset::create([
+                'session_id' => $session->id,
+                'version_id' => $version->id,
+                'asset_type' => 'imported_concept_set',
+                'role' => $roleByConceptSet[$conceptSet->id] ?? null,
+                'status' => StudyDesignAssetStatus::MATERIALIZED->value,
+                'draft_payload_json' => [
+                    'title' => $conceptSet->name,
+                    'description' => $conceptSet->description,
+                    'expression_json' => $conceptSet->expression_json ?? [],
+                    'source_concept_set_id' => $conceptSet->id,
+                ],
+                'canonical_type' => ConceptSet::class,
+                'canonical_id' => $conceptSet->id,
+                'provenance_json' => [
+                    'source' => 'bottom_up_import',
+                    'imported_from' => 'study_cohort_concept_set_ids',
+                    'concept_set_id' => $conceptSet->id,
+                ],
+                'verification_status' => StudyDesignVerificationStatus::VERIFIED->value,
+                'verification_json' => $this->verifiedJson('Imported concept set already exists as a native Parthenon concept set.'),
+                'verified_at' => now(),
+                'materialized_type' => ConceptSet::class,
+                'materialized_id' => $conceptSet->id,
+                'materialized_at' => now(),
+            ]))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  iterable<int, StudyCohort>  $studyCohorts
+     * @return list<StudyDesignAsset>
+     */
+    private function importStudyCohorts(StudyDesignSession $session, StudyDesignVersion $version, iterable $studyCohorts): array
+    {
+        return collect($studyCohorts)
+            ->map(function (StudyCohort $cohort) use ($session, $version): StudyDesignAsset {
+                $cohortDefinition = $cohort->cohortDefinition;
+                $deprecated = $cohortDefinition?->isDeprecated() === true;
+
+                return StudyDesignAsset::create([
+                    'session_id' => $session->id,
+                    'version_id' => $version->id,
+                    'asset_type' => 'imported_study_cohort',
+                    'role' => $this->normalizeRole($cohort->role),
+                    'status' => StudyDesignAssetStatus::ACCEPTED->value,
+                    'draft_payload_json' => [
+                        'study_cohort_id' => $cohort->id,
+                        'role' => $this->normalizeRole($cohort->role),
+                        'label' => $cohort->label,
+                        'description' => $cohort->description,
+                        'cohort_definition_id' => $cohort->cohort_definition_id,
+                        'cohort_definition_name' => $cohortDefinition?->name,
+                        'concept_set_ids' => $cohort->concept_set_ids ?? [],
+                        'expression_json' => $cohortDefinition?->expression_json ?? [],
+                        'is_deprecated' => $deprecated,
+                    ],
+                    'canonical_type' => CohortDefinition::class,
+                    'canonical_id' => $cohort->cohort_definition_id,
+                    'provenance_json' => [
+                        'source' => 'bottom_up_import',
+                        'study_cohort_id' => $cohort->id,
+                        'cohort_definition_id' => $cohort->cohort_definition_id,
+                    ],
+                    'verification_status' => $deprecated
+                        ? StudyDesignVerificationStatus::BLOCKED->value
+                        : StudyDesignVerificationStatus::VERIFIED->value,
+                    'verification_json' => $deprecated
+                        ? $this->blockedJson('Imported cohort definition is deprecated and should be replaced before lock or execution.')
+                        : $this->verifiedJson('Imported study cohort is linked to a native non-deprecated cohort definition.'),
+                    'verified_at' => now(),
+                    'materialized_type' => CohortDefinition::class,
+                    'materialized_id' => $cohort->cohort_definition_id,
+                    'materialized_at' => now(),
+                ]);
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  iterable<int, StudyAnalysis>  $studyAnalyses
+     * @return list<StudyDesignAsset>
+     */
+    private function importStudyAnalyses(StudyDesignSession $session, StudyDesignVersion $version, iterable $studyAnalyses): array
+    {
+        return collect($studyAnalyses)
+            ->map(function (StudyAnalysis $studyAnalysis) use ($session, $version): StudyDesignAsset {
+                $analysis = $studyAnalysis->analysis;
+                $analysisType = $studyAnalysis->toArray()['analysis_type'] ?? 'unknown';
+
+                return StudyDesignAsset::create([
+                    'session_id' => $session->id,
+                    'version_id' => $version->id,
+                    'asset_type' => 'imported_study_analysis',
+                    'role' => null,
+                    'status' => StudyDesignAssetStatus::ACCEPTED->value,
+                    'draft_payload_json' => [
+                        'study_analysis_id' => $studyAnalysis->id,
+                        'analysis_type' => $analysisType,
+                        'analysis_id' => $studyAnalysis->analysis_id,
+                        'title' => $analysis?->getAttribute('name'),
+                        'description' => $analysis?->getAttribute('description'),
+                        'design_json' => $analysis?->getAttribute('design_json') ?? [],
+                    ],
+                    'canonical_type' => $studyAnalysis->analysis_type,
+                    'canonical_id' => $studyAnalysis->analysis_id,
+                    'provenance_json' => [
+                        'source' => 'bottom_up_import',
+                        'study_analysis_id' => $studyAnalysis->id,
+                        'analysis_type' => $studyAnalysis->analysis_type,
+                        'analysis_id' => $studyAnalysis->analysis_id,
+                    ],
+                    'verification_status' => StudyDesignVerificationStatus::VERIFIED->value,
+                    'verification_json' => $this->verifiedJson('Imported study analysis already exists as a native Parthenon analysis.'),
+                    'verified_at' => now(),
+                    'materialized_type' => $studyAnalysis->analysis_type,
+                    'materialized_id' => $studyAnalysis->analysis_id,
+                    'materialized_at' => now(),
+                ]);
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function verifiedJson(string $reason): array
+    {
+        return [
+            'status' => StudyDesignVerificationStatus::VERIFIED->value,
+            'eligibility' => [
+                'can_accept' => true,
+                'can_materialize' => false,
+                'reason' => $reason,
+            ],
+            'blocking_reasons' => [],
+            'warnings' => [],
+            'checks' => [],
+            'accepted_downstream_actions' => ['critique', 'lock_when_complete'],
+            'acceptance_policy' => 'Imported assets preserve native Parthenon provenance and do not mutate canonical records.',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function blockedJson(string $reason): array
+    {
+        return [
+            'status' => StudyDesignVerificationStatus::BLOCKED->value,
+            'eligibility' => [
+                'can_accept' => false,
+                'can_materialize' => false,
+                'reason' => $reason,
+            ],
+            'blocking_reasons' => [$reason],
+            'warnings' => [],
+            'checks' => [['name' => 'imported_asset', 'status' => 'fail', 'message' => $reason]],
+            'accepted_downstream_actions' => ['replace_or_defer'],
+            'acceptance_policy' => 'Blocked imported assets cannot be accepted downstream until replaced or corrected.',
+        ];
+    }
+
+    private function normalizeRole(string $role): string
+    {
+        return match (trim(strtolower($role))) {
+            'population', 'exposure', 'intervention' => 'target',
+            'comparator', 'outcome', 'exclusion', 'subgroup', 'event' => trim(strtolower($role)),
+            default => 'target',
+        };
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyDesignLockService.php
+++ b/backend/app/Services/StudyDesign/StudyDesignLockService.php
@@ -1,0 +1,449 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignAssetStatus;
+use App\Enums\StudyDesignVerificationStatus;
+use App\Models\App\ConceptSet;
+use App\Models\App\Study;
+use App\Models\App\StudyAnalysis;
+use App\Models\App\StudyArtifact;
+use App\Models\App\StudyCohort;
+use App\Models\App\StudyDesignAsset;
+use App\Models\App\StudyDesignSession;
+use App\Models\App\StudyDesignVersion;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\ValidationException;
+
+class StudyDesignLockService
+{
+    public function __construct(
+        private readonly StudyCohortReadinessService $cohortReadiness,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function readiness(Study $study, StudyDesignSession $session, StudyDesignVersion $version): array
+    {
+        $blockers = [];
+        $warnings = [];
+
+        if (! in_array($version->status, ['accepted', 'locked'], true)) {
+            $blockers[] = $this->issue(
+                'version_not_accepted',
+                'Accept the study intent version before locking a study package.',
+                ['status' => $version->status],
+            );
+        }
+
+        $conceptSetAssets = $this->materializedConceptSetAssets($session, $version);
+        if ($conceptSetAssets->isEmpty()) {
+            $blockers[] = $this->issue(
+                'missing_materialized_concept_sets',
+                'Materialize at least one verified concept set draft before locking the study package.',
+            );
+        }
+
+        $cohortReadiness = $this->cohortReadiness->summarize($study, $session, $version);
+        foreach ((array) ($cohortReadiness['blockers'] ?? []) as $blocker) {
+            if (is_array($blocker)) {
+                $blockers[] = [
+                    ...$blocker,
+                    'code' => 'cohort_'.$blocker['code'],
+                ];
+            }
+        }
+        foreach ((array) ($cohortReadiness['warnings'] ?? []) as $warning) {
+            if (is_array($warning)) {
+                $warnings[] = [
+                    ...$warning,
+                    'code' => 'cohort_'.$warning['code'],
+                ];
+            }
+        }
+
+        $feasibility = $this->latestFeasibilityAsset($session, $version);
+        $feasibilityPayload = is_array($feasibility?->draft_payload_json) ? $feasibility->draft_payload_json : [];
+        if ($feasibility === null) {
+            $blockers[] = $this->issue(
+                'missing_feasibility_evidence',
+                'Run source-scoped feasibility and resolve blockers before locking the study package.',
+            );
+        } elseif (($feasibilityPayload['status'] ?? null) !== 'ready') {
+            $blockers[] = $this->issue(
+                'feasibility_not_ready',
+                'Latest feasibility evidence must be ready before locking the study package.',
+                ['status' => $feasibilityPayload['status'] ?? 'unknown', 'asset_id' => $feasibility->id],
+            );
+        }
+
+        $analysisPlanAssets = $this->materializedAnalysisPlanAssets($session, $version);
+        if ($analysisPlanAssets->isEmpty()) {
+            $blockers[] = $this->issue(
+                'missing_materialized_analysis_plan',
+                'Materialize at least one verified HADES analysis plan before locking the study package.',
+            );
+        }
+
+        $missingPackageVersions = $analysisPlanAssets
+            ->filter(fn (StudyDesignAsset $asset): bool => data_get($asset->draft_payload_json, 'hades_capability.version') === null)
+            ->pluck('id')
+            ->values()
+            ->all();
+        if ($missingPackageVersions !== []) {
+            $warnings[] = $this->issue(
+                'missing_hades_package_versions',
+                'One or more materialized analysis plans do not include a Darkstar package version.',
+                ['asset_ids' => $missingPackageVersions],
+            );
+        }
+
+        $status = $blockers === [] ? ($version->status === 'locked' ? 'locked' : 'ready') : 'blocked';
+        $packageArtifact = $this->latestStudyPackageArtifact($study, $version);
+
+        return [
+            'status' => $status,
+            'can_lock' => $blockers === [] && $version->status !== 'locked',
+            'locked' => $version->status === 'locked',
+            'blockers' => $blockers,
+            'warnings' => $warnings,
+            'summary' => [
+                'materialized_concept_sets' => $conceptSetAssets->count(),
+                'linked_cohorts' => count((array) ($cohortReadiness['linked_cohorts'] ?? [])),
+                'feasibility_status' => $feasibilityPayload['status'] ?? null,
+                'materialized_analysis_plans' => $analysisPlanAssets->count(),
+                'package_assets' => $this->packageAssets($session, $version)->count(),
+            ],
+            'cohort_readiness' => $cohortReadiness,
+            'feasibility_asset_id' => $feasibility?->id,
+            'package_artifact' => $packageArtifact === null ? null : $this->artifactSummary($packageArtifact),
+            'provenance_summary' => [
+                'intent' => [
+                    'version_id' => $version->id,
+                    'version_number' => $version->version_number,
+                    'status' => $version->status,
+                    'accepted_by' => $version->accepted_by,
+                    'accepted_at' => $version->accepted_at?->toIso8601String(),
+                ],
+                'ai_events' => $version->aiEvents()->count(),
+                'reviewed_assets' => $session->assets()
+                    ->where('version_id', $version->id)
+                    ->whereNotNull('reviewed_at')
+                    ->count(),
+                'verified_assets' => $session->assets()
+                    ->where('version_id', $version->id)
+                    ->where('verification_status', StudyDesignVerificationStatus::VERIFIED->value)
+                    ->count(),
+                'package_manifest_sha256' => $packageArtifact?->metadata['manifest_sha256'] ?? null,
+            ],
+            'policy' => 'A Study Designer version can be locked only after accepted intent, materialized concept sets, linked native cohorts, ready source feasibility, and materialized HADES analysis plans are present.',
+        ];
+    }
+
+    /**
+     * @return array{readiness: array<string, mixed>, package_asset: StudyDesignAsset|null, study_artifact: StudyArtifact|null}
+     */
+    public function lock(Study $study, StudyDesignSession $session, StudyDesignVersion $version, int $userId): array
+    {
+        $readiness = $this->readiness($study, $session, $version);
+
+        if ($version->status === 'locked') {
+            return [
+                'readiness' => $readiness,
+                'package_asset' => $this->packageAssets($session, $version)->first(),
+                'study_artifact' => $this->latestStudyPackageArtifact($study, $version),
+            ];
+        }
+
+        if (($readiness['blockers'] ?? []) !== []) {
+            throw ValidationException::withMessages([
+                'lock' => collect($readiness['blockers'])->pluck('message')->values()->all(),
+            ]);
+        }
+
+        return DB::transaction(function () use ($study, $session, $version, $userId, $readiness): array {
+            $lockedAt = now();
+            $manifest = $this->manifest($study, $session, $version, $readiness, $userId, $lockedAt->toIso8601String());
+            $manifestJson = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+            if ($manifestJson === false) {
+                throw ValidationException::withMessages(['lock' => 'Study package manifest could not be encoded.']);
+            }
+
+            $manifestHash = hash('sha256', $manifestJson);
+            $filePath = "study-packages/study-{$study->id}/design-version-{$version->id}-{$manifestHash}.json";
+            Storage::disk('local')->put($filePath, $manifestJson);
+
+            $packageAsset = StudyDesignAsset::create([
+                'session_id' => $session->id,
+                'version_id' => $version->id,
+                'asset_type' => 'study_package_snapshot',
+                'role' => null,
+                'status' => StudyDesignAssetStatus::MATERIALIZED->value,
+                'draft_payload_json' => $manifest,
+                'provenance_json' => [
+                    'source' => 'study_designer_lock',
+                    'study_id' => $study->id,
+                    'version_id' => $version->id,
+                    'locked_by' => $userId,
+                    'locked_at' => $lockedAt->toIso8601String(),
+                    'manifest_sha256' => $manifestHash,
+                ],
+                'verification_status' => StudyDesignVerificationStatus::VERIFIED->value,
+                'verification_json' => [
+                    'status' => StudyDesignVerificationStatus::VERIFIED->value,
+                    'verified_at' => $lockedAt->toIso8601String(),
+                    'eligibility' => [
+                        'can_accept' => true,
+                        'can_materialize' => true,
+                        'reason' => 'Locked study package manifest preserves reviewed intent, provenance, cohorts, feasibility, and analysis plans.',
+                    ],
+                    'blocking_reasons' => [],
+                    'warnings' => $readiness['warnings'] ?? [],
+                    'checks' => [],
+                    'acceptance_policy' => 'Locked package snapshots are immutable Study Designer provenance records.',
+                ],
+                'verified_at' => $lockedAt,
+                'materialized_type' => StudyDesignVersion::class,
+                'materialized_id' => $version->id,
+                'materialized_at' => $lockedAt,
+            ]);
+
+            StudyArtifact::query()
+                ->where('study_id', $study->id)
+                ->where('artifact_type', 'study_package_zip')
+                ->update(['is_current' => false]);
+
+            $artifact = StudyArtifact::create([
+                'study_id' => $study->id,
+                'artifact_type' => 'study_package_zip',
+                'title' => "Study Designer package v{$version->version_number}",
+                'description' => 'Locked Study Designer package manifest for OHDSI-aligned execution handoff.',
+                'version' => (string) $version->version_number,
+                'file_path' => $filePath,
+                'file_size_bytes' => strlen($manifestJson),
+                'mime_type' => 'application/vnd.parthenon.study-package+json',
+                'url' => "/api/v1/studies/{$study->slug}/artifacts/{artifact}/download",
+                'metadata' => [
+                    'design_session_id' => $session->id,
+                    'design_version_id' => $version->id,
+                    'package_asset_id' => $packageAsset->id,
+                    'manifest_sha256' => $manifestHash,
+                    'locked_at' => $lockedAt->toIso8601String(),
+                    'readiness_summary' => $readiness['summary'] ?? [],
+                ],
+                'uploaded_by' => $userId,
+                'is_current' => true,
+            ]);
+
+            $artifact->update([
+                'url' => "/api/v1/studies/{$study->slug}/artifacts/{$artifact->id}/download",
+            ]);
+
+            $version->update(['status' => 'locked']);
+            $session->update([
+                'active_version_id' => $version->id,
+                'status' => 'locked',
+            ]);
+
+            return [
+                'readiness' => $this->readiness($study, $session->fresh() ?? $session, $version->fresh() ?? $version),
+                'package_asset' => $packageAsset->fresh('reviewer:id,name,email'),
+                'study_artifact' => $artifact->fresh('uploadedBy:id,name,email'),
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function manifest(Study $study, StudyDesignSession $session, StudyDesignVersion $version, array $readiness, int $userId, string $lockedAt): array
+    {
+        return [
+            'schema_version' => 'study-package.v1',
+            'locked_at' => $lockedAt,
+            'locked_by' => $userId,
+            'study' => [
+                'id' => $study->id,
+                'slug' => $study->slug,
+                'title' => $study->title,
+                'study_type' => $study->study_type,
+                'study_design' => $study->study_design,
+            ],
+            'design_session' => [
+                'id' => $session->id,
+                'title' => $session->title,
+                'source_mode' => $session->source_mode,
+            ],
+            'design_version' => [
+                'id' => $version->id,
+                'version_number' => $version->version_number,
+                'status' => $version->status,
+                'accepted_by' => $version->accepted_by,
+                'accepted_at' => $version->accepted_at?->toIso8601String(),
+                'spec_json' => $version->spec_json,
+                'normalized_spec_json' => $version->normalized_spec_json,
+                'lint_results_json' => $version->lint_results_json,
+            ],
+            'concept_sets' => $this->materializedConceptSetAssets($session, $version)
+                ->map(fn (StudyDesignAsset $asset): array => $this->assetSummary($asset))
+                ->values()
+                ->all(),
+            'cohorts' => $study->cohorts()
+                ->with('cohortDefinition')
+                ->orderBy('sort_order')
+                ->get()
+                ->map(fn (StudyCohort $cohort): array => [
+                    'study_cohort_id' => $cohort->id,
+                    'role' => $cohort->role,
+                    'label' => $cohort->label,
+                    'cohort_definition_id' => $cohort->cohort_definition_id,
+                    'cohort_definition_name' => $cohort->cohortDefinition?->name,
+                    'concept_set_ids' => $cohort->concept_set_ids ?? [],
+                ])
+                ->values()
+                ->all(),
+            'feasibility' => [
+                'asset' => $this->latestFeasibilityAsset($session, $version)?->only(['id', 'asset_type', 'verification_status', 'verified_at']),
+                'result' => $this->latestFeasibilityAsset($session, $version)?->draft_payload_json,
+            ],
+            'analysis_plans' => $this->materializedAnalysisPlanAssets($session, $version)
+                ->map(fn (StudyDesignAsset $asset): array => $this->assetSummary($asset))
+                ->values()
+                ->all(),
+            'study_analyses' => StudyAnalysis::query()
+                ->where('study_id', $study->id)
+                ->orderBy('id')
+                ->get(['id', 'analysis_type', 'analysis_id'])
+                ->map(fn (StudyAnalysis $analysis): array => $analysis->toArray())
+                ->values()
+                ->all(),
+            'ai_events' => $version->aiEvents()
+                ->orderBy('id')
+                ->get(['id', 'event_type', 'provider', 'model', 'prompt_template_version', 'latency_ms', 'created_at'])
+                ->map(fn ($event): array => $event->toArray())
+                ->values()
+                ->all(),
+            'readiness' => $readiness,
+            'policy' => 'This package freezes the reviewed Study Designer path from intent through materialized OHDSI assets for execution handoff and audit.',
+        ];
+    }
+
+    private function latestFeasibilityAsset(StudyDesignSession $session, StudyDesignVersion $version): ?StudyDesignAsset
+    {
+        return $session->assets()
+            ->where('version_id', $version->id)
+            ->where('asset_type', 'feasibility_result')
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->first();
+    }
+
+    /**
+     * @return EloquentCollection<int, StudyDesignAsset>
+     */
+    private function materializedConceptSetAssets(StudyDesignSession $session, StudyDesignVersion $version): EloquentCollection
+    {
+        return $session->assets()
+            ->where('version_id', $version->id)
+            ->where('asset_type', 'concept_set_draft')
+            ->where('status', StudyDesignAssetStatus::MATERIALIZED->value)
+            ->where('materialized_type', ConceptSet::class)
+            ->whereNotNull('materialized_id')
+            ->orderBy('id')
+            ->get();
+    }
+
+    /**
+     * @return EloquentCollection<int, StudyDesignAsset>
+     */
+    private function materializedAnalysisPlanAssets(StudyDesignSession $session, StudyDesignVersion $version): EloquentCollection
+    {
+        return $session->assets()
+            ->where('version_id', $version->id)
+            ->where('asset_type', 'analysis_plan')
+            ->where('status', StudyDesignAssetStatus::MATERIALIZED->value)
+            ->whereNotNull('materialized_id')
+            ->orderBy('id')
+            ->get();
+    }
+
+    /**
+     * @return EloquentCollection<int, StudyDesignAsset>
+     */
+    private function packageAssets(StudyDesignSession $session, StudyDesignVersion $version): EloquentCollection
+    {
+        return $session->assets()
+            ->where('version_id', $version->id)
+            ->where('asset_type', 'study_package_snapshot')
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->get();
+    }
+
+    private function latestStudyPackageArtifact(Study $study, StudyDesignVersion $version): ?StudyArtifact
+    {
+        return StudyArtifact::query()
+            ->where('study_id', $study->id)
+            ->where('artifact_type', 'study_package_zip')
+            ->where('metadata->design_version_id', $version->id)
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->first();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifactSummary(StudyArtifact $artifact): array
+    {
+        return [
+            'id' => $artifact->id,
+            'artifact_type' => $artifact->artifact_type,
+            'title' => $artifact->title,
+            'version' => $artifact->version,
+            'file_size_bytes' => $artifact->file_size_bytes,
+            'mime_type' => $artifact->mime_type,
+            'url' => $artifact->url,
+            'metadata' => $artifact->metadata,
+            'created_at' => $artifact->created_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function assetSummary(StudyDesignAsset $asset): array
+    {
+        return [
+            'id' => $asset->id,
+            'asset_type' => $asset->asset_type,
+            'role' => $asset->role,
+            'status' => $asset->status,
+            'verification_status' => $asset->verification_status,
+            'draft_payload_json' => $asset->draft_payload_json,
+            'provenance_json' => $asset->provenance_json,
+            'materialized_type' => $asset->materialized_type,
+            'materialized_id' => $asset->materialized_id,
+            'materialized_at' => $asset->materialized_at?->toIso8601String(),
+            'reviewed_by' => $asset->reviewed_by,
+            'reviewed_at' => $asset->reviewed_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return array<string, mixed>
+     */
+    private function issue(string $code, string $message, array $meta = []): array
+    {
+        return [
+            'code' => $code,
+            'message' => $message,
+            'meta' => $meta,
+        ];
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyDesignReadinessService.php
+++ b/backend/app/Services/StudyDesign/StudyDesignReadinessService.php
@@ -22,13 +22,13 @@ class StudyDesignReadinessService
             ->get();
 
         $readyAssets = $cohortAssets->filter(fn (StudyDesignAsset $asset) => $asset->materialized_id !== null
-            && $this->verificationValue($asset) === StudyDesignVerificationStatus::Verified->value);
+            && $this->verificationValue($asset) === StudyDesignVerificationStatus::VERIFIED->value);
 
         return [
             'ready' => $readyAssets->isNotEmpty(),
             'cohort_asset_count' => $cohortAssets->count(),
             'materialized_verified_count' => $readyAssets->count(),
-            'blocked_count' => $cohortAssets->filter(fn (StudyDesignAsset $asset) => $this->verificationValue($asset) === StudyDesignVerificationStatus::Blocked->value)->count(),
+            'blocked_count' => $cohortAssets->filter(fn (StudyDesignAsset $asset) => $this->verificationValue($asset) === StudyDesignVerificationStatus::BLOCKED->value)->count(),
         ];
     }
 
@@ -40,10 +40,10 @@ class StudyDesignReadinessService
         $assets = $session->assets()->where('version_id', $version->id)->get();
         $cohortReadiness = $this->cohortReadiness($session, $version);
         $hasFeasibility = $assets->contains(fn (StudyDesignAsset $asset) => $asset->asset_type === 'feasibility_evidence'
-            && $this->verificationValue($asset) === StudyDesignVerificationStatus::Verified->value);
+            && $this->verificationValue($asset) === StudyDesignVerificationStatus::VERIFIED->value);
         $hasAnalysis = $assets->contains(fn (StudyDesignAsset $asset) => in_array($asset->asset_type, ['analysis_plan_draft', 'imported_study_analysis'], true)
             && $asset->materialized_id !== null
-            && $this->verificationValue($asset) === StudyDesignVerificationStatus::Verified->value);
+            && $this->verificationValue($asset) === StudyDesignVerificationStatus::VERIFIED->value);
         $blocking = [];
 
         if (! in_array($version->status, ['accepted', 'locked'], true)) {
@@ -78,7 +78,7 @@ class StudyDesignReadinessService
                 'accepted_at' => $version->accepted_at?->toISOString(),
                 'ai_events' => $session->aiEvents()->count(),
                 'reviewed_assets' => $assets->whereNotNull('reviewed_at')->count(),
-                'verified_assets' => $assets->filter(fn (StudyDesignAsset $asset) => $this->verificationValue($asset) === StudyDesignVerificationStatus::Verified->value)->count(),
+                'verified_assets' => $assets->filter(fn (StudyDesignAsset $asset) => $this->verificationValue($asset) === StudyDesignVerificationStatus::VERIFIED->value)->count(),
                 'package_manifest_sha256' => $version->provenance_json['package_manifest_sha256'] ?? null,
             ],
         ];

--- a/backend/app/Services/StudyDesign/StudyDesignSpecValidator.php
+++ b/backend/app/Services/StudyDesign/StudyDesignSpecValidator.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Models\App\Study;
+
+class StudyDesignSpecValidator
+{
+    /**
+     * @param  array<string, mixed>  $spec
+     * @return array{spec: array<string, mixed>, lint: array<string, mixed>}
+     */
+    public function normalize(array $spec, Study $study, string $researchQuestion): array
+    {
+        $normalized = [
+            'schema_version' => (string) ($spec['schema_version'] ?? '1.0'),
+            'study' => $this->normalizeStudy($spec['study'] ?? [], $study, $researchQuestion),
+            'pico' => $this->normalizePico($spec['pico'] ?? []),
+            'cohort_roles' => $this->listValue($spec['cohort_roles'] ?? []),
+            'concept_set_drafts' => $this->listValue($spec['concept_set_drafts'] ?? []),
+            'cohort_definition_drafts' => $this->listValue($spec['cohort_definition_drafts'] ?? []),
+            'analysis_plan' => $this->listValue($spec['analysis_plan'] ?? []),
+            'feasibility_plan' => $this->objectValue($spec['feasibility_plan'] ?? []),
+            'validation_plan' => $this->objectValue($spec['validation_plan'] ?? []),
+            'publication_plan' => $this->objectValue($spec['publication_plan'] ?? []),
+            'open_questions' => $this->listValue($spec['open_questions'] ?? []),
+            'provenance' => $this->objectValue($spec['provenance'] ?? []),
+        ];
+
+        $lint = $this->lint($normalized);
+
+        return [
+            'spec' => $normalized,
+            'lint' => $lint,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function fromAiPayload(array $payload, Study $study, string $researchQuestion, string $provider, ?string $model): array
+    {
+        $data = $this->unwrapPayload($payload);
+
+        $target = $this->stringValue($data['target_population'] ?? $data['target_statement'] ?? $data['target'] ?? null);
+        $outcome = $this->stringValue($data['outcome'] ?? $data['outcome_statement'] ?? null);
+        $comparator = $this->stringValue($data['comparator'] ?? $data['comparator_statement'] ?? null);
+        $exposure = $this->stringValue($data['exposure'] ?? $data['intervention'] ?? $data['intervention_or_exposure'] ?? null);
+        $time = $this->stringValue($data['time'] ?? $data['time_horizon'] ?? $data['time_at_risk'] ?? null);
+        $objective = $this->stringValue($data['primary_objective'] ?? $data['objective'] ?? null);
+        $hypothesis = $this->stringValue($data['hypothesis'] ?? null);
+        $rationale = $this->stringValue($data['rationale'] ?? $data['scientific_rationale'] ?? null);
+
+        $spec = [
+            'schema_version' => '1.0',
+            'study' => [
+                'title' => $study->title,
+                'short_title' => $study->short_title,
+                'research_question' => $researchQuestion,
+                'scientific_rationale' => $rationale,
+                'hypothesis' => $hypothesis,
+                'primary_objective' => $objective !== '' ? $objective : $researchQuestion,
+                'secondary_objectives' => $this->listValue($data['secondary_objectives'] ?? []),
+                'study_design' => $this->stringValue($data['study_design'] ?? $study->study_design ?? 'observational'),
+                'study_type' => $this->stringValue($data['study_type'] ?? $study->study_type ?? 'custom'),
+                'target_population_summary' => $target,
+                'estimand' => $this->objectValue($data['estimand'] ?? []),
+            ],
+            'pico' => [
+                'population' => ['summary' => $target],
+                'intervention_or_exposure' => ['summary' => $exposure],
+                'comparator' => ['summary' => $comparator],
+                'outcomes' => $outcome !== '' ? [['summary' => $outcome, 'primary' => true]] : [],
+                'time' => ['summary' => $time],
+            ],
+            'cohort_roles' => [],
+            'concept_set_drafts' => [],
+            'cohort_definition_drafts' => [],
+            'analysis_plan' => [],
+            'feasibility_plan' => [],
+            'validation_plan' => [],
+            'publication_plan' => [],
+            'open_questions' => $this->normalizeOpenQuestions($data),
+            'provenance' => [
+                'source' => 'study_intent_service',
+                'provider' => $provider,
+                'model' => $model,
+                'generated_at' => now()->toIso8601String(),
+            ],
+        ];
+
+        return $this->normalize($spec, $study, $researchQuestion);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function unwrapPayload(mixed $payload): array
+    {
+        if (! is_array($payload)) {
+            return [];
+        }
+
+        $data = $payload['data'] ?? $payload['result'] ?? $payload['output'] ?? $payload;
+        if (is_array($data) && isset($data['data']) && is_array($data['data'])) {
+            $data = $data['data'];
+        }
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeStudy(mixed $studySpec, Study $study, string $researchQuestion): array
+    {
+        $studySpec = is_array($studySpec) ? $studySpec : [];
+
+        return [
+            'title' => $this->stringValue($studySpec['title'] ?? $study->title),
+            'short_title' => $studySpec['short_title'] ?? $study->short_title,
+            'research_question' => $this->stringValue($studySpec['research_question'] ?? $researchQuestion),
+            'scientific_rationale' => $this->stringValue($studySpec['scientific_rationale'] ?? ''),
+            'hypothesis' => $this->stringValue($studySpec['hypothesis'] ?? ''),
+            'primary_objective' => $this->stringValue($studySpec['primary_objective'] ?? $researchQuestion),
+            'secondary_objectives' => $this->listValue($studySpec['secondary_objectives'] ?? []),
+            'study_design' => $this->stringValue($studySpec['study_design'] ?? $study->study_design ?? 'observational'),
+            'study_type' => $this->stringValue($studySpec['study_type'] ?? $study->study_type ?? 'custom'),
+            'target_population_summary' => $this->stringValue($studySpec['target_population_summary'] ?? ''),
+            'estimand' => $this->objectValue($studySpec['estimand'] ?? []),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizePico(mixed $pico): array
+    {
+        $pico = is_array($pico) ? $pico : [];
+
+        return [
+            'population' => $this->objectWithSummary($pico['population'] ?? []),
+            'intervention_or_exposure' => $this->objectWithSummary($pico['intervention_or_exposure'] ?? $pico['intervention'] ?? []),
+            'comparator' => $this->objectWithSummary($pico['comparator'] ?? []),
+            'outcomes' => $this->normalizeOutcomes($pico['outcomes'] ?? []),
+            'time' => $this->objectWithSummary($pico['time'] ?? []),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function objectWithSummary(mixed $value): array
+    {
+        if (is_string($value)) {
+            return ['summary' => trim($value)];
+        }
+
+        $object = $this->objectValue($value);
+        $object['summary'] = $this->stringValue($object['summary'] ?? '');
+
+        return $object;
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function listValue(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values($value);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function objectValue(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_is_list($value) ? [] : $value;
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        return is_scalar($value) ? trim((string) $value) : '';
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function normalizeOutcomes(mixed $outcomes): array
+    {
+        if (is_string($outcomes)) {
+            return [['summary' => trim($outcomes), 'primary' => true]];
+        }
+
+        if (! is_array($outcomes)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach (array_values($outcomes) as $index => $outcome) {
+            $item = is_array($outcome) ? $outcome : ['summary' => $this->stringValue($outcome)];
+            $item['summary'] = $this->stringValue($item['summary'] ?? '');
+            $item['primary'] = (bool) ($item['primary'] ?? $index === 0);
+            $normalized[] = $item;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return list<array<string, mixed>>
+     */
+    private function normalizeOpenQuestions(array $data): array
+    {
+        $questions = $this->listValue($data['open_questions'] ?? $data['questions'] ?? []);
+
+        if ($questions === []) {
+            foreach (['target_population', 'exposure', 'comparator', 'outcome', 'time'] as $field) {
+                if ($this->stringValue($data[$field] ?? '') === '') {
+                    $questions[] = [
+                        'field' => $field,
+                        'question' => "Clarify the {$field} for this study.",
+                        'severity' => 'blocking',
+                    ];
+                }
+            }
+        }
+
+        return array_map(function (mixed $question): array {
+            if (is_string($question)) {
+                return ['question' => $question, 'severity' => 'review'];
+            }
+
+            return is_array($question) ? $question : ['question' => 'Clarify this study design assumption.', 'severity' => 'review'];
+        }, $questions);
+    }
+
+    /**
+     * @param  array<string, mixed>  $spec
+     * @return array<string, mixed>
+     */
+    private function lint(array $spec): array
+    {
+        $issues = [];
+        $pico = $spec['pico'];
+
+        foreach ([
+            'population' => 'Population',
+            'intervention_or_exposure' => 'Intervention or exposure',
+            'comparator' => 'Comparator',
+            'time' => 'Time frame',
+        ] as $key => $label) {
+            if ($this->stringValue($pico[$key]['summary'] ?? '') === '') {
+                $issues[] = [
+                    'severity' => $key === 'comparator' ? 'review' : 'blocking',
+                    'field' => "pico.{$key}",
+                    'message' => "{$label} is not yet specified.",
+                ];
+            }
+        }
+
+        if (($pico['outcomes'] ?? []) === []) {
+            $issues[] = [
+                'severity' => 'blocking',
+                'field' => 'pico.outcomes',
+                'message' => 'At least one outcome is required before cohort drafting.',
+            ];
+        }
+
+        return [
+            'status' => collect($issues)->contains(fn (array $issue) => $issue['severity'] === 'blocking') ? 'needs_review' : 'ready',
+            'issues' => $issues,
+        ];
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyFeasibilityService.php
+++ b/backend/app/Services/StudyDesign/StudyFeasibilityService.php
@@ -1,0 +1,675 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\DaimonType;
+use App\Enums\ExecutionStatus;
+use App\Enums\StudyDesignAssetStatus;
+use App\Enums\StudyDesignVerificationStatus;
+use App\Models\App\CohortGeneration;
+use App\Models\App\DqdResult;
+use App\Models\App\Source;
+use App\Models\App\SourceRelease;
+use App\Models\App\Study;
+use App\Models\App\StudyCohort;
+use App\Models\App\StudyDesignAsset;
+use App\Models\App\StudyDesignSession;
+use App\Models\App\StudyDesignVersion;
+use App\Models\Results\AchillesRun;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class StudyFeasibilityService
+{
+    private const CORE_COVERAGE_TABLES = [
+        'person',
+        'observation_period',
+        'condition_occurrence',
+        'drug_exposure',
+        'procedure_occurrence',
+        'measurement',
+        'observation',
+        'visit_occurrence',
+        'death',
+    ];
+
+    private const ROLE_DOMAIN_TABLES = [
+        'target' => ['condition_occurrence', 'drug_exposure', 'procedure_occurrence', 'observation', 'measurement'],
+        'comparator' => ['drug_exposure', 'procedure_occurrence', 'observation', 'measurement'],
+        'outcome' => ['condition_occurrence', 'measurement', 'procedure_occurrence', 'observation', 'death'],
+        'exclusion' => ['condition_occurrence', 'drug_exposure', 'procedure_occurrence', 'observation', 'measurement'],
+        'subgroup' => ['person', 'condition_occurrence', 'drug_exposure', 'procedure_occurrence', 'observation', 'measurement'],
+        'event' => ['condition_occurrence', 'drug_exposure', 'procedure_occurrence', 'observation', 'measurement'],
+    ];
+
+    /**
+     * @param  list<int>  $sourceIds
+     * @return array<string, mixed>
+     */
+    public function run(Study $study, StudyDesignSession $session, StudyDesignVersion $version, array $sourceIds, int $minCellCount = 5): array
+    {
+        $studyCohorts = $study->cohorts()
+            ->with('cohortDefinition')
+            ->orderBy('sort_order')
+            ->get()
+            ->map(function (StudyCohort $cohort): StudyCohort {
+                $cohort->role = $this->normalizeRole($cohort->role);
+
+                return $cohort;
+            });
+
+        $sources = Source::query()
+            ->with('daimons')
+            ->whereIn('id', $sourceIds)
+            ->orderBy('source_name')
+            ->get();
+
+        $blockers = [];
+        $warnings = [];
+        if ($studyCohorts->isEmpty()) {
+            $blockers[] = $this->issue('missing_study_cohorts', 'Link study cohorts before running source feasibility.');
+        }
+
+        $sourceResults = $sources
+            ->map(function (Source $source) use ($studyCohorts, $minCellCount): array {
+                return $this->sourceFeasibility($source, $studyCohorts, $minCellCount);
+            })
+            ->values()
+            ->all();
+
+        foreach ($sourceResults as $sourceResult) {
+            foreach ($sourceResult['blockers'] as $blocker) {
+                $blockers[] = [
+                    ...$blocker,
+                    'source_id' => $sourceResult['source_id'],
+                    'source_name' => $sourceResult['source_name'],
+                ];
+            }
+
+            foreach ($sourceResult['warnings'] as $warning) {
+                $warnings[] = [
+                    ...$warning,
+                    'source_id' => $sourceResult['source_id'],
+                    'source_name' => $sourceResult['source_name'],
+                ];
+            }
+        }
+
+        $readySources = collect($sourceResults)
+            ->filter(fn (array $sourceResult): bool => $sourceResult['ready_for_analysis'] === true)
+            ->count();
+        $status = $blockers === [] ? 'ready' : ($readySources > 0 ? 'limited' : 'blocked');
+
+        $result = [
+            'status' => $status,
+            'ready_for_analysis' => $status === 'ready',
+            'ready_source_count' => $readySources,
+            'source_count' => $sources->count(),
+            'min_cell_count' => $minCellCount,
+            'ran_at' => now()->toIso8601String(),
+            'required_roles' => $studyCohorts->pluck('role')->unique()->values()->all(),
+            'sources' => $sourceResults,
+            'blockers' => $blockers,
+            'warnings' => $warnings,
+            'policy' => 'Feasibility is source-specific and requires completed cohort generations for linked study cohorts before analysis planning.',
+        ];
+
+        $asset = $this->storeEvidenceAsset($session, $version, $result, $studyCohorts, $sources, $minCellCount);
+        $version->update(['feasibility_summary_json' => $result]);
+
+        return [
+            'result' => $result,
+            'asset' => $asset->fresh('reviewer:id,name,email') ?? $asset,
+        ];
+    }
+
+    /**
+     * @param  Collection<int, StudyCohort>  $studyCohorts
+     * @return array<string, mixed>
+     */
+    private function sourceFeasibility(Source $source, Collection $studyCohorts, int $minCellCount): array
+    {
+        $sourceBlockers = [];
+        $sourceWarnings = [];
+        $cohortSummaries = $studyCohorts
+            ->map(function (StudyCohort $studyCohort) use ($source, $minCellCount, &$sourceBlockers, &$sourceWarnings): array {
+                $generation = $this->latestGeneration($studyCohort, $source);
+                $count = $generation?->person_count;
+                $generationStatus = $generation?->status?->value;
+
+                if (! $generation instanceof CohortGeneration) {
+                    $sourceBlockers[] = $this->issue('missing_cohort_generation', 'Generate this cohort on the selected source before analysis planning.', [
+                        'role' => $studyCohort->role,
+                        'study_cohort_id' => $studyCohort->id,
+                        'cohort_definition_id' => $studyCohort->cohort_definition_id,
+                    ]);
+                } elseif ($generation->status !== ExecutionStatus::Completed) {
+                    $sourceBlockers[] = $this->issue('incomplete_cohort_generation', 'Cohort generation is not completed on this source.', [
+                        'role' => $studyCohort->role,
+                        'study_cohort_id' => $studyCohort->id,
+                        'generation_id' => $generation->id,
+                        'status' => $generationStatus,
+                    ]);
+                } elseif ((int) $count === 0) {
+                    $sourceBlockers[] = $this->issue('empty_required_cohort', 'A linked study cohort generated zero people on this source.', [
+                        'role' => $studyCohort->role,
+                        'study_cohort_id' => $studyCohort->id,
+                        'generation_id' => $generation->id,
+                    ]);
+                } elseif ((int) $count < $minCellCount) {
+                    $sourceWarnings[] = $this->issue('small_required_cohort', 'A linked study cohort is below the small-cell threshold on this source.', [
+                        'role' => $studyCohort->role,
+                        'study_cohort_id' => $studyCohort->id,
+                        'generation_id' => $generation->id,
+                    ]);
+                }
+
+                return [
+                    'study_cohort_id' => $studyCohort->id,
+                    'role' => $studyCohort->role,
+                    'label' => $studyCohort->label,
+                    'cohort_definition_id' => $studyCohort->cohort_definition_id,
+                    'cohort_definition_name' => $studyCohort->cohortDefinition?->name,
+                    'generation_id' => $generation?->id,
+                    'generation_status' => $generationStatus,
+                    'generated_at' => $generation?->completed_at?->toIso8601String(),
+                    'person_count' => $this->disclosedCount($count, $minCellCount),
+                    'person_count_suppressed' => $this->isSuppressed($count, $minCellCount),
+                    'has_completed_generation' => $generation?->status === ExecutionStatus::Completed,
+                    'attrition' => $this->attritionSummary($generation, $count, $minCellCount),
+                ];
+            })
+            ->values()
+            ->all();
+
+        $overlap = $this->overlapMatrix($source, $studyCohorts, $minCellCount, $sourceWarnings);
+        $sourceQuality = $this->sourceQuality($source);
+        $coverage = $this->sourceCoverage($source);
+        $domainAvailability = $this->domainAvailability($studyCohorts, $coverage);
+        $personCount = $coverage['table_counts']['person']['count'] ?? null;
+        $observationPeriodCount = $coverage['observation_period']['record_count'] ?? null;
+
+        if (($coverage['cdm_schema'] ?? null) === null) {
+            $sourceBlockers[] = $this->issue('missing_cdm_daimon', 'This source does not declare a CDM schema for feasibility checks.');
+        }
+
+        if ($personCount === null) {
+            $sourceBlockers[] = $this->issue('person_records_unavailable', 'Person record availability could not be verified for this source.');
+        } elseif ($personCount === 0) {
+            $sourceBlockers[] = $this->issue('missing_person_records', 'This source has no person records available for feasibility checks.');
+        }
+
+        if ($observationPeriodCount === null) {
+            $sourceBlockers[] = $this->issue('observation_periods_unavailable', 'Observation period availability could not be verified for this source.');
+        } elseif ($observationPeriodCount === 0) {
+            $sourceBlockers[] = $this->issue('missing_observation_periods', 'This source has no observation periods available for longitudinal study design.');
+        }
+
+        if (($coverage['date_coverage']['start_date'] ?? null) === null || ($coverage['date_coverage']['end_date'] ?? null) === null) {
+            $sourceWarnings[] = $this->issue('date_coverage_unavailable', 'Observation-period date coverage could not be established for this source.');
+        }
+
+        $freshnessStatus = (string) ($coverage['freshness']['status'] ?? 'unknown');
+        if ($freshnessStatus === 'unknown') {
+            $sourceWarnings[] = $this->issue('source_freshness_unknown', 'No source release metadata is available to verify data freshness.');
+        } elseif ($freshnessStatus === 'stale') {
+            $sourceWarnings[] = $this->issue('source_freshness_stale', 'The latest source release metadata is more than one year old.', [
+                'latest_release_at' => $coverage['freshness']['latest_release_at'] ?? null,
+                'days_since_release' => $coverage['freshness']['days_since_release'] ?? null,
+            ]);
+        }
+
+        $missingDomains = collect($domainAvailability['roles'] ?? [])
+            ->filter(fn (array $roleAvailability): bool => ($roleAvailability['available'] ?? false) === false)
+            ->values();
+        foreach ($missingDomains as $missingDomain) {
+            $sourceWarnings[] = $this->issue('missing_required_domain_records', 'A linked study cohort role has no records in its expected CDM domains on this source.', [
+                'role' => $missingDomain['role'] ?? null,
+                'required_tables' => $missingDomain['required_tables'] ?? [],
+            ]);
+        }
+
+        $missingConceptTrace = $studyCohorts
+            ->filter(fn (StudyCohort $cohort): bool => empty($cohort->concept_set_ids))
+            ->values();
+        foreach ($missingConceptTrace as $cohort) {
+            $sourceWarnings[] = $this->issue('missing_concept_traceability', 'A linked study cohort does not preserve concept set traceability for source diagnostics.', [
+                'role' => $cohort->role,
+                'study_cohort_id' => $cohort->id,
+                'cohort_definition_id' => $cohort->cohort_definition_id,
+            ]);
+        }
+
+        if (($sourceQuality['dqd']['failed_checks'] ?? 0) > 0) {
+            $sourceWarnings[] = $this->issue('dqd_failed_checks', 'Data Quality Dashboard checks failed for this source.', [
+                'failed_checks' => $sourceQuality['dqd']['failed_checks'],
+                'severe_failed_checks' => $sourceQuality['dqd']['severe_failed_checks'],
+            ]);
+        }
+
+        return [
+            'source_id' => $source->id,
+            'source_name' => $source->source_name,
+            'source_key' => $source->source_key,
+            'source_dialect' => $source->source_dialect,
+            'ready_for_analysis' => $sourceBlockers === [],
+            'cohorts' => $cohortSummaries,
+            'overlap_matrix' => $overlap,
+            'coverage' => $coverage,
+            'domain_availability' => $domainAvailability,
+            'source_quality' => $sourceQuality,
+            'blockers' => $sourceBlockers,
+            'warnings' => $sourceWarnings,
+        ];
+    }
+
+    private function latestGeneration(StudyCohort $studyCohort, Source $source): ?CohortGeneration
+    {
+        $completed = CohortGeneration::query()
+            ->where('cohort_definition_id', $studyCohort->cohort_definition_id)
+            ->where('source_id', $source->id)
+            ->where('status', ExecutionStatus::Completed->value)
+            ->orderByDesc('completed_at')
+            ->orderByDesc('id')
+            ->first();
+
+        if ($completed instanceof CohortGeneration) {
+            return $completed;
+        }
+
+        return CohortGeneration::query()
+            ->where('cohort_definition_id', $studyCohort->cohort_definition_id)
+            ->where('source_id', $source->id)
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->first();
+    }
+
+    /**
+     * @param  Collection<int, StudyCohort>  $studyCohorts
+     * @param  list<array<string, mixed>>  $sourceWarnings
+     * @return array<string, mixed>
+     */
+    private function overlapMatrix(Source $source, Collection $studyCohorts, int $minCellCount, array &$sourceWarnings): array
+    {
+        $resultsSchema = $source->getTableQualifier(DaimonType::Results);
+        if ($resultsSchema === null || $studyCohorts->count() < 2) {
+            return ['status' => 'unavailable', 'pairs' => []];
+        }
+
+        try {
+            $connectionName = $source->source_connection ?? 'omop';
+            $pairs = [];
+            $cohorts = $studyCohorts->values();
+
+            for ($leftIndex = 0; $leftIndex < $cohorts->count(); $leftIndex++) {
+                for ($rightIndex = $leftIndex + 1; $rightIndex < $cohorts->count(); $rightIndex++) {
+                    /** @var StudyCohort $left */
+                    $left = $cohorts[$leftIndex];
+                    /** @var StudyCohort $right */
+                    $right = $cohorts[$rightIndex];
+                    $count = DB::connection($connectionName)
+                        ->table("{$resultsSchema}.cohort as left_cohort")
+                        ->join("{$resultsSchema}.cohort as right_cohort", 'left_cohort.subject_id', '=', 'right_cohort.subject_id')
+                        ->where('left_cohort.cohort_definition_id', $left->cohort_definition_id)
+                        ->where('right_cohort.cohort_definition_id', $right->cohort_definition_id)
+                        ->distinct()
+                        ->count('left_cohort.subject_id');
+
+                    $pairs[] = [
+                        'left_role' => $left->role,
+                        'right_role' => $right->role,
+                        'left_cohort_definition_id' => $left->cohort_definition_id,
+                        'right_cohort_definition_id' => $right->cohort_definition_id,
+                        'person_count' => $this->disclosedCount($count, $minCellCount),
+                        'person_count_suppressed' => $this->isSuppressed($count, $minCellCount),
+                    ];
+                }
+            }
+
+            return ['status' => 'available', 'pairs' => $pairs];
+        } catch (\Throwable $e) {
+            $sourceWarnings[] = $this->issue('overlap_unavailable', 'Overlap matrix could not be computed from the source results cohort table.', [
+                'error' => Str::limit($e->getMessage(), 240),
+            ]);
+
+            return ['status' => 'unavailable', 'pairs' => []];
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sourceQuality(Source $source): array
+    {
+        $dqdTotal = DqdResult::query()->where('source_id', $source->id)->count();
+        $dqdFailed = DqdResult::query()->where('source_id', $source->id)->where('passed', false)->count();
+        $severeFailed = DqdResult::query()
+            ->where('source_id', $source->id)
+            ->where('passed', false)
+            ->whereIn('severity', ['error', 'fatal'])
+            ->count();
+        $topFailures = DqdResult::query()
+            ->where('source_id', $source->id)
+            ->where('passed', false)
+            ->orderByDesc('violated_rows')
+            ->limit(5)
+            ->get(['check_id', 'category', 'cdm_table', 'severity', 'violated_rows', 'total_rows', 'description'])
+            ->map(fn (DqdResult $result): array => [
+                'check_id' => $result->check_id,
+                'category' => $result->category,
+                'cdm_table' => $result->cdm_table,
+                'severity' => $result->severity,
+                'violated_rows' => $result->violated_rows,
+                'total_rows' => $result->total_rows,
+                'description' => $result->description,
+            ])
+            ->all();
+
+        $latestAchilles = AchillesRun::query()
+            ->where('source_id', $source->id)
+            ->orderByDesc('completed_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        return [
+            'dqd' => [
+                'total_checks' => $dqdTotal,
+                'failed_checks' => $dqdFailed,
+                'severe_failed_checks' => $severeFailed,
+                'pass_rate' => $dqdTotal > 0 ? round((($dqdTotal - $dqdFailed) / $dqdTotal) * 100, 2) : null,
+                'top_failures' => $topFailures,
+            ],
+            'achilles' => [
+                'run_id' => $latestAchilles?->run_id,
+                'status' => $latestAchilles?->status,
+                'completed_at' => $latestAchilles?->completed_at?->toIso8601String(),
+                'completed_analyses' => $latestAchilles?->completed_analyses,
+                'failed_analyses' => $latestAchilles?->failed_analyses,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sourceCoverage(Source $source): array
+    {
+        $cdmSchema = $source->getTableQualifier(DaimonType::CDM);
+        $connectionName = $source->source_connection ?? 'omop';
+        $tableCounts = [];
+
+        foreach (self::CORE_COVERAGE_TABLES as $tableName) {
+            $count = null;
+            $status = 'unavailable';
+
+            if ($cdmSchema !== null) {
+                try {
+                    $count = DB::connection($connectionName)
+                        ->table("{$cdmSchema}.{$tableName}")
+                        ->count();
+                    $status = 'available';
+                } catch (\Throwable) {
+                    $count = null;
+                }
+            }
+
+            $tableCounts[$tableName] = [
+                'table' => $tableName,
+                'status' => $status,
+                'count' => is_numeric($count) ? (int) $count : null,
+            ];
+        }
+
+        $observationPeriod = [
+            'status' => 'unavailable',
+            'record_count' => null,
+            'person_count' => null,
+        ];
+        $dateCoverage = [
+            'status' => 'unavailable',
+            'start_date' => null,
+            'end_date' => null,
+        ];
+
+        if ($cdmSchema !== null) {
+            try {
+                $row = DB::connection($connectionName)
+                    ->table("{$cdmSchema}.observation_period")
+                    ->selectRaw('COUNT(*) AS record_count, COUNT(DISTINCT person_id) AS person_count, MIN(observation_period_start_date) AS start_date, MAX(observation_period_end_date) AS end_date')
+                    ->first();
+
+                $recordCount = (int) ($row->record_count ?? 0);
+                $personCount = (int) ($row->person_count ?? 0);
+                $startDate = $this->dateString($row->start_date ?? null);
+                $endDate = $this->dateString($row->end_date ?? null);
+
+                $observationPeriod = [
+                    'status' => 'available',
+                    'record_count' => $recordCount,
+                    'person_count' => $personCount,
+                ];
+                $dateCoverage = [
+                    'status' => $startDate !== null && $endDate !== null ? 'available' : 'unavailable',
+                    'start_date' => $startDate,
+                    'end_date' => $endDate,
+                ];
+            } catch (\Throwable) {
+                // Table counts already capture the unavailable state.
+            }
+        }
+
+        $latestRelease = SourceRelease::query()
+            ->where('source_id', $source->id)
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->first();
+        $daysSinceRelease = $latestRelease?->created_at === null
+            ? null
+            : (int) $latestRelease->created_at->diffInDays(now());
+
+        return [
+            'cdm_schema' => $cdmSchema,
+            'table_counts' => $tableCounts,
+            'observation_period' => $observationPeriod,
+            'date_coverage' => $dateCoverage,
+            'freshness' => [
+                'status' => $latestRelease === null ? 'unknown' : ($daysSinceRelease !== null && $daysSinceRelease > 365 ? 'stale' : 'current'),
+                'latest_release_id' => $latestRelease?->id,
+                'latest_release_key' => $latestRelease?->release_key,
+                'latest_release_name' => $latestRelease?->release_name,
+                'latest_release_at' => $latestRelease?->created_at?->toIso8601String(),
+                'days_since_release' => $daysSinceRelease,
+                'cdm_version' => $latestRelease?->cdm_version,
+                'vocabulary_version' => $latestRelease?->vocabulary_version,
+                'person_count' => $latestRelease?->person_count,
+                'record_count' => $latestRelease?->record_count,
+            ],
+        ];
+    }
+
+    /**
+     * @param  Collection<int, StudyCohort>  $studyCohorts
+     * @param  array<string, mixed>  $coverage
+     * @return array<string, mixed>
+     */
+    private function domainAvailability(Collection $studyCohorts, array $coverage): array
+    {
+        $tableCounts = $coverage['table_counts'] ?? [];
+        $roles = $studyCohorts
+            ->map(function (StudyCohort $cohort) use ($tableCounts): array {
+                $role = $this->normalizeRole($cohort->role);
+                $requiredTables = self::ROLE_DOMAIN_TABLES[$role] ?? self::ROLE_DOMAIN_TABLES['target'];
+                $availableTables = collect($requiredTables)
+                    ->filter(function (string $tableName) use ($tableCounts): bool {
+                        $count = $tableCounts[$tableName]['count'] ?? null;
+
+                        return is_numeric($count) && (int) $count > 0;
+                    })
+                    ->values()
+                    ->all();
+
+                return [
+                    'role' => $role,
+                    'study_cohort_id' => $cohort->id,
+                    'cohort_definition_id' => $cohort->cohort_definition_id,
+                    'required_tables' => $requiredTables,
+                    'available_tables' => $availableTables,
+                    'available' => $availableTables !== [],
+                ];
+            })
+            ->values()
+            ->all();
+
+        return [
+            'roles' => $roles,
+            'available_role_count' => collect($roles)->where('available', true)->count(),
+            'role_count' => count($roles),
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function attritionSummary(?CohortGeneration $generation, mixed $finalCount, int $minCellCount): array
+    {
+        if (! $generation instanceof CohortGeneration) {
+            return [];
+        }
+
+        $rawSteps = $generation->getAttribute('inclusion_rule_stats');
+        if (! is_array($rawSteps) || $rawSteps === []) {
+            return [[
+                'name' => 'Generated cohort',
+                'person_count' => $this->disclosedCount($finalCount, $minCellCount),
+                'person_count_suppressed' => $this->isSuppressed($finalCount, $minCellCount),
+                'person_percent' => null,
+                'source' => 'cohort_generation',
+            ]];
+        }
+
+        return collect($rawSteps)
+            ->map(function (mixed $step, int $index) use ($minCellCount): array {
+                $stepArray = is_array($step) ? $step : [];
+                $count = $stepArray['person_count']
+                    ?? $stepArray['persons']
+                    ?? $stepArray['count']
+                    ?? $stepArray['remaining']
+                    ?? null;
+
+                return [
+                    'name' => (string) ($stepArray['name'] ?? $stepArray['rule_name'] ?? 'Inclusion rule '.($index + 1)),
+                    'person_count' => $this->disclosedCount($count, $minCellCount),
+                    'person_count_suppressed' => $this->isSuppressed($count, $minCellCount),
+                    'person_percent' => is_numeric($stepArray['person_percent'] ?? null) ? (float) $stepArray['person_percent'] : null,
+                    'source' => 'inclusion_rule_stats',
+                ];
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @param  Collection<int, StudyCohort>  $studyCohorts
+     * @param  Collection<int, Source>  $sources
+     */
+    private function storeEvidenceAsset(
+        StudyDesignSession $session,
+        StudyDesignVersion $version,
+        array $result,
+        Collection $studyCohorts,
+        Collection $sources,
+        int $minCellCount,
+    ): StudyDesignAsset {
+        return StudyDesignAsset::create([
+            'session_id' => $session->id,
+            'version_id' => $version->id,
+            'asset_type' => 'feasibility_result',
+            'role' => null,
+            'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+            'draft_payload_json' => $result,
+            'provenance_json' => [
+                'source' => 'study_designer_feasibility',
+                'source_ids' => $sources->pluck('id')->values()->all(),
+                'study_cohort_ids' => $studyCohorts->pluck('id')->values()->all(),
+                'cohort_definition_ids' => $studyCohorts->pluck('cohort_definition_id')->values()->all(),
+                'min_cell_count' => $minCellCount,
+            ],
+            'verification_status' => $result['status'] === 'ready'
+                ? StudyDesignVerificationStatus::VERIFIED->value
+                : StudyDesignVerificationStatus::BLOCKED->value,
+            'verification_json' => [
+                'status' => $result['status'] === 'ready'
+                    ? StudyDesignVerificationStatus::VERIFIED->value
+                    : StudyDesignVerificationStatus::BLOCKED->value,
+                'eligibility' => [
+                    'can_accept' => $result['status'] === 'ready',
+                    'can_materialize' => false,
+                    'reason' => $result['status'] === 'ready'
+                        ? 'Feasibility evidence is sufficient for analysis planning.'
+                        : 'Resolve source feasibility blockers before analysis planning.',
+                ],
+                'blocking_reasons' => collect($result['blockers'])->pluck('message')->values()->all(),
+                'warnings' => collect($result['warnings'])->pluck('message')->values()->all(),
+                'checks' => [],
+                'source_summary' => [
+                    'source' => 'study_designer_feasibility',
+                    'retrieved_at' => $result['ran_at'],
+                ],
+                'canonical_summary' => null,
+                'accepted_downstream_actions' => $result['status'] === 'ready' ? ['analysis_plan_generation'] : ['defer'],
+                'acceptance_policy' => 'Only source-specific feasibility without blockers may move to analysis planning.',
+            ],
+            'verified_at' => now(),
+        ]);
+    }
+
+    private function disclosedCount(mixed $count, int $minCellCount): ?int
+    {
+        if (! is_numeric($count)) {
+            return null;
+        }
+
+        $integerCount = (int) $count;
+
+        return $this->isSuppressed($integerCount, $minCellCount) ? null : $integerCount;
+    }
+
+    private function isSuppressed(mixed $count, int $minCellCount): bool
+    {
+        return is_numeric($count) && (int) $count > 0 && (int) $count < $minCellCount;
+    }
+
+    private function dateString(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return substr((string) $value, 0, 10);
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return array<string, mixed>
+     */
+    private function issue(string $code, string $message, array $meta = []): array
+    {
+        return [
+            'code' => $code,
+            'message' => $message,
+            'meta' => $meta,
+        ];
+    }
+
+    private function normalizeRole(string $role): string
+    {
+        return match (trim(strtolower($role))) {
+            'population', 'exposure', 'intervention' => 'target',
+            'comparator', 'outcome', 'exclusion', 'subgroup', 'event' => trim(strtolower($role)),
+            default => 'target',
+        };
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyIntentService.php
+++ b/backend/app/Services/StudyDesign/StudyIntentService.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Models\App\Study;
+use App\Models\App\StudyDesignAiEvent;
+use App\Models\App\StudyDesignSession;
+use App\Models\App\StudyDesignVersion;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+
+class StudyIntentService
+{
+    public function __construct(
+        private readonly StudyDesignSpecValidator $validator,
+    ) {}
+
+    public function generate(Study $study, StudyDesignSession $session, string $researchQuestion, int $userId): StudyDesignVersion
+    {
+        $started = microtime(true);
+        $provider = 'study-agent';
+        $model = null;
+        $aiPayload = [];
+        $safetyFlags = [];
+
+        try {
+            $aiPayload = $this->callStudyAgent($researchQuestion);
+        } catch (\Throwable $studyAgentException) {
+            $safetyFlags[] = [
+                'type' => 'provider_fallback',
+                'message' => 'StudyAgent intent split failed; attempting Anthropic fallback if configured.',
+            ];
+
+            try {
+                $provider = 'anthropic';
+                $model = (string) config('services.anthropic.model');
+                $aiPayload = $this->callAnthropic($study, $researchQuestion);
+            } catch (\Throwable $anthropicException) {
+                Log::warning('Study intent generation failed', [
+                    'study_id' => $study->id,
+                    'session_id' => $session->id,
+                    'study_agent_error' => $studyAgentException->getMessage(),
+                    'anthropic_error' => $anthropicException->getMessage(),
+                ]);
+
+                throw new RuntimeException('Unable to generate study intent. StudyAgent was unavailable and Anthropic fallback was not configured or failed.');
+            }
+        }
+
+        $normalized = $this->validator->fromAiPayload($aiPayload, $study, $researchQuestion, $provider, $model);
+        $latencyMs = (int) round((microtime(true) - $started) * 1000);
+
+        return DB::transaction(function () use ($session, $userId, $normalized, $aiPayload, $researchQuestion, $provider, $model, $latencyMs, $safetyFlags): StudyDesignVersion {
+            $versionNumber = ((int) $session->versions()->max('version_number')) + 1;
+            $status = ($normalized['lint']['status'] ?? 'needs_review') === 'ready' ? 'review_ready' : 'draft';
+
+            /** @var StudyDesignVersion $version */
+            $version = $session->versions()->create([
+                'version_number' => $versionNumber,
+                'status' => $status,
+                'spec_json' => $normalized['spec'],
+                'normalized_spec_json' => $normalized['spec'],
+                'lint_results_json' => $normalized['lint'],
+                'ai_model_metadata_json' => [
+                    'provider' => $provider,
+                    'model' => $model,
+                    'prompt_template_version' => 'study-intent-v1',
+                ],
+                'created_by' => $userId,
+            ]);
+
+            $session->update([
+                'active_version_id' => $version->id,
+                'status' => 'reviewing',
+            ]);
+
+            StudyDesignAiEvent::create([
+                'session_id' => $session->id,
+                'version_id' => $version->id,
+                'created_by' => $userId,
+                'event_type' => 'intent_extract',
+                'provider' => $provider,
+                'model' => $model,
+                'prompt_template_version' => 'study-intent-v1',
+                'input_summary_json' => [
+                    'research_question_length' => strlen($researchQuestion),
+                    'research_question_hash' => hash('sha256', $researchQuestion),
+                ],
+                'output_json' => [
+                    'raw' => $aiPayload,
+                    'normalized' => $normalized['spec'],
+                    'lint' => $normalized['lint'],
+                ],
+                'safety_flags_json' => $safetyFlags,
+                'latency_ms' => $latencyMs,
+            ]);
+
+            return $version->fresh(['creator', 'aiEvents']);
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function callStudyAgent(string $researchQuestion): array
+    {
+        $baseUrl = rtrim((string) config('services.ai.url', 'http://python-ai:8000'), '/');
+        $response = Http::timeout(60)->post("{$baseUrl}/study-agent/intent/split", [
+            'intent' => $researchQuestion,
+        ]);
+
+        if ($response->failed()) {
+            throw new RuntimeException('StudyAgent returned HTTP '.$response->status());
+        }
+
+        $json = $response->json();
+
+        return is_array($json) ? $json : [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function callAnthropic(Study $study, string $researchQuestion): array
+    {
+        $apiKey = (string) config('services.anthropic.key');
+        if ($apiKey === '') {
+            throw new RuntimeException('Anthropic API key is not configured.');
+        }
+
+        $model = (string) config('services.anthropic.model', 'claude-sonnet-4-6');
+        $timeout = (int) config('services.anthropic.timeout', 60);
+
+        $system = <<<'PROMPT'
+You extract OHDSI observational study intent. Return only compact JSON with these keys:
+target_population, exposure, comparator, outcome, time, study_type, study_design, primary_objective, hypothesis, scientific_rationale, open_questions.
+Use empty strings for missing fields and open_questions for ambiguity. Do not invent OMOP concept IDs.
+PROMPT;
+
+        $response = Http::timeout($timeout)
+            ->withHeaders([
+                'x-api-key' => $apiKey,
+                'anthropic-version' => '2023-06-01',
+                'content-type' => 'application/json',
+            ])
+            ->post('https://api.anthropic.com/v1/messages', [
+                'model' => $model,
+                'max_tokens' => 1200,
+                'system' => $system,
+                'messages' => [
+                    [
+                        'role' => 'user',
+                        'content' => json_encode([
+                            'study_title' => $study->title,
+                            'current_study_type' => $study->study_type,
+                            'research_question' => $researchQuestion,
+                        ], JSON_THROW_ON_ERROR),
+                    ],
+                ],
+            ]);
+
+        if ($response->failed()) {
+            throw new RuntimeException('Anthropic returned HTTP '.$response->status());
+        }
+
+        $content = $response->json('content.0.text');
+        if (! is_string($content)) {
+            throw new RuntimeException('Anthropic response did not contain text content.');
+        }
+
+        $decoded = json_decode($content, true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Anthropic response was not valid JSON.');
+        }
+
+        return $decoded;
+    }
+}

--- a/backend/app/Services/StudyDesign/StudyPhenotypeRecommendationService.php
+++ b/backend/app/Services/StudyDesign/StudyPhenotypeRecommendationService.php
@@ -1,0 +1,415 @@
+<?php
+
+namespace App\Services\StudyDesign;
+
+use App\Enums\StudyDesignAssetStatus;
+use App\Enums\StudyDesignVerificationStatus;
+use App\Models\App\CohortDefinition;
+use App\Models\App\ConceptSet;
+use App\Models\App\PhenotypeLibraryEntry;
+use App\Models\App\StudyDesignAiEvent;
+use App\Models\App\StudyDesignAsset;
+use App\Models\App\StudyDesignSession;
+use App\Models\App\StudyDesignVersion;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class StudyPhenotypeRecommendationService
+{
+    public function __construct(
+        private readonly StudyDesignAssetVerificationService $verifier,
+    ) {}
+
+    /**
+     * @return Collection<int, StudyDesignAsset>
+     */
+    public function recommend(StudyDesignSession $session, StudyDesignVersion $version, int $userId): Collection
+    {
+        $spec = $version->normalized_spec_json ?? $version->spec_json ?? [];
+        $terms = $this->queryTerms($spec);
+        $started = microtime(true);
+        $remote = $this->studyAgentRecommendations($spec, $terms);
+
+        $recommendations = collect()
+            ->merge($remote)
+            ->merge($this->phenotypeLibraryRecommendations($terms))
+            ->merge($this->localCohortRecommendations($terms))
+            ->merge($this->localConceptSetRecommendations($terms))
+            ->unique(fn (array $item) => ($item['asset_type'] ?? '').':'.($item['canonical_type'] ?? '').':'.($item['canonical_id'] ?? '').':'.($item['payload']['external_id'] ?? ''))
+            ->sortByDesc(fn (array $item) => $this->preRankRecommendation($item))
+            ->take(12)
+            ->values();
+
+        return DB::transaction(function () use ($session, $version, $userId, $recommendations, $terms, $remote, $started): Collection {
+            $session->assets()
+                ->where('version_id', $version->id)
+                ->whereIn('asset_type', ['phenotype_recommendation', 'local_cohort', 'local_concept_set'])
+                ->where('status', StudyDesignAssetStatus::NEEDS_REVIEW->value)
+                ->delete();
+
+            $assets = $recommendations->map(function (array $item) use ($session, $version): StudyDesignAsset {
+                $asset = StudyDesignAsset::create([
+                    'session_id' => $session->id,
+                    'version_id' => $version->id,
+                    'asset_type' => $item['asset_type'],
+                    'role' => $item['role'] ?? null,
+                    'status' => StudyDesignAssetStatus::NEEDS_REVIEW->value,
+                    'draft_payload_json' => $item['payload'],
+                    'canonical_type' => $item['canonical_type'] ?? null,
+                    'canonical_id' => $item['canonical_id'] ?? null,
+                    'provenance_json' => $item['provenance'] ?? [],
+                ]);
+
+                $verified = $this->verifier->verify($asset);
+                $rank = $this->rankAsset($verified, $item);
+                $verified->update([
+                    'rank_score' => $rank['score'],
+                    'rank_score_json' => $rank,
+                ]);
+
+                return $verified->fresh() ?? $verified;
+            })->sortByDesc('rank_score')->values();
+
+            StudyDesignAiEvent::create([
+                'session_id' => $session->id,
+                'version_id' => $version->id,
+                'created_by' => $userId,
+                'event_type' => 'phenotype_recommend',
+                'provider' => 'study-agent',
+                'model' => null,
+                'prompt_template_version' => 'phenotype-recommend-v1',
+                'input_summary_json' => [
+                    'terms' => $terms,
+                    'spec_hash' => hash('sha256', json_encode($version->normalized_spec_json ?? $version->spec_json)),
+                ],
+                'output_json' => [
+                    'remote_count' => count($remote),
+                    'recommendation_count' => $assets->count(),
+                ],
+                'safety_flags_json' => [],
+                'latency_ms' => (int) round((microtime(true) - $started) * 1000),
+            ]);
+
+            return $assets->values();
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $spec
+     * @return list<string>
+     */
+    private function queryTerms(array $spec): array
+    {
+        $values = [
+            data_get($spec, 'study.research_question'),
+            data_get($spec, 'study.primary_objective'),
+            data_get($spec, 'study.target_population_summary'),
+            data_get($spec, 'pico.population.summary'),
+            data_get($spec, 'pico.intervention_or_exposure.summary'),
+            data_get($spec, 'pico.comparator.summary'),
+            data_get($spec, 'pico.time.summary'),
+        ];
+
+        foreach ((array) data_get($spec, 'pico.outcomes', []) as $outcome) {
+            $values[] = is_array($outcome) ? ($outcome['summary'] ?? null) : $outcome;
+        }
+
+        return collect($values)
+            ->filter(fn (mixed $value) => is_string($value) && trim($value) !== '')
+            ->map(fn (string $value) => trim($value))
+            ->unique()
+            ->take(8)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $spec
+     * @param  list<string>  $terms
+     * @return list<array<string, mixed>>
+     */
+    private function studyAgentRecommendations(array $spec, array $terms): array
+    {
+        if ($terms === []) {
+            return [];
+        }
+
+        try {
+            $baseUrl = rtrim((string) config('services.ai.url', 'http://python-ai:8000'), '/');
+            $response = Http::timeout(120)->post("{$baseUrl}/study-agent/recommend-phenotypes", [
+                'description' => (string) data_get($spec, 'study.research_question', implode(' ', $terms)),
+            ]);
+
+            if ($response->failed()) {
+                return [];
+            }
+
+            $items = $this->extractItems($response->json());
+
+            return collect($items)->map(function (array $item): array {
+                $externalId = $item['cohort_id'] ?? $item['id'] ?? null;
+                $entry = $externalId ? PhenotypeLibraryEntry::where('cohort_id', (int) $externalId)->first() : null;
+
+                return [
+                    'asset_type' => 'phenotype_recommendation',
+                    'role' => $item['role'] ?? null,
+                    'canonical_type' => $entry ? PhenotypeLibraryEntry::class : null,
+                    'canonical_id' => $entry?->id,
+                    'payload' => [
+                        'title' => (string) ($entry?->cohort_name ?? $item['cohort_name'] ?? $item['name'] ?? 'Recommended phenotype'),
+                        'description' => $entry?->description ?? $item['description'] ?? null,
+                        'logic_description' => $entry?->logic_description ?? $item['logic_description'] ?? null,
+                        'external_id' => $externalId,
+                        'score' => (float) ($item['score'] ?? $item['relevance_score'] ?? 0.75),
+                        'domain' => $entry?->domain ?? $item['domain'] ?? null,
+                        'severity' => $entry?->severity ?? $item['severity'] ?? null,
+                        'has_expression' => (bool) ($entry?->expression_json ?? false),
+                        'is_imported' => (bool) ($entry?->is_imported ?? false),
+                        'imported_cohort_id' => $entry?->imported_cohort_id,
+                        'rationale' => $item['rationale'] ?? 'Recommended by StudyAgent from the reviewed study intent.',
+                    ],
+                    'provenance' => [
+                        'source' => 'study-agent',
+                        'retrieved_at' => now()->toIso8601String(),
+                    ],
+                ];
+            })->all();
+        } catch (\Throwable $e) {
+            Log::info('StudyAgent phenotype recommendation unavailable', ['message' => $e->getMessage()]);
+
+            return [];
+        }
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function extractItems(mixed $payload): array
+    {
+        if (! is_array($payload)) {
+            return [];
+        }
+
+        $items = $payload['data']['recommendations']
+            ?? $payload['data']['phenotypes']
+            ?? $payload['recommendations']
+            ?? $payload['phenotypes']
+            ?? [];
+
+        return is_array($items) ? array_values(array_filter($items, 'is_array')) : [];
+    }
+
+    /**
+     * @param  list<string>  $terms
+     * @return list<array<string, mixed>>
+     */
+    private function phenotypeLibraryRecommendations(array $terms): array
+    {
+        return collect($terms)
+            ->flatMap(function (string $term) {
+                return PhenotypeLibraryEntry::query()
+                    ->where(function ($query) use ($term) {
+                        $query->where('cohort_name', 'ilike', "%{$term}%")
+                            ->orWhere('description', 'ilike', "%{$term}%")
+                            ->orWhere('logic_description', 'ilike', "%{$term}%");
+                    })
+                    ->limit(4)
+                    ->get()
+                    ->map(fn (PhenotypeLibraryEntry $entry) => $this->phenotypeAsset($entry, $term));
+            })
+            ->values()
+            ->all();
+    }
+
+    private function phenotypeAsset(PhenotypeLibraryEntry $entry, string $term): array
+    {
+        return [
+            'asset_type' => 'phenotype_recommendation',
+            'canonical_type' => PhenotypeLibraryEntry::class,
+            'canonical_id' => $entry->id,
+            'payload' => [
+                'title' => $entry->cohort_name,
+                'description' => $entry->description,
+                'logic_description' => $entry->logic_description,
+                'external_id' => $entry->cohort_id,
+                'score' => $this->scoreText($term, $entry->cohort_name, $entry->description),
+                'domain' => $entry->domain,
+                'severity' => $entry->severity,
+                'has_expression' => $entry->expression_json !== null,
+                'is_imported' => $entry->is_imported,
+                'imported_cohort_id' => $entry->imported_cohort_id,
+                'rationale' => 'Matched against OHDSI PhenotypeLibrary metadata.',
+            ],
+            'provenance' => [
+                'source' => 'phenotype_library',
+                'matched_term' => $term,
+                'retrieved_at' => now()->toIso8601String(),
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $terms
+     * @return list<array<string, mixed>>
+     */
+    private function localCohortRecommendations(array $terms): array
+    {
+        return collect($terms)
+            ->flatMap(function (string $term) {
+                return CohortDefinition::query()
+                    ->active()
+                    ->where(function ($query) use ($term) {
+                        $query->where('name', 'ilike', "%{$term}%")
+                            ->orWhere('description', 'ilike', "%{$term}%");
+                    })
+                    ->limit(3)
+                    ->get()
+                    ->map(fn (CohortDefinition $cohort) => [
+                        'asset_type' => 'local_cohort',
+                        'canonical_type' => CohortDefinition::class,
+                        'canonical_id' => $cohort->id,
+                        'payload' => [
+                            'title' => $cohort->name,
+                            'description' => $cohort->description,
+                            'score' => $this->scoreText($term, $cohort->name, $cohort->description),
+                            'has_expression' => $cohort->expression_json !== null,
+                            'quality_tier' => $cohort->quality_tier,
+                            'version' => $cohort->version,
+                            'rationale' => 'Existing local cohort definition matched the reviewed study intent.',
+                        ],
+                        'provenance' => [
+                            'source' => 'local_cohort_definitions',
+                            'matched_term' => $term,
+                            'retrieved_at' => now()->toIso8601String(),
+                        ],
+                    ]);
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  list<string>  $terms
+     * @return list<array<string, mixed>>
+     */
+    private function localConceptSetRecommendations(array $terms): array
+    {
+        return collect($terms)
+            ->flatMap(function (string $term) {
+                return ConceptSet::query()
+                    ->where(function ($query) use ($term) {
+                        $query->where('name', 'ilike', "%{$term}%")
+                            ->orWhere('description', 'ilike', "%{$term}%");
+                    })
+                    ->limit(3)
+                    ->get()
+                    ->map(fn (ConceptSet $conceptSet) => [
+                        'asset_type' => 'local_concept_set',
+                        'canonical_type' => ConceptSet::class,
+                        'canonical_id' => $conceptSet->id,
+                        'payload' => [
+                            'title' => $conceptSet->name,
+                            'description' => $conceptSet->description,
+                            'score' => $this->scoreText($term, $conceptSet->name, $conceptSet->description),
+                            'has_expression' => $conceptSet->expression_json !== null,
+                            'is_public' => $conceptSet->is_public,
+                            'rationale' => 'Existing local concept set matched the reviewed study intent.',
+                        ],
+                        'provenance' => [
+                            'source' => 'local_concept_sets',
+                            'matched_term' => $term,
+                            'retrieved_at' => now()->toIso8601String(),
+                        ],
+                    ]);
+            })
+            ->values()
+            ->all();
+    }
+
+    private function scoreText(string $term, string $title, ?string $description): float
+    {
+        $haystack = mb_strtolower($title.' '.($description ?? ''));
+        $needle = mb_strtolower($term);
+
+        if (str_contains($haystack, $needle)) {
+            return 0.9;
+        }
+
+        $tokens = collect(preg_split('/\s+/', $needle) ?: [])
+            ->filter(fn (string $token) => mb_strlen($token) > 3);
+        $matches = $tokens->filter(fn (string $token) => str_contains($haystack, $token))->count();
+
+        return min(0.85, 0.45 + ($matches * 0.1));
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     */
+    private function preRankRecommendation(array $item): float
+    {
+        $payload = (array) ($item['payload'] ?? []);
+        $provenance = (array) ($item['provenance'] ?? []);
+        $source = (string) ($provenance['source'] ?? '');
+        $hasCanonical = ! empty($item['canonical_type']) && ! empty($item['canonical_id']);
+
+        return ((float) ($payload['score'] ?? 0) * 20)
+            + ($hasCanonical ? 20 : 0)
+            + match ($source) {
+                'local_cohort_definitions' => 15,
+                'phenotype_library' => 14,
+                'local_concept_sets' => 12,
+                'study-agent' => $hasCanonical ? 10 : 0,
+                default => 0,
+            }
+        + (! empty($payload['has_expression']) ? 10 : 0);
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>
+     */
+    private function rankAsset(StudyDesignAsset $asset, array $item): array
+    {
+        $payload = $asset->draft_payload_json ?? [];
+        $provenance = $asset->provenance_json ?? [];
+        $source = (string) ($provenance['source'] ?? 'unknown');
+        $verification = StudyDesignVerificationStatus::tryFrom((string) $asset->verification_status)
+            ?? StudyDesignVerificationStatus::UNVERIFIED;
+        $aiScore = (float) ($payload['score'] ?? 0);
+        $hasExpression = (bool) ($payload['has_expression'] ?? false);
+        $hasCanonical = $asset->canonical_type !== null && $asset->canonical_id !== null;
+
+        $components = [
+            'verification' => match ($verification) {
+                StudyDesignVerificationStatus::VERIFIED => 45.0,
+                StudyDesignVerificationStatus::PARTIAL => 10.0,
+                StudyDesignVerificationStatus::BLOCKED => -60.0,
+                StudyDesignVerificationStatus::UNVERIFIED => 0.0,
+            },
+            'source_quality' => match ($source) {
+                'local_cohort_definitions' => 18.0,
+                'phenotype_library' => 16.0,
+                'local_concept_sets' => 14.0,
+                'study-agent' => $hasCanonical ? 10.0 : 0.0,
+                default => 2.0,
+            },
+            'computable_expression' => $hasExpression ? 12.0 : 0.0,
+            'canonical_record' => $hasCanonical ? 10.0 : 0.0,
+            'matched_text' => min(12.0, max(0.0, $aiScore * 12.0)),
+            'role_hint' => ! empty($item['role'] ?? null) ? 3.0 : 0.0,
+        ];
+
+        $score = max(0.0, min(100.0, array_sum($components)));
+
+        return [
+            'score' => round($score, 3),
+            'components' => $components,
+            'source' => $source,
+            'ai_score' => $aiScore,
+            'verification_status' => $verification->value,
+            'policy' => 'Deterministic rank score is separate from AI-provided score and cannot override verification blockers.',
+        ];
+    }
+}

--- a/backend/database/migrations/2026_04_15_000005_add_verification_to_study_design_assets_table.php
+++ b/backend/database/migrations/2026_04_15_000005_add_verification_to_study_design_assets_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('study_design_assets', function (Blueprint $table) {
+            $table->string('verification_status', 32)->default('unverified')->after('provenance_json');
+            $table->jsonb('verification_json')->nullable()->after('verification_status');
+            $table->timestamp('verified_at')->nullable()->after('verification_json');
+            $table->index(['session_id', 'verification_status'], 'study_design_assets_session_verification_idx');
+        });
+
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DO $grants$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'parthenon_app') THEN
+                        GRANT SELECT, INSERT, UPDATE, DELETE ON app.study_design_assets TO parthenon_app;
+                    END IF;
+                END
+                $grants$
+            SQL);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('study_design_assets', function (Blueprint $table) {
+            $table->dropIndex('study_design_assets_session_verification_idx');
+            $table->dropColumn(['verification_status', 'verification_json', 'verified_at']);
+        });
+    }
+};

--- a/backend/database/migrations/2026_04_15_000006_rename_failed_study_design_asset_verification_status.php
+++ b/backend/database/migrations/2026_04_15_000006_rename_failed_study_design_asset_verification_status.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('study_design_assets')
+            ->where('verification_status', 'failed')
+            ->update(['verification_status' => 'blocked']);
+    }
+
+    public function down(): void
+    {
+        DB::table('study_design_assets')
+            ->where('verification_status', 'blocked')
+            ->update(['verification_status' => 'failed']);
+    }
+};

--- a/backend/database/migrations/2026_04_15_000007_add_ranking_to_study_design_assets_table.php
+++ b/backend/database/migrations/2026_04_15_000007_add_ranking_to_study_design_assets_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('study_design_assets', function (Blueprint $table) {
+            $table->decimal('rank_score', 6, 3)->nullable()->after('verified_at');
+            $table->jsonb('rank_score_json')->nullable()->after('rank_score');
+            $table->index(['session_id', 'rank_score'], 'study_design_assets_session_rank_idx');
+        });
+
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DO $grants$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'parthenon_app') THEN
+                        GRANT SELECT, INSERT, UPDATE, DELETE ON app.study_design_assets TO parthenon_app;
+                    END IF;
+                END
+                $grants$
+            SQL);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('study_design_assets', function (Blueprint $table) {
+            $table->dropIndex('study_design_assets_session_rank_idx');
+            $table->dropColumn(['rank_score', 'rank_score_json']);
+        });
+    }
+};

--- a/backend/database/migrations/2026_04_15_000008_add_materialization_to_study_design_assets_table.php
+++ b/backend/database/migrations/2026_04_15_000008_add_materialization_to_study_design_assets_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('study_design_assets', function (Blueprint $table) {
+            $table->string('materialized_type', 128)->nullable()->after('rank_score_json');
+            $table->unsignedBigInteger('materialized_id')->nullable()->after('materialized_type');
+            $table->timestamp('materialized_at')->nullable()->after('materialized_id');
+            $table->index(['materialized_type', 'materialized_id'], 'study_design_assets_materialized_idx');
+        });
+
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DO $grants$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'parthenon_app') THEN
+                        GRANT SELECT, INSERT, UPDATE, DELETE ON app.study_design_assets TO parthenon_app;
+                    END IF;
+                END
+                $grants$
+            SQL);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('study_design_assets', function (Blueprint $table) {
+            $table->dropIndex('study_design_assets_materialized_idx');
+            $table->dropColumn(['materialized_type', 'materialized_id', 'materialized_at']);
+        });
+    }
+};

--- a/backend/scripts/run-study-design-tests.sh
+++ b/backend/scripts/run-study-design-tests.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-parthenon-postgres}"
+PHP_CONTAINER="${PHP_CONTAINER:-parthenon-php}"
+DB_PREFIX="${DB_PREFIX:-codex_study}"
+ROLE_PREFIX="${ROLE_PREFIX:-codex_role}"
+PASSWORD="${PASSWORD:-codex-study-design-test}"
+TEST_PATH="${TEST_PATH:-tests/Feature/Api/V1/StudyDesignTest.php}"
+
+suffix="$(date +%s)_$$"
+db_name="${DB_PREFIX}_${suffix}"
+role_name="${ROLE_PREFIX}_${suffix}"
+
+cleanup() {
+  if [[ "${db_name}" == codex_study_* && "${role_name}" == codex_role_* ]]; then
+    docker exec "${POSTGRES_CONTAINER}" psql -U parthenon -d postgres -v ON_ERROR_STOP=1 \
+      -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${db_name}';" \
+      -c "DROP DATABASE IF EXISTS \"${db_name}\";" \
+      -c "DROP ROLE IF EXISTS \"${role_name}\";" >/dev/null
+  fi
+}
+trap cleanup EXIT
+
+if [[ "${db_name}" != codex_study_* || "${role_name}" != codex_role_* ]]; then
+  echo "Refusing to create test database or role outside codex prefixes." >&2
+  exit 1
+fi
+
+docker exec "${POSTGRES_CONTAINER}" psql -U parthenon -d postgres -v ON_ERROR_STOP=1 \
+  -c "CREATE ROLE \"${role_name}\" LOGIN PASSWORD '${PASSWORD}';" \
+  -c "CREATE DATABASE \"${db_name}\" OWNER \"${role_name}\";" \
+  -c "GRANT CREATE ON DATABASE \"${db_name}\" TO \"${role_name}\";" >/dev/null
+
+docker exec -i "${POSTGRES_CONTAINER}" psql -U parthenon -d "${db_name}" -v ON_ERROR_STOP=1 >/dev/null <<SQL
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE SCHEMA IF NOT EXISTS app AUTHORIZATION "${role_name}";
+CREATE SCHEMA IF NOT EXISTS omop AUTHORIZATION "${role_name}";
+CREATE SCHEMA IF NOT EXISTS vocab AUTHORIZATION "${role_name}";
+CREATE SCHEMA IF NOT EXISTS results AUTHORIZATION "${role_name}";
+CREATE SCHEMA IF NOT EXISTS gis AUTHORIZATION "${role_name}";
+CREATE SCHEMA IF NOT EXISTS eunomia AUTHORIZATION "${role_name}";
+CREATE SCHEMA IF NOT EXISTS eunomia_results AUTHORIZATION "${role_name}";
+CREATE SCHEMA IF NOT EXISTS php AUTHORIZATION "${role_name}";
+CREATE SCHEMA IF NOT EXISTS webapi AUTHORIZATION "${role_name}";
+CREATE SCHEMA IF NOT EXISTS inpatient AUTHORIZATION "${role_name}";
+CREATE SCHEMA IF NOT EXISTS inpatient_ext AUTHORIZATION "${role_name}";
+GRANT ALL ON SCHEMA app, omop, vocab, results, gis, eunomia, eunomia_results, php, webapi, inpatient, inpatient_ext TO "${role_name}";
+SQL
+
+docker exec \
+  -e APP_ENV=testing \
+  -e PGOPTIONS='-c search_path=app,php,public' \
+  -e DB_HOST=postgres \
+  -e DB_PORT=5432 \
+  -e DB_DATABASE="${db_name}" \
+  -e DB_USERNAME="${role_name}" \
+  -e DB_PASSWORD="${PASSWORD}" \
+  -e DB_TEST_HOST=postgres \
+  -e DB_TEST_PORT=5432 \
+  -e DB_TEST_DATABASE="${db_name}" \
+  -e DB_TEST_USERNAME="${role_name}" \
+  -e DB_TEST_PASSWORD="${PASSWORD}" \
+  -e PROTECTED_CONSOLE_DATABASES=parthenon \
+  -w /var/www/html \
+  "${PHP_CONTAINER}" vendor/bin/pest "${TEST_PATH}" --colors=never

--- a/frontend/src/features/studies/components/StudyDesignWorkbench.tsx
+++ b/frontend/src/features/studies/components/StudyDesignWorkbench.tsx
@@ -1,0 +1,2271 @@
+import { useMemo, useState, type ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle, Brain, CheckCircle2, ChevronDown, ChevronRight, Loader2, Lock, Plus, Save, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { fetchSources } from "@/features/data-sources/api/sourcesApi";
+import { searchConcepts } from "@/features/vocabulary/api/vocabularyApi";
+import type { Source } from "@/types/models";
+import type { Concept } from "@/features/vocabulary/types/vocabulary";
+import type { Study, StudyAnalysisPlanDraft, StudyCohortReadiness, StudyDesignAsset, StudyDesignDraftConcept, StudyDesignLockReadiness, StudyDesignSpec, StudyDesignVersion, StudyFeasibilityResult } from "../types/study";
+import {
+  useAcceptStudyDesignVersion,
+  useCreateStudyDesignSession,
+  useDraftStudyAnalysisPlans,
+  useDraftStudyCohorts,
+  useDraftStudyConceptSets,
+  useGenerateStudyIntent,
+  useImportExistingStudyDesign,
+  useCritiqueStudyDesignVersion,
+  useLinkStudyCohortDraft,
+  useMaterializeStudyCohortDraft,
+  useMaterializeStudyConceptSetDraft,
+  useMaterializeStudyAnalysisPlan,
+  useLockStudyDesignVersion,
+  useRecommendStudyPhenotypes,
+  useReviewStudyDesignAsset,
+  useRunStudyFeasibility,
+  useVerifyStudyAnalysisPlan,
+  useStudyDesignLockReadiness,
+  useStudyCohortReadiness,
+  useStudyDesignAssets,
+  useStudyDesignSessions,
+  useStudyDesignVersions,
+  useVerifyStudyCohortDraft,
+  useUpdateStudyConceptSetDraft,
+  useUpdateStudyDesignVersion,
+  useVerifyStudyConceptSetDraft,
+} from "../hooks/useStudies";
+
+interface StudyDesignWorkbenchProps {
+  study: Study;
+}
+
+interface IntentFormState {
+  researchQuestion: string;
+  primaryObjective: string;
+  population: string;
+  exposure: string;
+  comparator: string;
+  outcome: string;
+  time: string;
+}
+
+export function StudyDesignWorkbench({ study }: StudyDesignWorkbenchProps) {
+  const slug = study.slug || String(study.id);
+  const [selectedSessionId, setSelectedSessionId] = useState<number | null>(null);
+  const [researchQuestion, setResearchQuestion] = useState(
+    study.primary_objective || study.description || "",
+  );
+  const [selectedVersionId, setSelectedVersionId] = useState<number | null>(null);
+
+  const sessionsQuery = useStudyDesignSessions(slug);
+  const createSession = useCreateStudyDesignSession();
+  const generateIntent = useGenerateStudyIntent();
+  const updateVersion = useUpdateStudyDesignVersion();
+  const acceptVersion = useAcceptStudyDesignVersion();
+  const importExistingStudy = useImportExistingStudyDesign();
+  const critiqueStudyDesign = useCritiqueStudyDesignVersion();
+  const recommendPhenotypes = useRecommendStudyPhenotypes();
+  const draftConceptSets = useDraftStudyConceptSets();
+  const draftCohorts = useDraftStudyCohorts();
+  const verifyConceptSetDraft = useVerifyStudyConceptSetDraft();
+  const verifyCohortDraft = useVerifyStudyCohortDraft();
+  const updateConceptSetDraft = useUpdateStudyConceptSetDraft();
+  const materializeConceptSetDraft = useMaterializeStudyConceptSetDraft();
+  const materializeCohortDraft = useMaterializeStudyCohortDraft();
+  const linkCohortDraft = useLinkStudyCohortDraft();
+  const runFeasibility = useRunStudyFeasibility();
+  const draftAnalysisPlans = useDraftStudyAnalysisPlans();
+  const verifyAnalysisPlan = useVerifyStudyAnalysisPlan();
+  const materializeAnalysisPlan = useMaterializeStudyAnalysisPlan();
+  const lockDesignVersion = useLockStudyDesignVersion();
+  const reviewAsset = useReviewStudyDesignAsset();
+
+  const sessions = useMemo(() => sessionsQuery.data ?? [], [sessionsQuery.data]);
+  const effectiveSessionId = selectedSessionId ?? sessions[0]?.id ?? null;
+  const versionsQuery = useStudyDesignVersions(slug, effectiveSessionId);
+  const selectedSession = sessions.find((session) => session.id === effectiveSessionId) ?? null;
+  const versions = useMemo(() => versionsQuery.data ?? [], [versionsQuery.data]);
+  const selectedVersion = useMemo(
+    () => versions.find((version) => version.id === selectedVersionId) ?? versions[0] ?? null,
+    [versions, selectedVersionId],
+  );
+  const assetsQuery = useStudyDesignAssets(
+    slug,
+    effectiveSessionId,
+    selectedVersion ? { version_id: selectedVersion.id } : undefined,
+  );
+  const cohortReadinessQuery = useStudyCohortReadiness(slug, effectiveSessionId, selectedVersion?.id ?? null);
+  const lockReadinessQuery = useStudyDesignLockReadiness(slug, effectiveSessionId, selectedVersion?.id ?? null);
+  const assets = useMemo(() => assetsQuery.data ?? [], [assetsQuery.data]);
+
+  const ensureSession = async () => {
+    if (selectedSession) return selectedSession.id;
+
+    const session = await createSession.mutateAsync({
+      slug,
+      payload: {
+        title: "Study intent design",
+        source_mode: "natural_language",
+      },
+    });
+    setSelectedSessionId(session.id);
+    return session.id;
+  };
+
+  const handleGenerate = async () => {
+    if (!researchQuestion.trim()) return;
+    const sessionId = await ensureSession();
+    const version = await generateIntent.mutateAsync({
+      slug,
+      sessionId,
+      researchQuestion: researchQuestion.trim(),
+    });
+    setSelectedVersionId(version.id);
+  };
+
+  const handleSaveReview = (formState: IntentFormState) => {
+    if (!selectedSession || !selectedVersion) return;
+    updateVersion.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      versionId: selectedVersion.id,
+      spec: formToSpec(selectedVersion.spec_json, formState, study),
+    });
+  };
+
+  const handleAccept = () => {
+    if (!selectedSession || !selectedVersion) return;
+    acceptVersion.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      versionId: selectedVersion.id,
+    });
+  };
+
+  const handleImportExistingStudy = async () => {
+    const sessionId = await ensureSession();
+    const result = await importExistingStudy.mutateAsync({ slug, sessionId });
+    setSelectedVersionId(result.version.id);
+  };
+
+  const handleCritiqueStudyDesign = () => {
+    if (!selectedSession || !selectedVersion) return;
+    critiqueStudyDesign.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      versionId: selectedVersion.id,
+    });
+  };
+
+  const handleRecommendPhenotypes = () => {
+    if (!selectedSession || !selectedVersion) return;
+    recommendPhenotypes.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      versionId: selectedVersion.id,
+    });
+  };
+
+  const handleReviewAsset = (asset: StudyDesignAsset, decision: "accept" | "reject" | "defer") => {
+    if (!selectedSession) return;
+    reviewAsset.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      assetId: asset.id,
+      decision,
+    });
+  };
+
+  const handleDraftConceptSets = () => {
+    if (!selectedSession || !selectedVersion) return;
+    draftConceptSets.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      versionId: selectedVersion.id,
+    });
+  };
+
+  const handleVerifyConceptSetDraft = (asset: StudyDesignAsset) => {
+    if (!selectedSession) return;
+    verifyConceptSetDraft.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      assetId: asset.id,
+    });
+  };
+
+  const handleUpdateConceptSetDraft = (asset: StudyDesignAsset, concepts: StudyDesignDraftConcept[]) => {
+    if (!selectedSession) return;
+    updateConceptSetDraft.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      assetId: asset.id,
+      payload: conceptDraftPayload(asset, concepts),
+    });
+  };
+
+  const handleMaterializeConceptSetDraft = (asset: StudyDesignAsset) => {
+    if (!selectedSession) return;
+    materializeConceptSetDraft.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      assetId: asset.id,
+    });
+  };
+
+  const handleDraftCohorts = () => {
+    if (!selectedSession || !selectedVersion) return;
+    draftCohorts.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      versionId: selectedVersion.id,
+    });
+  };
+
+  const handleVerifyCohortDraft = (asset: StudyDesignAsset) => {
+    if (!selectedSession) return;
+    verifyCohortDraft.mutate({ slug, sessionId: selectedSession.id, assetId: asset.id });
+  };
+
+  const handleMaterializeCohortDraft = (asset: StudyDesignAsset) => {
+    if (!selectedSession) return;
+    materializeCohortDraft.mutate({ slug, sessionId: selectedSession.id, assetId: asset.id });
+  };
+
+  const handleLinkCohortDraft = (asset: StudyDesignAsset) => {
+    if (!selectedSession) return;
+    linkCohortDraft.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      assetId: asset.id,
+      role: asset.role ?? String(asset.draft_payload_json.role ?? "target"),
+    });
+  };
+
+  const handleRunFeasibility = (sourceIds: number[], minCellCount: number) => {
+    if (!selectedSession || !selectedVersion) return;
+    runFeasibility.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      versionId: selectedVersion.id,
+      sourceIds,
+      minCellCount,
+    });
+  };
+
+  const handleDraftAnalysisPlans = () => {
+    if (!selectedSession || !selectedVersion) return;
+    draftAnalysisPlans.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      versionId: selectedVersion.id,
+    });
+  };
+
+  const handleVerifyAnalysisPlan = (asset: StudyDesignAsset) => {
+    if (!selectedSession) return;
+    verifyAnalysisPlan.mutate({ slug, sessionId: selectedSession.id, assetId: asset.id });
+  };
+
+  const handleMaterializeAnalysisPlan = (asset: StudyDesignAsset) => {
+    if (!selectedSession) return;
+    materializeAnalysisPlan.mutate({ slug, sessionId: selectedSession.id, assetId: asset.id });
+  };
+
+  const handleLockVersion = () => {
+    if (!selectedSession || !selectedVersion) return;
+    lockDesignVersion.mutate({
+      slug,
+      sessionId: selectedSession.id,
+      versionId: selectedVersion.id,
+    });
+  };
+
+  const activeMutationError =
+    mutationError(createSession.error) ||
+    mutationError(generateIntent.error) ||
+    mutationError(updateVersion.error) ||
+    mutationError(acceptVersion.error) ||
+    mutationError(importExistingStudy.error) ||
+    mutationError(critiqueStudyDesign.error) ||
+    mutationError(recommendPhenotypes.error) ||
+    mutationError(draftConceptSets.error) ||
+    mutationError(draftCohorts.error) ||
+    mutationError(verifyConceptSetDraft.error) ||
+    mutationError(verifyCohortDraft.error) ||
+    mutationError(updateConceptSetDraft.error) ||
+    mutationError(materializeConceptSetDraft.error) ||
+    mutationError(materializeCohortDraft.error) ||
+    mutationError(linkCohortDraft.error) ||
+    mutationError(runFeasibility.error) ||
+    mutationError(draftAnalysisPlans.error) ||
+    mutationError(verifyAnalysisPlan.error) ||
+    mutationError(materializeAnalysisPlan.error) ||
+    mutationError(lockDesignVersion.error) ||
+    mutationError(reviewAsset.error);
+
+  return (
+    <div className="panel space-y-5">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <Brain size={18} className="text-success" />
+            <h3 className="panel-title" style={{ fontSize: "var(--text-base)" }}>
+              Study Design Compiler
+            </h3>
+          </div>
+          <p className="mt-1 text-sm text-text-muted">
+            Convert a research question into reviewed OHDSI-aligned study intent, then vet reusable phenotype assets before anything moves downstream.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            createSession.mutate(
+              { slug, payload: { title: "Study intent design", source_mode: "natural_language" } },
+              { onSuccess: (session) => setSelectedSessionId(session.id) },
+            );
+          }}
+          disabled={createSession.isPending}
+          className="btn btn-ghost btn-sm shrink-0"
+        >
+          {createSession.isPending ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
+          New Session
+        </button>
+      </div>
+
+      {sessions.length > 0 && (
+        <div className="grid gap-3 md:grid-cols-[minmax(0,240px)_1fr]">
+          <div className="space-y-2">
+            <p className="text-[10px] text-text-ghost uppercase tracking-wider">Sessions</p>
+            <div className="space-y-1">
+              {sessions.map((session) => (
+                <button
+                  key={session.id}
+                  type="button"
+                  onClick={() => {
+                    setSelectedSessionId(session.id);
+                    setSelectedVersionId(null);
+                  }}
+                  className={cn(
+                    "w-full rounded-lg border px-3 py-2 text-left transition-colors",
+                    selectedSession?.id === session.id
+                      ? "border-success/60 bg-success/10"
+                      : "border-border-default bg-surface-raised hover:bg-surface-overlay",
+                  )}
+                >
+                  <p className="text-sm font-medium text-text-secondary">{session.title}</p>
+                  <p className="text-xs text-text-ghost">{session.status}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div>
+              <label className="form-label">Research Question</label>
+              <textarea
+                value={researchQuestion}
+                onChange={(event) => setResearchQuestion(event.target.value)}
+                rows={3}
+                className="form-input form-textarea"
+                placeholder="Compare recurrent MACE in post-MI patients initiating clopidogrel versus aspirin."
+              />
+              <div className="mt-2 flex justify-end">
+                <button
+                  type="button"
+                  onClick={handleGenerate}
+                  disabled={!researchQuestion.trim() || generateIntent.isPending || createSession.isPending}
+                  className="btn btn-primary btn-sm"
+                >
+                  {generateIntent.isPending ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+                  Generate Intent
+                </button>
+              </div>
+            </div>
+
+            {versions.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {versions.map((version) => (
+                  <button
+                    key={version.id}
+                    type="button"
+                    onClick={() => setSelectedVersionId(version.id)}
+                    className={cn(
+                      "rounded-md border px-2.5 py-1 text-xs",
+                      selectedVersion?.id === version.id
+                        ? "border-success/70 bg-success/10 text-success"
+                        : "border-border-default text-text-muted hover:text-text-secondary",
+                    )}
+                  >
+                    v{version.version_number} · {version.status}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {selectedVersion && (
+              <>
+                <IntentReviewPanel
+                  key={selectedVersion.id}
+                  version={selectedVersion}
+                  initialFormState={specToForm(selectedVersion.spec_json)}
+                  onSave={handleSaveReview}
+                  onAccept={handleAccept}
+                  isSaving={updateVersion.isPending}
+                  isAccepting={acceptVersion.isPending}
+                />
+                <BottomUpCompatibilityPanel
+                  assets={assets}
+                  isImporting={importExistingStudy.isPending}
+                  isCritiquing={critiqueStudyDesign.isPending}
+                  canCritique={selectedVersion.status !== "locked"}
+                  onImport={handleImportExistingStudy}
+                  onCritique={handleCritiqueStudyDesign}
+                />
+                <PhenotypeRecommendationPanel
+                  assets={assets}
+                  isLoading={assetsQuery.isLoading}
+                  isGenerating={recommendPhenotypes.isPending}
+                  isReviewing={reviewAsset.isPending}
+                  onGenerate={handleRecommendPhenotypes}
+                  onReview={handleReviewAsset}
+                  canGenerate={selectedVersion.status === "accepted" || selectedVersion.status === "review_ready"}
+                />
+                <ConceptSetDraftPanel
+                  assets={assets}
+                  isGenerating={draftConceptSets.isPending}
+                  isReviewing={reviewAsset.isPending}
+                  isVerifying={verifyConceptSetDraft.isPending}
+                  isUpdating={updateConceptSetDraft.isPending}
+                  isMaterializing={materializeConceptSetDraft.isPending}
+                  onGenerate={handleDraftConceptSets}
+                  onReview={handleReviewAsset}
+                  onVerify={handleVerifyConceptSetDraft}
+                  onUpdate={handleUpdateConceptSetDraft}
+                  onMaterialize={handleMaterializeConceptSetDraft}
+                />
+                <CohortDraftPanel
+                  assets={assets}
+                  readiness={cohortReadinessQuery.data ?? null}
+                  isReadinessLoading={cohortReadinessQuery.isLoading}
+                  isGenerating={draftCohorts.isPending}
+                  isReviewing={reviewAsset.isPending}
+                  isVerifying={verifyCohortDraft.isPending}
+                  isMaterializing={materializeCohortDraft.isPending}
+                  isLinking={linkCohortDraft.isPending}
+                  onGenerate={handleDraftCohorts}
+                  onReview={handleReviewAsset}
+                  onVerify={handleVerifyCohortDraft}
+                  onMaterialize={handleMaterializeCohortDraft}
+                  onLink={handleLinkCohortDraft}
+                />
+                <FeasibilityDashboard
+                  assets={assets}
+                  readiness={cohortReadinessQuery.data ?? null}
+                  isRunning={runFeasibility.isPending}
+                  onRun={handleRunFeasibility}
+                />
+                <AnalysisPlanPanel
+                  assets={assets}
+                  isGenerating={draftAnalysisPlans.isPending}
+                  isReviewing={reviewAsset.isPending}
+                  isVerifying={verifyAnalysisPlan.isPending}
+                  isMaterializing={materializeAnalysisPlan.isPending}
+                  onGenerate={handleDraftAnalysisPlans}
+                  onReview={handleReviewAsset}
+                  onVerify={handleVerifyAnalysisPlan}
+                  onMaterialize={handleMaterializeAnalysisPlan}
+                />
+                <DesignLockPanel
+                  readiness={lockReadinessQuery.data ?? null}
+                  isLoading={lockReadinessQuery.isLoading}
+                  isLocking={lockDesignVersion.isPending}
+                  versionStatus={selectedVersion.status}
+                  onLock={handleLockVersion}
+                />
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {sessions.length === 0 && !sessionsQuery.isLoading && (
+        <div className="rounded-lg border border-border-default bg-surface-raised p-4">
+          <p className="text-sm text-text-secondary">
+            Start a design session, then generate a structured PICO intent from the study question.
+          </p>
+          <div className="mt-3">
+            <textarea
+              value={researchQuestion}
+              onChange={(event) => setResearchQuestion(event.target.value)}
+              rows={3}
+              className="form-input form-textarea"
+              placeholder="Describe the study question..."
+            />
+            <button
+              type="button"
+              onClick={handleGenerate}
+              disabled={!researchQuestion.trim() || createSession.isPending || generateIntent.isPending}
+              className="btn btn-primary btn-sm mt-3"
+            >
+              {createSession.isPending || generateIntent.isPending ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+              Create Session and Generate Intent
+            </button>
+          </div>
+        </div>
+      )}
+
+      {sessionsQuery.isLoading && (
+        <div className="flex items-center gap-2 text-sm text-text-muted">
+          <Loader2 size={14} className="animate-spin" />
+          Loading design sessions...
+        </div>
+      )}
+
+      {activeMutationError && (
+        <div className="rounded-lg border border-critical/40 bg-critical/10 p-3 text-sm text-critical">
+          {activeMutationError}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PhenotypeRecommendationPanel({
+  assets,
+  isLoading,
+  isGenerating,
+  isReviewing,
+  onGenerate,
+  onReview,
+  canGenerate,
+}: {
+  assets: StudyDesignAsset[];
+  isLoading: boolean;
+  isGenerating: boolean;
+  isReviewing: boolean;
+  onGenerate: () => void;
+  onReview: (asset: StudyDesignAsset, decision: "accept" | "reject" | "defer") => void;
+  canGenerate: boolean;
+}) {
+  const recommendations = assets.filter((asset) =>
+    ["phenotype_recommendation", "local_cohort", "local_concept_set"].includes(asset.asset_type),
+  ).sort((left, right) =>
+    (right.rank_score ?? -1) - (left.rank_score ?? -1) || right.id - left.id,
+  );
+  const evidenceCounts = recommendations.reduce(
+    (counts, asset) => {
+      if (asset.verification_status === "verified") counts.verified += 1;
+      else if (asset.verification_status === "blocked") counts.blocked += 1;
+      else if (asset.verification_status === "partial") counts.partial += 1;
+      else counts.unverified += 1;
+      return counts;
+    },
+    { verified: 0, partial: 0, blocked: 0, unverified: 0 },
+  );
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-text-secondary">Phenotype and Reuse Recommendations</p>
+          <p className="text-xs text-text-ghost">
+            Review reusable Phenotype Library entries, local cohorts, and local concept sets before drafting anything new.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onGenerate}
+          disabled={!canGenerate || isGenerating}
+          className="btn btn-primary btn-sm shrink-0"
+        >
+          {isGenerating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+          Recommend
+        </button>
+      </div>
+
+      {recommendations.length > 0 && (
+        <div className="grid gap-2 text-xs sm:grid-cols-4">
+          <EvidenceMetric label="Verified" value={evidenceCounts.verified} tone="success" />
+          <EvidenceMetric label="Needs check" value={evidenceCounts.partial + evidenceCounts.unverified} tone="warning" />
+          <EvidenceMetric label="Blocked" value={evidenceCounts.blocked} tone="critical" />
+          <EvidenceMetric label="Review queue" value={recommendations.length} tone="neutral" />
+        </div>
+      )}
+
+      {!canGenerate && (
+        <p className="text-xs text-text-ghost">
+          Save a review-ready intent or accept the intent before requesting recommendations.
+        </p>
+      )}
+
+      {isLoading && (
+        <div className="flex items-center gap-2 text-sm text-text-muted">
+          <Loader2 size={14} className="animate-spin" />
+          Loading recommendations...
+        </div>
+      )}
+
+      {!isLoading && recommendations.length === 0 && (
+        <div className="rounded-md border border-border-default bg-surface-base p-3 text-sm text-text-muted">
+          No recommendations yet.
+        </div>
+      )}
+
+      {recommendations.length > 0 && (
+        <div className="space-y-2">
+          {recommendations.map((asset) => (
+            <RecommendationCard
+              key={asset.id}
+              asset={asset}
+              isReviewing={isReviewing}
+              onReview={onReview}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConceptSetDraftPanel({
+  assets,
+  isGenerating,
+  isReviewing,
+  isVerifying,
+  isUpdating,
+  isMaterializing,
+  onGenerate,
+  onReview,
+  onVerify,
+  onUpdate,
+  onMaterialize,
+}: {
+  assets: StudyDesignAsset[];
+  isGenerating: boolean;
+  isReviewing: boolean;
+  isVerifying: boolean;
+  isUpdating: boolean;
+  isMaterializing: boolean;
+  onGenerate: () => void;
+  onReview: (asset: StudyDesignAsset, decision: "accept" | "reject" | "defer") => void;
+  onVerify: (asset: StudyDesignAsset) => void;
+  onUpdate: (asset: StudyDesignAsset, concepts: StudyDesignDraftConcept[]) => void;
+  onMaterialize: (asset: StudyDesignAsset) => void;
+}) {
+  const acceptedInputs = assets.filter((asset) =>
+    ["phenotype_recommendation", "local_cohort", "local_concept_set"].includes(asset.asset_type) &&
+    asset.status === "accepted",
+  );
+  const drafts = assets
+    .filter((asset) => asset.asset_type === "concept_set_draft")
+    .sort((left, right) => right.id - left.id);
+  const canGenerate = acceptedInputs.length > 0;
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-text-secondary">Concept Set Drafts</p>
+          <p className="text-xs text-text-ghost">
+            Convert accepted evidence into vocabulary-checked drafts before creating native concept sets.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onGenerate}
+          disabled={!canGenerate || isGenerating}
+          className="btn btn-primary btn-sm shrink-0"
+        >
+          {isGenerating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+          Draft Concept Sets
+        </button>
+      </div>
+
+      {!canGenerate && (
+        <p className="text-xs text-text-ghost">
+          Accept at least one verified phenotype, cohort, or concept set recommendation first.
+        </p>
+      )}
+
+      {drafts.length === 0 && (
+        <div className="rounded-md border border-border-default bg-surface-base p-3 text-sm text-text-muted">
+          No concept set drafts yet.
+        </div>
+      )}
+
+      {drafts.length > 0 && (
+        <div className="space-y-2">
+          {drafts.map((asset) => (
+            <ConceptSetDraftCard
+              key={asset.id}
+              asset={asset}
+              isReviewing={isReviewing}
+              isVerifying={isVerifying}
+              isUpdating={isUpdating}
+              isMaterializing={isMaterializing}
+              onReview={onReview}
+              onVerify={onVerify}
+              onUpdate={onUpdate}
+              onMaterialize={onMaterialize}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConceptSetDraftCard({
+  asset,
+  isReviewing,
+  isVerifying,
+  isUpdating,
+  isMaterializing,
+  onReview,
+  onVerify,
+  onUpdate,
+  onMaterialize,
+}: {
+  asset: StudyDesignAsset;
+  isReviewing: boolean;
+  isVerifying: boolean;
+  isUpdating: boolean;
+  isMaterializing: boolean;
+  onReview: (asset: StudyDesignAsset, decision: "accept" | "reject" | "defer") => void;
+  onVerify: (asset: StudyDesignAsset) => void;
+  onUpdate: (asset: StudyDesignAsset, concepts: StudyDesignDraftConcept[]) => void;
+  onMaterialize: (asset: StudyDesignAsset) => void;
+}) {
+  const [expanded, setExpanded] = useState(asset.verification_status !== "verified");
+  const [conceptQuery, setConceptQuery] = useState("");
+  const [conceptResults, setConceptResults] = useState<Concept[]>([]);
+  const [isSearchingConcepts, setIsSearchingConcepts] = useState(false);
+  const payload = asset.draft_payload_json;
+  const verified = asset.verification_status === "verified";
+  const accepted = asset.status === "accepted";
+  const materialized = asset.status === "materialized" && asset.materialized_id != null;
+  const verification = asset.verification_json;
+  const concepts = verification?.concepts ?? payload.concepts ?? [];
+  const blockers = verification?.blocking_reasons ?? [];
+  const warnings = verification?.warnings ?? [];
+  const canEdit = !materialized && asset.status !== "accepted";
+
+  const handleSearchConcepts = async () => {
+    if (conceptQuery.trim().length < 2) return;
+    setIsSearchingConcepts(true);
+    try {
+      const result = await searchConcepts({ q: conceptQuery.trim(), standard: true, limit: 8 });
+      setConceptResults(result.items);
+    } finally {
+      setIsSearchingConcepts(false);
+    }
+  };
+
+  const handleAddConcept = (concept: Concept) => {
+    if (concepts.some((item) => item.concept_id === concept.concept_id)) return;
+    onUpdate(asset, [...concepts, conceptFromVocabulary(concept)]);
+    setConceptQuery("");
+    setConceptResults([]);
+  };
+
+  const handleRemoveConcept = (conceptId: number | null | undefined) => {
+    if (conceptId == null) return;
+    onUpdate(asset, concepts.filter((concept) => concept.concept_id !== conceptId));
+  };
+
+  const handleToggleConcept = (conceptId: number | null | undefined, field: "is_excluded" | "include_descendants" | "include_mapped") => {
+    if (conceptId == null) return;
+    onUpdate(
+      asset,
+      concepts.map((concept) =>
+        concept.concept_id === conceptId
+          ? { ...concept, [field]: !concept[field] }
+          : concept,
+      ),
+    );
+  };
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-base px-3 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-md bg-success/10 px-2 py-0.5 text-[10px] uppercase tracking-wider text-success">
+              concept set draft
+            </span>
+            <VerificationBadge status={asset.verification_status} />
+            <span className="text-[10px] text-text-muted">{asset.status}</span>
+            {payload.role && <span className="text-[10px] text-text-ghost">{String(payload.role)}</span>}
+          </div>
+          <p className="mt-1 text-sm font-medium text-text-secondary">
+            {payload.title ?? `Concept set draft #${asset.id}`}
+          </p>
+          {payload.clinical_rationale && (
+            <p className="mt-1 text-xs text-text-muted line-clamp-2">{payload.clinical_rationale}</p>
+          )}
+          <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-text-ghost">
+            <span>{concepts.length} concepts</span>
+            {payload.domain && <span>{String(payload.domain)}</span>}
+            {materialized && <span>Native concept set #{asset.materialized_id}</span>}
+          </div>
+          {blockers.length > 0 && <p className="mt-2 text-xs text-critical">{blockers[0]}</p>}
+          {blockers.length === 0 && warnings.length > 0 && <p className="mt-2 text-xs text-warning">{warnings[0]}</p>}
+        </div>
+
+        <div className="flex shrink-0 flex-wrap justify-end gap-1">
+          {!materialized && asset.verification_status === "unverified" && (
+            <button
+              type="button"
+              onClick={() => onVerify(asset)}
+              disabled={isVerifying}
+              className="btn btn-ghost btn-sm"
+            >
+              Verify
+            </button>
+          )}
+          {!materialized && asset.status === "needs_review" && (
+            <>
+              <button
+                type="button"
+                onClick={() => onReview(asset, "accept")}
+                disabled={isReviewing || !verified}
+                title={verified ? undefined : verification?.eligibility?.reason ?? "Only verified concept set drafts can be accepted."}
+                className="btn btn-primary btn-sm"
+              >
+                Accept
+              </button>
+              <button
+                type="button"
+                onClick={() => onReview(asset, "defer")}
+                disabled={isReviewing}
+                className="btn btn-ghost btn-sm"
+              >
+                Defer
+              </button>
+              <button
+                type="button"
+                onClick={() => onReview(asset, "reject")}
+                disabled={isReviewing}
+                className="btn btn-ghost btn-sm"
+              >
+                Reject
+              </button>
+            </>
+          )}
+          {!materialized && accepted && (
+            <button
+              type="button"
+              onClick={() => onMaterialize(asset)}
+              disabled={isMaterializing || !verified}
+              className="btn btn-primary btn-sm"
+            >
+              Materialize
+            </button>
+          )}
+          {materialized && (
+            <a href={`/concept-sets/${asset.materialized_id}`} className="btn btn-ghost btn-sm">
+              Open Native Editor
+            </a>
+          )}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="mt-3 inline-flex items-center gap-1 text-xs text-text-muted hover:text-text-secondary"
+      >
+        {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+        Concepts
+      </button>
+
+      {expanded && (
+        <div className="mt-3 border-t border-border-default pt-3">
+          {canEdit && (
+            <div className="mb-3 space-y-2">
+              <div className="flex gap-2">
+                <input
+                  value={conceptQuery}
+                  onChange={(event) => setConceptQuery(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      void handleSearchConcepts();
+                    }
+                  }}
+                  className="form-input"
+                  placeholder="Search OMOP vocabulary concepts"
+                />
+                <button
+                  type="button"
+                  onClick={() => void handleSearchConcepts()}
+                  disabled={conceptQuery.trim().length < 2 || isSearchingConcepts}
+                  className="btn btn-ghost btn-sm shrink-0"
+                >
+                  {isSearchingConcepts ? <Loader2 size={14} className="animate-spin" /> : "Search"}
+                </button>
+              </div>
+              {conceptResults.length > 0 && (
+                <div className="rounded-md border border-border-default bg-surface-raised">
+                  {conceptResults.map((concept) => (
+                    <button
+                      key={concept.concept_id}
+                      type="button"
+                      onClick={() => handleAddConcept(concept)}
+                      className="flex w-full items-center justify-between gap-3 border-b border-border-default px-3 py-2 text-left last:border-b-0 hover:bg-surface-overlay"
+                    >
+                      <span className="min-w-0">
+                        <span className="block truncate text-xs font-medium text-text-secondary">{concept.concept_name}</span>
+                        <span className="text-[10px] text-text-ghost">
+                          {concept.concept_id} · {concept.domain_id} · {concept.vocabulary_id}
+                        </span>
+                      </span>
+                      <span className="text-xs text-success">Add</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-xs">
+            <thead className="text-[10px] uppercase tracking-wider text-text-ghost">
+              <tr>
+                <th className="py-2 pr-3 font-medium">Concept</th>
+                <th className="py-2 pr-3 font-medium">Domain</th>
+                <th className="py-2 pr-3 font-medium">Vocabulary</th>
+                <th className="py-2 pr-3 font-medium">Flags</th>
+                {canEdit && <th className="py-2 pr-3 font-medium">Actions</th>}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border-default">
+              {concepts.map((concept, index) => (
+                <tr key={`${asset.id}-${concept.concept_id ?? index}`}>
+                  <td className="py-2 pr-3 text-text-secondary">
+                    <span className="block font-medium">{concept.concept?.concept_name ?? `Concept ${concept.concept_id ?? "missing"}`}</span>
+                    <span className="text-text-ghost">{concept.concept_id ?? "Missing ID"}</span>
+                  </td>
+                  <td className="py-2 pr-3 text-text-muted">{concept.concept?.domain_id ?? "Unknown"}</td>
+                  <td className="py-2 pr-3 text-text-muted">{concept.concept?.vocabulary_id ?? "Unknown"}</td>
+                  <td className="py-2 pr-3 text-text-ghost">
+                    <button
+                      type="button"
+                      onClick={() => handleToggleConcept(concept.concept_id, "is_excluded")}
+                      disabled={!canEdit || isUpdating}
+                      className="hover:text-text-secondary disabled:hover:text-text-ghost"
+                    >
+                      {concept.is_excluded ? "Excluded" : "Included"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleToggleConcept(concept.concept_id, "include_descendants")}
+                      disabled={!canEdit || isUpdating}
+                      className="hover:text-text-secondary disabled:hover:text-text-ghost"
+                    >
+                      {concept.include_descendants ? " · Descendants" : " · No descendants"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleToggleConcept(concept.concept_id, "include_mapped")}
+                      disabled={!canEdit || isUpdating}
+                      className="hover:text-text-secondary disabled:hover:text-text-ghost"
+                    >
+                      {concept.include_mapped ? " · Mapped" : " · No mapped"}
+                    </button>
+                    {concept.concept?.standard_concept !== "S" ? " · Non-standard" : ""}
+                    {concept.concept?.invalid_reason ? " · Invalid" : ""}
+                  </td>
+                  {canEdit && (
+                    <td className="py-2 pr-3">
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveConcept(concept.concept_id)}
+                        disabled={isUpdating}
+                        className="text-xs text-critical hover:underline"
+                      >
+                        Remove
+                      </button>
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CohortDraftPanel({
+  assets,
+  readiness,
+  isReadinessLoading,
+  isGenerating,
+  isReviewing,
+  isVerifying,
+  isMaterializing,
+  isLinking,
+  onGenerate,
+  onReview,
+  onVerify,
+  onMaterialize,
+  onLink,
+}: {
+  assets: StudyDesignAsset[];
+  readiness: StudyCohortReadiness | null;
+  isReadinessLoading: boolean;
+  isGenerating: boolean;
+  isReviewing: boolean;
+  isVerifying: boolean;
+  isMaterializing: boolean;
+  isLinking: boolean;
+  onGenerate: () => void;
+  onReview: (asset: StudyDesignAsset, decision: "accept" | "reject" | "defer") => void;
+  onVerify: (asset: StudyDesignAsset) => void;
+  onMaterialize: (asset: StudyDesignAsset) => void;
+  onLink: (asset: StudyDesignAsset) => void;
+}) {
+  const materializedConceptSets = assets.filter((asset) =>
+    asset.asset_type === "concept_set_draft" &&
+    asset.status === "materialized" &&
+    asset.materialized_id != null,
+  );
+  const drafts = assets
+    .filter((asset) => asset.asset_type === "cohort_draft")
+    .sort((left, right) => right.id - left.id);
+  const roleLine = readiness
+    ? readiness.required_roles.map((role) => `${role}: ${readiness.present_roles[role] ?? 0}`).join(" · ")
+    : null;
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-text-secondary">Cohort Drafts</p>
+          <p className="text-xs text-text-ghost">
+            Turn materialized concept sets into native cohort definition drafts.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onGenerate}
+          disabled={materializedConceptSets.length === 0 || isGenerating}
+          className="btn btn-primary btn-sm shrink-0"
+        >
+          {isGenerating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+          Draft Cohorts
+        </button>
+      </div>
+
+      <div className="border-t border-border-default pt-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <p className="text-xs font-semibold text-text-secondary">Study Cohort Readiness</p>
+            <p className="text-[11px] text-text-ghost">
+              {isReadinessLoading ? "Checking linked roles..." : roleLine ?? "No readiness signal yet."}
+            </p>
+          </div>
+          {readiness && (
+            <span
+              className={cn(
+                "rounded-md px-2 py-1 text-[10px] uppercase tracking-wider",
+                readiness.ready_for_feasibility
+                  ? "bg-success/10 text-success"
+                  : "bg-warning/10 text-warning",
+              )}
+            >
+              {readiness.ready_for_feasibility ? "Ready" : "Blocked"}
+            </span>
+          )}
+        </div>
+        {readiness?.blockers[0] && (
+          <p className="mt-2 text-xs text-critical">{readiness.blockers[0].message}</p>
+        )}
+        {!readiness?.blockers[0] && readiness?.warnings[0] && (
+          <p className="mt-2 text-xs text-warning">{readiness.warnings[0].message}</p>
+        )}
+        {readiness && (
+          <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-text-ghost">
+            <span>{readiness.drafts.total} drafts</span>
+            <span>{readiness.drafts.materialized} materialized</span>
+            <span>{readiness.drafts.linked} linked</span>
+          </div>
+        )}
+      </div>
+
+      {materializedConceptSets.length === 0 && (
+        <p className="text-xs text-text-ghost">
+          Materialize at least one verified concept set draft first.
+        </p>
+      )}
+
+      {drafts.length === 0 && (
+        <div className="rounded-md border border-border-default bg-surface-base p-3 text-sm text-text-muted">
+          No cohort drafts yet.
+        </div>
+      )}
+
+      {drafts.map((asset) => (
+        <CohortDraftCard
+          key={asset.id}
+          asset={asset}
+          isReviewing={isReviewing}
+          isVerifying={isVerifying}
+          isMaterializing={isMaterializing}
+          isLinking={isLinking}
+          onReview={onReview}
+          onVerify={onVerify}
+          onMaterialize={onMaterialize}
+          onLink={onLink}
+        />
+      ))}
+    </div>
+  );
+}
+
+function CohortDraftCard({
+  asset,
+  isReviewing,
+  isVerifying,
+  isMaterializing,
+  isLinking,
+  onReview,
+  onVerify,
+  onMaterialize,
+  onLink,
+}: {
+  asset: StudyDesignAsset;
+  isReviewing: boolean;
+  isVerifying: boolean;
+  isMaterializing: boolean;
+  isLinking: boolean;
+  onReview: (asset: StudyDesignAsset, decision: "accept" | "reject" | "defer") => void;
+  onVerify: (asset: StudyDesignAsset) => void;
+  onMaterialize: (asset: StudyDesignAsset) => void;
+  onLink: (asset: StudyDesignAsset) => void;
+}) {
+  const [expanded, setExpanded] = useState(asset.verification_status !== "verified");
+  const payload = asset.draft_payload_json;
+  const verified = asset.verification_status === "verified";
+  const accepted = asset.status === "accepted";
+  const materialized = asset.status === "materialized" && asset.materialized_id != null;
+  const studyCohortId = typeof asset.provenance_json?.study_cohort_id === "number" ? asset.provenance_json.study_cohort_id : null;
+  const verification = asset.verification_json;
+  const blockers = verification?.blocking_reasons ?? [];
+  const warnings = verification?.warnings ?? [];
+  const conceptSetIds = payload.concept_set_ids ?? [];
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-base px-3 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-md bg-success/10 px-2 py-0.5 text-[10px] uppercase tracking-wider text-success">
+              cohort draft
+            </span>
+            <VerificationBadge status={asset.verification_status} />
+            <span className="text-[10px] text-text-muted">{asset.status}</span>
+            {payload.role && <span className="text-[10px] text-text-ghost">{String(payload.role)}</span>}
+          </div>
+          <p className="mt-1 text-sm font-medium text-text-secondary">
+            {payload.title ?? `Cohort draft #${asset.id}`}
+          </p>
+          {payload.logic_description && (
+            <p className="mt-1 text-xs text-text-muted line-clamp-2">{payload.logic_description}</p>
+          )}
+          <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-text-ghost">
+            <span>{conceptSetIds.length} concept sets</span>
+            {materialized && <span>Native cohort #{asset.materialized_id}</span>}
+            {studyCohortId != null && <span>Linked study cohort #{studyCohortId}</span>}
+          </div>
+          {blockers.length > 0 && <p className="mt-2 text-xs text-critical">{blockers[0]}</p>}
+          {blockers.length === 0 && warnings.length > 0 && <p className="mt-2 text-xs text-warning">{warnings[0]}</p>}
+        </div>
+
+        <div className="flex shrink-0 flex-wrap justify-end gap-1">
+          {!materialized && asset.verification_status === "unverified" && (
+            <button type="button" onClick={() => onVerify(asset)} disabled={isVerifying} className="btn btn-ghost btn-sm">
+              Verify
+            </button>
+          )}
+          {!materialized && asset.status === "needs_review" && (
+            <>
+              <button
+                type="button"
+                onClick={() => onReview(asset, "accept")}
+                disabled={isReviewing || !verified}
+                className="btn btn-primary btn-sm"
+              >
+                Accept
+              </button>
+              <button type="button" onClick={() => onReview(asset, "defer")} disabled={isReviewing} className="btn btn-ghost btn-sm">
+                Defer
+              </button>
+              <button type="button" onClick={() => onReview(asset, "reject")} disabled={isReviewing} className="btn btn-ghost btn-sm">
+                Reject
+              </button>
+            </>
+          )}
+          {!materialized && accepted && (
+            <button
+              type="button"
+              onClick={() => onMaterialize(asset)}
+              disabled={isMaterializing || !verified}
+              className="btn btn-primary btn-sm"
+            >
+              Materialize
+            </button>
+          )}
+          {materialized && (
+            <>
+              {studyCohortId == null && (
+                <button
+                  type="button"
+                  onClick={() => onLink(asset)}
+                  disabled={isLinking}
+                  className="btn btn-primary btn-sm"
+                >
+                  Link to Study
+                </button>
+              )}
+              <a href={`/cohort-definitions/${asset.materialized_id}`} className="btn btn-ghost btn-sm">
+                Open Native Editor
+              </a>
+            </>
+          )}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="mt-3 inline-flex items-center gap-1 text-xs text-text-muted hover:text-text-secondary"
+      >
+        {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+        Lint
+      </button>
+
+      {expanded && (
+        <div className="mt-3 border-t border-border-default pt-3">
+          <div className="space-y-1">
+            {(verification?.checks ?? []).map((check) => (
+              <div key={`${asset.id}-${check.name}`} className="flex gap-2 text-xs text-text-muted">
+                <span
+                  className={cn(
+                    "mt-1 h-2 w-2 shrink-0 rounded-full",
+                    check.status === "pass" && "bg-success",
+                    check.status === "warn" && "bg-warning",
+                    check.status === "fail" && "bg-critical",
+                    check.status === "info" && "bg-surface-overlay",
+                  )}
+                />
+                <span>{check.message}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FeasibilityDashboard({
+  assets,
+  readiness,
+  isRunning,
+  onRun,
+}: {
+  assets: StudyDesignAsset[];
+  readiness: StudyCohortReadiness | null;
+  isRunning: boolean;
+  onRun: (sourceIds: number[], minCellCount: number) => void;
+}) {
+  const { data: sources = [], isLoading: sourcesLoading } = useQuery({
+    queryKey: ["sources"],
+    queryFn: fetchSources,
+  });
+  const [selectedSourceIds, setSelectedSourceIds] = useState<number[]>([]);
+  const [minCellCount, setMinCellCount] = useState(5);
+  const selectedIds = selectedSourceIds.length > 0 ? selectedSourceIds : sources[0] ? [sources[0].id] : [];
+  const feasibilityAsset = assets
+    .filter((asset) => asset.asset_type === "feasibility_result")
+    .sort((left, right) => right.id - left.id)[0];
+  const feasibility = feasibilityAsset?.draft_payload_json as unknown as StudyFeasibilityResult | undefined;
+  const canRun = selectedIds.length > 0 && readiness?.ready_for_feasibility === true;
+  const attritionSources = feasibility?.sources.filter((source) =>
+    source.cohorts.some((cohort) => (cohort.attrition ?? []).length > 0),
+  ) ?? [];
+
+  const toggleSource = (source: Source) => {
+    setSelectedSourceIds((current) => {
+      const active = current.length > 0 ? current : sources[0] ? [sources[0].id] : [];
+      return active.includes(source.id)
+        ? active.filter((id) => id !== source.id)
+        : [...active, source.id];
+    });
+  };
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-text-secondary">Feasibility</p>
+          <p className="text-xs text-text-ghost">
+            Check linked cohorts against selected CDM sources before analysis planning.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onRun(selectedIds, minCellCount)}
+          disabled={!canRun || isRunning}
+          className="btn btn-primary btn-sm shrink-0"
+        >
+          {isRunning ? <Loader2 size={14} className="animate-spin" /> : <CheckCircle2 size={14} />}
+          Run Feasibility
+        </button>
+      </div>
+
+      {readiness && !readiness.ready_for_feasibility && (
+        <p className="text-xs text-warning">
+          Link required study cohorts before source feasibility.
+        </p>
+      )}
+
+      <div className="grid gap-3 md:grid-cols-[1fr_auto]">
+        <div>
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-text-ghost">Sources</p>
+          {sourcesLoading ? (
+            <p className="text-xs text-text-muted">Loading sources...</p>
+          ) : sources.length === 0 ? (
+            <p className="text-xs text-text-muted">No CDM sources configured.</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {sources.map((source) => {
+                const active = selectedIds.includes(source.id);
+                return (
+                  <button
+                    key={source.id}
+                    type="button"
+                    onClick={() => toggleSource(source)}
+                    className={cn(
+                      "rounded-md border px-2.5 py-1.5 text-xs",
+                      active
+                        ? "border-success bg-success/10 text-success"
+                        : "border-border-default text-text-muted hover:text-text-secondary",
+                    )}
+                  >
+                    {source.source_name}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+        <label className="text-xs text-text-muted">
+          Small-cell threshold
+          <input
+            type="number"
+            min={1}
+            max={100}
+            value={minCellCount}
+            onChange={(event) => setMinCellCount(Number(event.target.value) || 5)}
+            className="form-input mt-1 w-24"
+          />
+        </label>
+      </div>
+
+      {feasibility ? (
+        <div className="border-t border-border-default pt-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="text-xs font-semibold text-text-secondary">
+                {feasibility.ready_source_count}/{feasibility.source_count} sources ready
+              </p>
+              <p className="text-[11px] text-text-ghost">
+                Ran {new Date(feasibility.ran_at).toLocaleString()}
+              </p>
+            </div>
+            <span
+              className={cn(
+                "rounded-md px-2 py-1 text-[10px] uppercase tracking-wider",
+                feasibility.status === "ready" && "bg-success/10 text-success",
+                feasibility.status === "limited" && "bg-warning/10 text-warning",
+                feasibility.status === "blocked" && "bg-critical/10 text-critical",
+              )}
+            >
+              {feasibility.status}
+            </span>
+          </div>
+          {feasibility.blockers[0] && (
+            <p className="mt-2 text-xs text-critical">{feasibility.blockers[0].message}</p>
+          )}
+          {!feasibility.blockers[0] && feasibility.warnings[0] && (
+            <p className="mt-2 text-xs text-warning">{feasibility.warnings[0].message}</p>
+          )}
+          <div className="mt-3 overflow-x-auto">
+            <table className="min-w-full text-left text-xs">
+              <thead className="text-text-ghost">
+                <tr>
+                  <th className="py-1 pr-3 font-medium">Source</th>
+                  <th className="py-1 pr-3 font-medium">Status</th>
+                  <th className="py-1 pr-3 font-medium">Cohorts</th>
+                  <th className="py-1 pr-3 font-medium">Coverage</th>
+                  <th className="py-1 pr-3 font-medium">Domains</th>
+                  <th className="py-1 pr-3 font-medium">Freshness</th>
+                  <th className="py-1 pr-3 font-medium">DQD</th>
+                </tr>
+              </thead>
+              <tbody>
+                {feasibility.sources.map((source) => (
+                  <tr key={source.source_id} className="border-t border-border-default">
+                    <td className="py-2 pr-3 text-text-secondary">{source.source_name}</td>
+                    <td className="py-2 pr-3">
+                      <span className={source.ready_for_analysis ? "text-success" : "text-warning"}>
+                        {source.ready_for_analysis ? "Ready" : "Review"}
+                      </span>
+                    </td>
+                    <td className="py-2 pr-3 text-text-muted">
+                      {source.cohorts.map((cohort) => (
+                        <span key={cohort.study_cohort_id} className="mr-2 inline-block">
+                          {cohort.role}: {cohort.person_count_suppressed ? `<${feasibility.min_cell_count}` : cohort.person_count ?? "none"}
+                        </span>
+                      ))}
+                    </td>
+                    <td className="py-2 pr-3 text-text-muted">
+                      <span className="block">
+                        {source.coverage?.date_coverage.start_date && source.coverage.date_coverage.end_date
+                          ? `${source.coverage.date_coverage.start_date} to ${source.coverage.date_coverage.end_date}`
+                          : "No dates"}
+                      </span>
+                      <span className="block text-[11px] text-text-ghost">
+                        OP: {source.coverage?.observation_period.record_count ?? "none"}
+                      </span>
+                    </td>
+                    <td className="py-2 pr-3 text-text-muted">
+                      {source.domain_availability
+                        ? `${source.domain_availability.available_role_count}/${source.domain_availability.role_count} roles`
+                        : "Unknown"}
+                    </td>
+                    <td className="py-2 pr-3 text-text-muted">
+                      {!source.coverage || source.coverage.freshness.status === "unknown"
+                        ? "Unknown"
+                        : `${source.coverage.freshness.status}${source.coverage.freshness.days_since_release == null ? "" : ` (${source.coverage.freshness.days_since_release}d)`}`}
+                    </td>
+                    <td className="py-2 pr-3 text-text-muted">
+                      {source.source_quality.dqd.pass_rate == null
+                        ? "No DQD"
+                        : `${source.source_quality.dqd.pass_rate}% pass`}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {attritionSources.length > 0 && (
+            <div className="mt-4 border-t border-border-default pt-3">
+              <p className="text-xs font-semibold text-text-secondary">Attrition</p>
+              <div className="mt-2 grid gap-2 md:grid-cols-2">
+                {attritionSources.map((source) => (
+                  <div key={source.source_id} className="border-l border-border-default pl-3">
+                    <p className="text-xs font-semibold text-text-secondary">{source.source_name}</p>
+                    <div className="mt-2 space-y-1">
+                      {source.cohorts.map((cohort) => (
+                        <div key={cohort.study_cohort_id} className="text-[11px] text-text-muted">
+                          <span className="font-medium text-text-secondary">{cohort.role}</span>
+                          {(cohort.attrition ?? []).map((step) => (
+                            <span key={`${cohort.study_cohort_id}-${step.name}`} className="ml-2 inline-block">
+                              {step.name}: {step.person_count_suppressed ? `<${feasibility.min_cell_count}` : step.person_count ?? "none"}
+                            </span>
+                          ))}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <p className="border-t border-border-default pt-3 text-xs text-text-ghost">
+          No feasibility evidence has been stored for this design version.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function AnalysisPlanPanel({
+  assets,
+  isGenerating,
+  isReviewing,
+  isVerifying,
+  isMaterializing,
+  onGenerate,
+  onReview,
+  onVerify,
+  onMaterialize,
+}: {
+  assets: StudyDesignAsset[];
+  isGenerating: boolean;
+  isReviewing: boolean;
+  isVerifying: boolean;
+  isMaterializing: boolean;
+  onGenerate: () => void;
+  onReview: (asset: StudyDesignAsset, decision: "accept" | "reject" | "defer") => void;
+  onVerify: (asset: StudyDesignAsset) => void;
+  onMaterialize: (asset: StudyDesignAsset) => void;
+}) {
+  const plans = assets
+    .filter((asset) => asset.asset_type === "analysis_plan")
+    .sort((left, right) => (right.rank_score ?? -1) - (left.rank_score ?? -1) || right.id - left.id);
+  const latestFeasibility = assets
+    .filter((asset) => asset.asset_type === "feasibility_result")
+    .sort((left, right) => right.id - left.id)[0];
+  const canGenerate = latestFeasibility != null;
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-text-secondary">Analysis Plans</p>
+          <p className="text-xs text-text-ghost">
+            Compile feasible study cohorts into native HADES-compatible analysis designs.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onGenerate}
+          disabled={!canGenerate || isGenerating}
+          className="btn btn-primary btn-sm shrink-0"
+        >
+          {isGenerating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+          Draft Plans
+        </button>
+      </div>
+
+      {!canGenerate && (
+        <p className="text-xs text-text-ghost">
+          Run source feasibility before drafting analysis plans.
+        </p>
+      )}
+
+      {plans.length === 0 ? (
+        <div className="rounded-md border border-border-default bg-surface-base p-3 text-sm text-text-muted">
+          No analysis plans yet.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {plans.map((asset) => {
+            const payload = asset.draft_payload_json as unknown as Partial<StudyAnalysisPlanDraft>;
+            const blockers = asset.verification_json?.blocking_reasons ?? [];
+            const warnings = asset.verification_json?.warnings ?? [];
+            const verified = asset.verification_status === "verified";
+            const accepted = asset.status === "accepted";
+            const materialized = asset.status === "materialized" && asset.materialized_id != null;
+            const analysisPath = analysisDetailPath(payload.analysis_type, asset.materialized_id);
+
+            return (
+              <div key={asset.id} className="rounded-lg border border-border-default bg-surface-base px-3 py-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded-md bg-success/10 px-2 py-0.5 text-[10px] uppercase tracking-wider text-success">
+                        {payload.analysis_type ?? "analysis"}
+                      </span>
+                      <VerificationBadge status={asset.verification_status} />
+                      <span className="text-[10px] text-text-muted">{asset.status}</span>
+                    </div>
+                    <p className="mt-1 text-sm font-medium text-text-secondary">
+                      {payload.title ?? `Analysis plan #${asset.id}`}
+                    </p>
+                    {payload.description && (
+                      <p className="mt-1 text-xs text-text-muted line-clamp-2">{payload.description}</p>
+                    )}
+                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-text-ghost">
+                      <span>{payload.hades_package ?? "HADES"}</span>
+                      <span>{payload.hades_capability?.installed ? "installed" : "missing"}</span>
+                      <span>Feasibility: {payload.feasibility?.status ?? "unknown"}</span>
+                      {materialized && analysisPath && (
+                        <a href={analysisPath} className="text-success hover:text-success-light">
+                          Native analysis #{asset.materialized_id}
+                        </a>
+                      )}
+                      {materialized && !analysisPath && <span>Native analysis #{asset.materialized_id}</span>}
+                    </div>
+                    {blockers[0] && <p className="mt-2 text-xs text-critical">{blockers[0]}</p>}
+                    {!blockers[0] && warnings[0] && <p className="mt-2 text-xs text-warning">{warnings[0]}</p>}
+                  </div>
+
+                  <div className="flex shrink-0 flex-wrap justify-end gap-1">
+                    {!materialized && asset.verification_status === "unverified" && (
+                      <button
+                        type="button"
+                        onClick={() => onVerify(asset)}
+                        disabled={isVerifying}
+                        className="btn btn-ghost btn-sm"
+                      >
+                        Verify
+                      </button>
+                    )}
+                    {!materialized && asset.status === "needs_review" && (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => onReview(asset, "accept")}
+                          disabled={isReviewing || !verified}
+                          className="btn btn-primary btn-sm"
+                        >
+                          Accept
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onReview(asset, "defer")}
+                          disabled={isReviewing}
+                          className="btn btn-ghost btn-sm"
+                        >
+                          Defer
+                        </button>
+                      </>
+                    )}
+                    {!materialized && accepted && (
+                      <button
+                        type="button"
+                        onClick={() => onMaterialize(asset)}
+                        disabled={isMaterializing}
+                        className="btn btn-primary btn-sm"
+                      >
+                        Materialize
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DesignLockPanel({
+  readiness,
+  isLoading,
+  isLocking,
+  versionStatus,
+  onLock,
+}: {
+  readiness: StudyDesignLockReadiness | null;
+  isLoading: boolean;
+  isLocking: boolean;
+  versionStatus: string;
+  onLock: () => void;
+}) {
+  const blockers = readiness?.blockers ?? [];
+  const warnings = readiness?.warnings ?? [];
+  const summary = readiness?.summary;
+  const provenance = readiness?.provenance_summary;
+  const packageArtifact = readiness?.package_artifact;
+  const locked = readiness?.locked === true || versionStatus === "locked";
+  const canLock = readiness?.can_lock === true && !locked;
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-text-secondary">Package Lock</p>
+          <p className="text-xs text-text-ghost">
+            Freeze accepted intent, concept sets, cohorts, feasibility, and native analyses into an auditable study package.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onLock}
+          disabled={!canLock || isLocking || isLoading}
+          className="btn btn-primary btn-sm shrink-0"
+        >
+          {isLocking ? <Loader2 size={14} className="animate-spin" /> : <Lock size={14} />}
+          {locked ? "Locked" : "Lock Package"}
+        </button>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-5">
+        <EvidenceMetric label="Concept Sets" value={summary?.materialized_concept_sets ?? 0} tone={summary?.materialized_concept_sets ? "success" : "warning"} />
+        <EvidenceMetric label="Cohorts" value={summary?.linked_cohorts ?? 0} tone={summary?.linked_cohorts ? "success" : "warning"} />
+        <EvidenceMetric label="Feasibility" value={summary?.feasibility_status ?? "missing"} tone={summary?.feasibility_status === "ready" ? "success" : "warning"} />
+        <EvidenceMetric label="Analyses" value={summary?.materialized_analysis_plans ?? 0} tone={summary?.materialized_analysis_plans ? "success" : "warning"} />
+        <EvidenceMetric label="Packages" value={summary?.package_assets ?? 0} tone={locked ? "success" : "warning"} />
+      </div>
+
+      {isLoading && (
+        <p className="text-xs text-text-ghost">Checking package readiness...</p>
+      )}
+
+      {!isLoading && blockers[0] && (
+        <p className="text-xs text-critical">{blockers[0].message}</p>
+      )}
+
+      {!isLoading && !blockers[0] && warnings[0] && (
+        <p className="text-xs text-warning">{warnings[0].message}</p>
+      )}
+
+      {!isLoading && readiness?.status === "ready" && (
+        <p className="text-xs text-success">Ready to lock.</p>
+      )}
+
+      {!isLoading && locked && (
+        <div className="space-y-2">
+          <p className="text-xs text-success">Locked package is available in study artifacts.</p>
+          {packageArtifact?.url && (
+            <a href={packageArtifact.url} className="btn btn-ghost btn-sm inline-flex">
+              Download package summary
+            </a>
+          )}
+        </div>
+      )}
+
+      {provenance && (
+        <div className="grid gap-2 sm:grid-cols-4">
+          <EvidenceMetric label="AI Events" value={provenance.ai_events ?? 0} tone="neutral" />
+          <EvidenceMetric label="Reviewed" value={provenance.reviewed_assets ?? 0} tone="neutral" />
+          <EvidenceMetric label="Verified" value={provenance.verified_assets ?? 0} tone="success" />
+          <EvidenceMetric label="Manifest" value={provenance.package_manifest_sha256 ? "signed" : "pending"} tone={provenance.package_manifest_sha256 ? "success" : "neutral"} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BottomUpCompatibilityPanel({
+  assets,
+  isImporting,
+  isCritiquing,
+  canCritique,
+  onImport,
+  onCritique,
+}: {
+  assets: StudyDesignAsset[];
+  isImporting: boolean;
+  isCritiquing: boolean;
+  canCritique: boolean;
+  onImport: () => void;
+  onCritique: () => void;
+}) {
+  const importedAssets = assets.filter((asset) => asset.asset_type.startsWith("imported_"));
+  const critiqueAssets = assets.filter((asset) => asset.asset_type === "design_critique");
+  const latestCritique = critiqueAssets[0]?.draft_payload_json as { message?: string; severity?: string; code?: string } | undefined;
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-text-secondary">Current Study Assets</p>
+          <p className="text-xs text-text-ghost">
+            Bring manually built cohorts and analyses into this design path, then review gaps without changing existing records.
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            onClick={onImport}
+            disabled={isImporting}
+            className="btn btn-ghost btn-sm"
+          >
+            {isImporting ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
+            Import Current
+          </button>
+          <button
+            type="button"
+            onClick={onCritique}
+            disabled={isCritiquing || !canCritique}
+            className="btn btn-primary btn-sm"
+          >
+            {isCritiquing ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+            Critique
+          </button>
+        </div>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-3">
+        <EvidenceMetric label="Imported" value={importedAssets.length} tone={importedAssets.length > 0 ? "success" : "neutral"} />
+        <EvidenceMetric label="Critiques" value={critiqueAssets.length} tone={critiqueAssets.length > 0 ? "warning" : "neutral"} />
+        <EvidenceMetric label="Blocked" value={critiqueAssets.filter((asset) => asset.draft_payload_json.severity === "blocking").length} tone="critical" />
+      </div>
+
+      {latestCritique?.message && (
+        <p className={cn("text-xs", latestCritique.severity === "blocking" ? "text-critical" : "text-warning")}>
+          {latestCritique.message}
+        </p>
+      )}
+
+      {importedAssets.length > 0 && (
+        <div className="flex flex-wrap gap-2 text-[10px] text-text-ghost">
+          {importedAssets.slice(0, 6).map((asset) => (
+            <span key={asset.id} className="rounded-md border border-border-default px-2 py-1">
+              {asset.asset_type.replace("imported_", "").replace(/_/g, " ")}
+              {asset.role ? ` · ${asset.role}` : ""}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EvidenceMetric({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number | string;
+  tone: "success" | "warning" | "critical" | "neutral";
+}) {
+  return (
+    <div className="rounded-md border border-border-default bg-surface-base px-3 py-2">
+      <p
+        className={cn(
+          "text-lg font-semibold",
+          tone === "success" && "text-success",
+          tone === "warning" && "text-warning",
+          tone === "critical" && "text-critical",
+          tone === "neutral" && "text-text-secondary",
+        )}
+      >
+        {value}
+      </p>
+      <p className="text-[10px] uppercase tracking-wider text-text-ghost">{label}</p>
+    </div>
+  );
+}
+
+function RecommendationCard({
+  asset,
+  isReviewing,
+  onReview,
+}: {
+  asset: StudyDesignAsset;
+  isReviewing: boolean;
+  onReview: (asset: StudyDesignAsset, decision: "accept" | "reject" | "defer") => void;
+}) {
+  const [expanded, setExpanded] = useState(asset.verification_status !== "verified");
+  const payload = asset.draft_payload_json;
+  const score = typeof payload.score === "number" ? Math.round(payload.score * 100) : null;
+  const rankScore = typeof asset.rank_score === "number" ? Math.round(asset.rank_score) : null;
+  const typeLabel = asset.asset_type.replace(/_/g, " ");
+  const reviewed = ["accepted", "rejected", "deferred"].includes(asset.status);
+  const verified = asset.verification_status === "verified";
+  const verification = asset.verification_json;
+  const verificationChecks = verification?.checks ?? [];
+  const blockers = verification?.blocking_reasons ?? [];
+  const warnings = verification?.warnings ?? [];
+  const rawSource = verification?.source_summary?.source ?? asset.rank_score_json?.source ?? asset.provenance_json?.source;
+  const source = rawSource == null ? null : String(rawSource);
+  const acceptDisabledReason = verified
+    ? null
+    : verification?.eligibility?.reason ?? "Only deterministically verified recommendations can be accepted.";
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-base px-3 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-md bg-success/10 px-2 py-0.5 text-[10px] uppercase tracking-wider text-success">
+              {typeLabel}
+            </span>
+            {rankScore != null && (
+              <span className="rounded-md border border-border-default px-2 py-0.5 text-[10px] uppercase tracking-wider text-text-muted">
+                Rank {rankScore}
+              </span>
+            )}
+            {score != null && <span className="text-[10px] text-text-ghost">{score}% match</span>}
+            <VerificationBadge status={asset.verification_status} />
+            {asset.status !== "needs_review" && (
+              <span className="text-[10px] text-text-muted">{asset.status}</span>
+            )}
+          </div>
+          <p className="mt-1 text-sm font-medium text-text-secondary">
+            {payload.title ?? `Recommendation #${asset.id}`}
+          </p>
+          {payload.description && (
+            <p className="mt-1 text-xs text-text-muted line-clamp-2">{payload.description}</p>
+          )}
+          {payload.rationale && (
+            <p className="mt-1 text-xs text-text-ghost">{payload.rationale}</p>
+          )}
+          <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-text-ghost">
+            {source && <span>{sourceLabel(source)}</span>}
+            {payload.external_id != null && <span>OHDSI #{String(payload.external_id)}</span>}
+            {payload.domain && <span>{String(payload.domain)}</span>}
+            {payload.has_expression === true && <span>Computable</span>}
+            {payload.is_imported === true && <span>Imported</span>}
+          </div>
+          {blockers.length > 0 && (
+            <p className="mt-2 text-xs text-critical">{blockers[0]}</p>
+          )}
+          {blockers.length === 0 && warnings.length > 0 && (
+            <p className="mt-2 text-xs text-warning">{warnings[0]}</p>
+          )}
+          {acceptDisabledReason && !reviewed && (
+            <p className="mt-2 text-[10px] text-text-ghost">{acceptDisabledReason}</p>
+          )}
+        </div>
+
+        {!reviewed && (
+          <div className="flex shrink-0 gap-1">
+            <button
+              type="button"
+              onClick={() => onReview(asset, "accept")}
+              disabled={isReviewing || !verified}
+              title={acceptDisabledReason ?? undefined}
+              className="btn btn-primary btn-sm"
+            >
+              Accept
+            </button>
+            <button
+              type="button"
+              onClick={() => onReview(asset, "defer")}
+              disabled={isReviewing}
+              className="btn btn-ghost btn-sm"
+            >
+              Defer
+            </button>
+            <button
+              type="button"
+              onClick={() => onReview(asset, "reject")}
+              disabled={isReviewing}
+              className="btn btn-ghost btn-sm"
+            >
+              Reject
+            </button>
+          </div>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="mt-3 inline-flex items-center gap-1 text-xs text-text-muted hover:text-text-secondary"
+      >
+        {expanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+        Evidence
+      </button>
+
+      {expanded && (
+        <div className="mt-3 border-t border-border-default pt-3">
+          <div className="grid gap-3 md:grid-cols-2">
+            <EvidenceBlock title="Source">
+              <EvidenceLine label="Origin" value={source ? sourceLabel(source) : "Unknown"} />
+              <EvidenceLine label="Matched term" value={verification?.source_summary?.matched_term ?? null} />
+              <EvidenceLine label="Canonical record" value={verification?.canonical_summary?.title ?? "No canonical record"} />
+            </EvidenceBlock>
+            <EvidenceBlock title="Governance">
+              <EvidenceLine label="Eligibility" value={verification?.eligibility?.can_accept ? "Acceptable" : "Blocked or needs review"} />
+              <EvidenceLine label="Policy" value={verification?.acceptance_policy ?? asset.rank_score_json?.policy ?? null} />
+              <EvidenceLine label="Next actions" value={(verification?.accepted_downstream_actions ?? []).join(", ")} />
+            </EvidenceBlock>
+          </div>
+
+          {asset.rank_score_json?.components && (
+            <div className="mt-3">
+              <p className="text-[10px] uppercase tracking-wider text-text-ghost">Rank components</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {Object.entries(asset.rank_score_json.components).map(([name, value]) => (
+                  <span
+                    key={`${asset.id}-${name}`}
+                    className="rounded-md border border-border-default px-2 py-1 text-[10px] text-text-muted"
+                  >
+                    {formatEvidenceName(name)} {formatRankComponent(value)}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {verificationChecks.length > 0 && (
+            <div className="mt-3 space-y-1">
+              <p className="text-[10px] uppercase tracking-wider text-text-ghost">Verifier checks</p>
+              {verificationChecks.map((check) => (
+                <div
+                  key={`${asset.id}-${check.name}`}
+                  className="flex gap-2 text-xs text-text-muted"
+                >
+                  <span
+                    className={cn(
+                      "mt-1 h-2 w-2 shrink-0 rounded-full",
+                      check.status === "pass" && "bg-success",
+                      check.status === "warn" && "bg-warning",
+                      check.status === "fail" && "bg-critical",
+                      check.status === "info" && "bg-surface-overlay",
+                    )}
+                  />
+                  <span>{check.message}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EvidenceBlock({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div>
+      <p className="text-[10px] uppercase tracking-wider text-text-ghost">{title}</p>
+      <div className="mt-1 space-y-1">{children}</div>
+    </div>
+  );
+}
+
+function EvidenceLine({ label, value }: { label: string; value: string | number | null | undefined }) {
+  if (value == null || value === "") return null;
+
+  return (
+    <p className="text-xs text-text-muted">
+      <span className="text-text-ghost">{label}:</span> {String(value)}
+    </p>
+  );
+}
+
+function analysisDetailPath(type: string | undefined, id: number | null): string | null {
+  if (id == null) return null;
+
+  const basePath = {
+    characterization: "/analyses/characterizations",
+    incidence_rate: "/analyses/incidence-rates",
+    pathway: "/analyses/pathways",
+    estimation: "/analyses/estimations",
+    prediction: "/analyses/predictions",
+    sccs: "/analyses/sccs",
+    self_controlled_cohort: "/analyses/self-controlled-cohorts",
+    evidence_synthesis: "/analyses/evidence-synthesis",
+  }[type ?? ""];
+
+  return basePath ? `${basePath}/${id}` : null;
+}
+
+function VerificationBadge({ status }: { status: string }) {
+  const label = status === "verified"
+    ? "Verified"
+    : status === "partial"
+      ? "Needs check"
+      : status === "blocked"
+        ? "Blocked"
+        : "Unverified";
+  const tone = status === "verified" ? "success" : status === "blocked" ? "critical" : "warning";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-[10px] uppercase tracking-wider",
+        tone === "success" && "bg-success/10 text-success",
+        tone === "warning" && "bg-warning/10 text-warning",
+        tone === "critical" && "bg-critical/10 text-critical",
+      )}
+    >
+      {tone === "success" ? <CheckCircle2 size={10} /> : <AlertTriangle size={10} />}
+      {label}
+    </span>
+  );
+}
+
+function sourceLabel(source: string): string {
+  return source
+    .replace(/_/g, " ")
+    .replace(/\bstudy-agent\b/i, "StudyAgent")
+    .replace(/\bohdsi\b/i, "OHDSI");
+}
+
+function formatEvidenceName(name: string): string {
+  return name.replace(/_/g, " ");
+}
+
+function formatRankComponent(value: number): string {
+  if (value > 0) return `+${value.toFixed(1)}`;
+  return value.toFixed(1);
+}
+
+function conceptFromVocabulary(concept: Concept): StudyDesignDraftConcept {
+  return {
+    concept_id: concept.concept_id,
+    is_excluded: false,
+    include_descendants: true,
+    include_mapped: false,
+    concept: {
+      concept_id: concept.concept_id,
+      concept_name: concept.concept_name,
+      domain_id: concept.domain_id,
+      vocabulary_id: concept.vocabulary_id,
+      concept_class_id: concept.concept_class_id,
+      standard_concept: concept.standard_concept,
+      concept_code: concept.concept_code,
+      invalid_reason: concept.invalid_reason,
+    },
+  };
+}
+
+function conceptDraftPayload(asset: StudyDesignAsset, concepts: StudyDesignDraftConcept[]) {
+  const payload = asset.draft_payload_json;
+
+  return {
+    title: payload.title ?? `Concept set draft #${asset.id}`,
+    role: payload.role ?? asset.role,
+    domain: payload.domain ?? null,
+    clinical_rationale: payload.clinical_rationale ?? null,
+    search_terms: payload.search_terms ?? [],
+    source_concept_set_references: payload.source_concept_set_references ?? [],
+    concepts: concepts.map((concept) => ({
+      concept_id: Number(concept.concept_id),
+      is_excluded: concept.is_excluded ?? false,
+      include_descendants: concept.include_descendants ?? true,
+      include_mapped: concept.include_mapped ?? false,
+      rationale: concept.rationale ?? null,
+    })),
+  };
+}
+
+function IntentReviewPanel({
+  version,
+  initialFormState,
+  onSave,
+  onAccept,
+  isSaving,
+  isAccepting,
+}: {
+  version: StudyDesignVersion;
+  initialFormState: IntentFormState;
+  onSave: (state: IntentFormState) => void;
+  onAccept: () => void;
+  isSaving: boolean;
+  isAccepting: boolean;
+}) {
+  const [formState, setFormState] = useState(initialFormState);
+  const lint = version.lint_results_json;
+  const isImmutable = ["accepted", "compiled", "locked"].includes(version.status);
+  const isReady = lint?.status === "ready";
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-text-secondary">Intent Review</p>
+          <p className="text-xs text-text-ghost">Version {version.version_number} · {version.status}</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => onSave(formState)}
+            disabled={isSaving || isImmutable}
+            className="btn btn-ghost btn-sm"
+          >
+            {isSaving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+            Save Review
+          </button>
+          <button
+            type="button"
+            onClick={onAccept}
+            disabled={isAccepting || isImmutable || !isReady}
+            className="btn btn-primary btn-sm"
+          >
+            {isAccepting ? <Loader2 size={14} className="animate-spin" /> : <CheckCircle2 size={14} />}
+            Accept Intent
+          </button>
+        </div>
+      </div>
+
+      {lint && lint.issues.length > 0 && (
+        <div className="space-y-2">
+          {lint.issues.map((issue, index) => (
+            <div
+              key={`${issue.field ?? "issue"}-${index}`}
+              className={cn(
+                "flex gap-2 rounded-md border px-3 py-2 text-sm",
+                issue.severity === "blocking"
+                  ? "border-critical/40 bg-critical/10 text-critical"
+                  : "border-warning/40 bg-warning/10 text-warning",
+              )}
+            >
+              <AlertTriangle size={14} className="shrink-0 mt-0.5" />
+              <span>{issue.message}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <Field label="Primary Objective" value={formState.primaryObjective} onChange={(value) => setFormState({ ...formState, primaryObjective: value })} />
+        <Field label="Population" value={formState.population} onChange={(value) => setFormState({ ...formState, population: value })} />
+        <Field label="Exposure" value={formState.exposure} onChange={(value) => setFormState({ ...formState, exposure: value })} />
+        <Field label="Comparator" value={formState.comparator} onChange={(value) => setFormState({ ...formState, comparator: value })} />
+        <Field label="Primary Outcome" value={formState.outcome} onChange={(value) => setFormState({ ...formState, outcome: value })} />
+        <Field label="Time At Risk" value={formState.time} onChange={(value) => setFormState({ ...formState, time: value })} />
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value, onChange }: { label: string; value: string; onChange: (value: string) => void }) {
+  return (
+    <div>
+      <label className="form-label">{label}</label>
+      <textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        rows={2}
+        className="form-input form-textarea"
+      />
+    </div>
+  );
+}
+
+function specToForm(spec: StudyDesignSpec): IntentFormState {
+  return {
+    researchQuestion: spec.study.research_question ?? "",
+    primaryObjective: spec.study.primary_objective ?? "",
+    population: spec.pico.population?.summary ?? "",
+    exposure: spec.pico.intervention_or_exposure?.summary ?? "",
+    comparator: spec.pico.comparator?.summary ?? "",
+    outcome: spec.pico.outcomes?.[0]?.summary ?? "",
+    time: spec.pico.time?.summary ?? "",
+  };
+}
+
+function formToSpec(spec: StudyDesignSpec, form: IntentFormState, study: Study): StudyDesignSpec {
+  return {
+    ...spec,
+    study: {
+      ...spec.study,
+      title: spec.study.title || study.title,
+      short_title: spec.study.short_title ?? study.short_title,
+      research_question: form.researchQuestion || spec.study.research_question || study.primary_objective || "",
+      primary_objective: form.primaryObjective,
+      study_design: spec.study.study_design || study.study_design || "observational",
+      study_type: spec.study.study_type || study.study_type || "custom",
+      target_population_summary: form.population,
+    },
+    pico: {
+      ...spec.pico,
+      population: { ...(spec.pico.population ?? {}), summary: form.population },
+      intervention_or_exposure: { ...(spec.pico.intervention_or_exposure ?? {}), summary: form.exposure },
+      comparator: { ...(spec.pico.comparator ?? {}), summary: form.comparator },
+      outcomes: [{ ...(spec.pico.outcomes?.[0] ?? {}), summary: form.outcome, primary: true }],
+      time: { ...(spec.pico.time ?? {}), summary: form.time },
+    },
+  };
+}
+
+function mutationError(error: unknown): string | null {
+  if (!error) return null;
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  return "Study design request failed.";
+}


### PR DESCRIPTION
## Risk: HIGHEST — touches shipped code on main

This PR has **2 aspects** that need explicit review:

### 1. Enum convention rename (PascalCase → UPPERCASE)
Per CLAUDE.md gotcha #13 (\"DaimonType enum cases are UPPERCASE\"), renamed:

**StudyDesignAssetStatus:**
- \`NeedsReview\` → \`NEEDS_REVIEW\`
- \`Accepted\` → \`ACCEPTED\`
- \`Rejected\` → \`REJECTED\`
- \`Deferred\` → \`DEFERRED\`
- NEW: \`MATERIALIZED\`

**StudyDesignVerificationStatus:**
- \`Unverified\` → \`UNVERIFIED\`
- \`Verified\` → \`VERIFIED\`
- \`Blocked\` → \`BLOCKED\`
- NEW: \`PARTIAL\`

**Backed string values unchanged** — DB schema and existing rows unaffected.

Shipped-code call sites updated (40 references total):
- \`StudyDesignController.php\` (29 refs)
- \`StudyDesignReadinessService.php\` (5 refs)
- \`StudyConceptSetDraftVerifier.php\` (3 refs)
- \`StudyCohortDraftVerifier.php\` (3 refs)

If the PascalCase convention was intentional, revert this PR and we'll redo as option (B) from the triage: 68 find-and-replaces in the stash-extracted services to match PascalCase instead.

### 2. Service layer extraction (33 new files)
- 10 FormRequests under \`app/Http/Requests/StudyDesign/\`
- 17 Services under \`app/Services/StudyDesign/\`
- 4 migrations: add_verification, rename_failed→blocked, add_ranking, add_materialization
- 1 frontend component: StudyDesignWorkbench.tsx (2,271 lines)
- 1 test runner script

## Surgical additions to shipped files
- \`StudyDesignVersion::aiEvents()\` HasMany — needed by StudyDesignLockService
- \`StudyConceptSetDraftVerifier::normalizeConcepts()\` — needed by StudyConceptSetMaterializer
- Lint fix to \`StudyDesignCritiqueService\` (removed redundant \`get(['role'])\` before \`pluck\`)

## Depends on
None — standalone. But consider merging #133 (phenotype-validation) before or after so the services that share enums land in one batch.

## Deployment
\`\`\`bash
./deploy.sh --db  # runs 4 new migrations (GRANT to parthenon_app baked in)
./deploy.sh --frontend  # rebuild SPA with StudyDesignWorkbench
\`\`\`

## Test plan
- [ ] Enum rename doesn't break any existing StudyDesignController endpoint call
- [ ] Migrations run clean, especially 2026_04_15_000006_rename_failed→blocked data migration
- [ ] Existing study_design_assets rows with verification_status='failed' are updated to 'blocked'
- [ ] SPA builds and StudyDesignWorkbench renders

**Recommend: review the enum rename carefully before merging.** If you want PascalCase kept, close this PR and I'll redo as option (B).