### PR TITLE
Add Community runtime compose installer path

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Validate Python installer entry points
         run: |
           python -m py_compile install.py installer/bootstrap_remote.py installer/bundle_manifest.py installer/contract.py installer/data_probe.py installer/webapp.py installer/docker_ops.py installer/build_cosmo.py
+          cp backend/.env.example backend/.env
+          docker compose -f docker-compose.community.yml config >/dev/null
           python install.py --contract plan --community --contract-redact >/tmp/parthenon-community-contract.json
           python install.py --contract data-check --community --contract-redact >/tmp/parthenon-community-data-check.json
           python install.py --contract bundle-manifest --community --contract-redact >/tmp/parthenon-community-bundle-manifest.json

--- a/.github/workflows/build-rust-installer-gui.yml
+++ b/.github/workflows/build-rust-installer-gui.yml
@@ -15,6 +15,7 @@ on:
       - ".github/workflows/build-rust-installer-gui.yml"
       - ".env.example"
       - "backend/.env.example"
+      - "docker-compose.community.yml"
       - "docker-compose.yml"
       - "docker/**"
       - "frontend/.env.example"
@@ -119,6 +120,12 @@ jobs:
         run: |
           python -m py_compile install.py installer/bundle_manifest.py installer/contract.py installer/data_probe.py installer/webapp.py installer/docker_ops.py
           python -m py_compile installer/build_cosmo.py
+          if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+            cp backend/.env.example backend/.env
+            docker compose -f docker-compose.community.yml config >/dev/null
+          else
+            echo "Docker Compose not available on this runner; skipping runtime compose config validation."
+          fi
           python install.py --contract validate --community --contract-redact --contract-pretty
           python install.py --contract plan --community --contract-redact --contract-pretty >/dev/null
           python install.py --contract data-check --community --contract-redact --contract-pretty >/dev/null

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,7 +14,11 @@ on:
     branches: [main]
     paths:
       - 'docker/**'
+      - 'backend/**'
+      - 'frontend/**'
+      - 'ai/**'
       - 'blackrabbit/**'
+      - 'solr/**'
       - '.github/workflows/docker-build.yml'
       # Dependency files — rebuild base images when deps change
       - 'backend/composer.json'
@@ -34,9 +38,11 @@ on:
         type: choice
         options:
           - all
+          - nginx
           - php
           - node
           - postgres
+          - solr
           - python-ai
           - study-agent
           - jupyterhub
@@ -82,9 +88,11 @@ jobs:
           IMAGES='[]'
 
           IMAGE_NAMES=(
+            nginx
             php
             node
             postgres
+            solr
             python-ai
             study-agent
             jupyterhub
@@ -97,14 +105,16 @@ jobs:
           )
 
           declare -A WATCH_PATHS=(
-            [php]="docker/php"
-            [node]="docker/node"
+            [nginx]="docker/nginx frontend docs/site docs/blog backend/public/docs/openapi.yaml"
+            [php]="docker/php backend"
+            [node]="docker/node frontend"
             [postgres]="docker/postgres"
-            [python-ai]="docker/python"
-            [study-agent]="docker/study-agent"
+            [solr]="docker/solr solr/configsets"
+            [python-ai]="docker/python ai backend/resources/help docs GIS OHDSI-scraper scripts"
+            [study-agent]="docker/study-agent study-agent"
             [jupyterhub]="docker/jupyterhub"
             [jupyter-user]="docker/jupyter-user"
-            [darkstar]="docker/r"
+            [darkstar]="docker/r darkstar"
             [hecate]="docker/hecate"
             [blackrabbit]="docker/blackrabbit blackrabbit"
             [fhir-to-cdm]="docker/fhir-to-cdm"
@@ -161,6 +171,7 @@ jobs:
                 add_image "php"
               fi
               if path_changed "frontend/package.json" "frontend/package-lock.json"; then
+                add_image "nginx"
                 add_image "node"
               fi
               if path_changed "ai/requirements.txt" "ai/requirements-dev.txt"; then
@@ -202,9 +213,11 @@ jobs:
 
           # Map image name to Dockerfile path and build context
           case "$NAME" in
+            nginx)           DOCKERFILE="docker/nginx/Dockerfile";         CONTEXT="." ;;
             php)              DOCKERFILE="docker/php/Dockerfile";           CONTEXT="." ;;
             node)             DOCKERFILE="docker/node/Dockerfile";          CONTEXT="." ;;
             postgres)         DOCKERFILE="docker/postgres/Dockerfile";      CONTEXT="." ;;
+            solr)             DOCKERFILE="docker/solr/Dockerfile";          CONTEXT="." ;;
             python-ai)        DOCKERFILE="docker/python/Dockerfile";        CONTEXT="." ;;
             study-agent)      DOCKERFILE="docker/study-agent/Dockerfile";   CONTEXT="." ;;
             jupyterhub)       DOCKERFILE="docker/jupyterhub/Dockerfile";    CONTEXT="." ;;

--- a/.github/workflows/review-pr.yml
+++ b/.github/workflows/review-pr.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
   pull-requests: write
 
 jobs:
@@ -46,7 +47,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: |
+          direct_prompt: |
             You are reviewing a pull request for the Parthenon project.
             Read the review guidelines in .github/prompts/review-pr.md.
 

--- a/docker-compose.community.yml
+++ b/docker-compose.community.yml
@@ -1,0 +1,385 @@
+services:
+  nginx:
+    container_name: parthenon-nginx
+    image: ghcr.io/sudoshi/parthenon-nginx:${PARTHENON_IMAGE_TAG:-latest}
+    ports:
+      - "${NGINX_PORT:-8082}:80"
+    volumes:
+      - parthenon-storage:/var/www/html/storage:ro
+      - ohif-dist:/var/www/ohif:ro
+      - finngen-artifacts:/opt/finngen-artifacts:ro
+    environment:
+      - ORTHANC_AUTH_HEADER=${ORTHANC_AUTH_HEADER:-}
+      - NGINX_ENVSUBST_TEMPLATE_SUFFIX=.template
+      - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/conf.d
+    depends_on:
+      php:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    networks:
+      - parthenon
+    restart: unless-stopped
+
+  php:
+    container_name: parthenon-php
+    image: ghcr.io/sudoshi/parthenon-php:${PARTHENON_IMAGE_TAG:-latest}
+    volumes:
+      - parthenon-storage:/var/www/html/storage
+      - finngen-artifacts:/opt/finngen-artifacts
+    env_file:
+      - ./backend/.env
+    environment:
+      - HOST_UID=${HOST_UID:-1000}
+      - HOST_GID=${HOST_GID:-1000}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "php-fpm-healthcheck || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+    networks:
+      - parthenon
+    restart: unless-stopped
+
+  postgres:
+    container_name: parthenon-postgres
+    image: ghcr.io/sudoshi/parthenon-postgres:${PARTHENON_IMAGE_TAG:-latest}
+    ports:
+      - "${POSTGRES_PORT:-5480}:5432"
+    environment:
+      POSTGRES_DB: parthenon
+      POSTGRES_USER: parthenon
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-secret}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U parthenon"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+    networks:
+      - parthenon
+    restart: unless-stopped
+
+  redis:
+    container_name: parthenon-redis
+    image: redis:7-alpine
+    ports:
+      - "${REDIS_PORT:-6381}:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-parthenon_redis_secret}", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru --requirepass ${REDIS_PASSWORD:-parthenon_redis_secret}
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    networks:
+      - parthenon
+    restart: unless-stopped
+
+  horizon:
+    container_name: parthenon-horizon
+    image: ghcr.io/sudoshi/parthenon-php:${PARTHENON_IMAGE_TAG:-latest}
+    command: php artisan horizon
+    volumes:
+      - parthenon-storage:/var/www/html/storage
+    env_file:
+      - ./backend/.env
+    environment:
+      - HOST_UID=${HOST_UID:-1000}
+      - HOST_GID=${HOST_GID:-1000}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      php:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "php artisan horizon:status | grep -q running || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+    networks:
+      - parthenon
+    restart: unless-stopped
+
+  solr:
+    container_name: parthenon-solr
+    image: ghcr.io/sudoshi/parthenon-solr:${PARTHENON_IMAGE_TAG:-latest}
+    ports:
+      - "${SOLR_PORT:-8983}:8983"
+    volumes:
+      - solr_data:/var/solr
+    environment:
+      - SOLR_JAVA_MEM=${SOLR_JAVA_MEM:--Xms512m -Xmx2g}
+    command: bash -c "precreate-core vocabulary /opt/solr/server/solr/configsets/vocabulary; precreate-core cohorts /opt/solr/server/solr/configsets/cohorts; precreate-core analyses /opt/solr/server/solr/configsets/analyses; precreate-core mappings /opt/solr/server/solr/configsets/mappings; precreate-core clinical /opt/solr/server/solr/configsets/clinical; precreate-core imaging /opt/solr/server/solr/configsets/imaging; precreate-core claims /opt/solr/server/solr/configsets/claims; precreate-core gis_spatial /opt/solr/server/solr/configsets/gis_spatial; precreate-core vector_explorer /opt/solr/server/solr/configsets/vector_explorer; precreate-core query_library /opt/solr/server/solr/configsets/query_library; exec solr-foreground"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8983/solr/vocabulary/admin/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 3G
+    networks:
+      - parthenon
+    restart: unless-stopped
+
+  qdrant:
+    container_name: parthenon-qdrant
+    image: qdrant/qdrant:v1.17.1
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - qdrant-data:/qdrant/storage
+    environment:
+      - QDRANT__STORAGE__OPTIMIZERS__MEMMAP_THRESHOLD_KB=20000
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/6333'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          memory: 8G
+    networks:
+      - parthenon
+    restart: unless-stopped
+
+  hecate:
+    container_name: parthenon-hecate
+    image: ghcr.io/sudoshi/parthenon-hecate:${PARTHENON_IMAGE_TAG:-latest}
+    ports:
+      - "${HECATE_PORT:-8088}:8080"
+    volumes:
+      - ./output/hecate-bootstrap:/app/data:ro
+      - ./output/hecate-bootstrap/ConceptRecordCounts.json:/app/ConceptRecordCounts.json:ro
+    env_file:
+      - ./backend/.env
+    environment:
+      - SERVER_ADDR=0.0.0.0:8080
+      - VECTORDB_DATA_PATH=/app/data/all_pairs.txt
+      - QDRANT_URI=http://qdrant:6334
+      - CORS_ORIGINS=http://nginx:80
+      - OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+      - OPENAI_API_KEY=not-needed
+      - PG__USER=${HECATE_PG_USER:-parthenon}
+      - PG__PASSWORD=${HECATE_PG_PASSWORD:-}
+      - PG__HOST=host.docker.internal
+      - PG__PORT=5432
+      - PG__DBNAME=${HECATE_PG_DBNAME:-parthenon}
+      - PG__POOL_MAX_SIZE=16
+      - VOCAB_SCHEMA=vocab
+      - CACHE_MAX_CAPACITY=32
+      - CACHE_TTL_DAYS=10
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      qdrant:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf 'http://localhost:8080/api/search?q=health&limit=1' -o /dev/null || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+    networks:
+      - parthenon
+    restart: unless-stopped
+
+  study-agent:
+    container_name: parthenon-study-agent
+    image: ghcr.io/sudoshi/parthenon-study-agent:${PARTHENON_IMAGE_TAG:-latest}
+    ports:
+      - "${STUDY_AGENT_PORT:-8765}:8765"
+    volumes:
+      - study-agent-data:/data/phenotype-index
+    environment:
+      - LLM_API_URL=${LLM_API_URL:-http://host.docker.internal:11434/v1/chat/completions}
+      - LLM_API_KEY=${LLM_API_KEY:-ollama}
+      - LLM_MODEL=${LLM_MODEL:-gemma3:4b}
+      - EMBED_URL=${EMBED_URL:-http://host.docker.internal:11434/api/embed}
+      - EMBED_MODEL=${EMBED_MODEL:-nomic-embed-text}
+      - PHENOTYPE_INDEX_DIR=/data/phenotype-index
+      - MCP_PORT=3000
+      - STUDY_AGENT_PORT=8765
+      - MCP_TRANSPORT=http
+      - MCP_HOST=0.0.0.0
+      - STUDY_AGENT_HOST=0.0.0.0
+      - STUDY_AGENT_THREADING=1
+      - STUDY_AGENT_ALLOW_CORE_FALLBACK=1
+      - FINNGEN_COHORT_OPERATIONS_ENABLED=1
+      - FINNGEN_CO2_ANALYSIS_ENABLED=1
+      - FINNGEN_HADES_EXTRAS_ENABLED=1
+      - FINNGEN_ROMOPAPI_ENABLED=1
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8765/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 45s
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+    networks:
+      - parthenon
+    restart: unless-stopped
+
+  blackrabbit:
+    container_name: parthenon-blackrabbit
+    image: ghcr.io/sudoshi/parthenon-blackrabbit:${PARTHENON_IMAGE_TAG:-latest}
+    ports:
+      - "${BLACKRABBIT_PORT:-8090}:8090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - BLACKRABBIT_SCAN_TIMEOUT_SECONDS=${BLACKRABBIT_SCAN_TIMEOUT_SECONDS:-1200}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8090/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+    networks:
+      - parthenon
+    restart: unless-stopped
+
+  fhir-to-cdm:
+    container_name: parthenon-fhir-to-cdm
+    image: ghcr.io/sudoshi/parthenon-fhir-to-cdm:${PARTHENON_IMAGE_TAG:-latest}
+    ports:
+      - "${FHIR_TO_CDM_PORT:-8091}:8091"
+    environment:
+      - PG_HOST=host.docker.internal
+      - PG_PORT=5432
+      - PG_DATABASE=${FHIR_CDM_PG_DATABASE:-ohdsi}
+      - PG_USER=${FHIR_CDM_PG_USER:-smudoshi}
+      - PG_PASSWORD=${FHIR_CDM_PG_PASSWORD:-}
+      - CDM_SCHEMA=${FHIR_CDM_SCHEMA:-cdm}
+      - VOCAB_SCHEMA=${FHIR_VOCAB_SCHEMA:-omop}
+      - FHIR_CDM_BINARY=/app/dotnet/FHIRtoCDM
+      - FHIR_INPUT_DIR=/tmp/fhir_input
+      - CDM_OUTPUT_DIR=/tmp/cdm_output
+      - FHIR_CDM_TIMEOUT=300
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8091/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+    networks:
+      - parthenon
+    restart: unless-stopped
+
+  orthanc:
+    container_name: parthenon-orthanc
+    image: orthancteam/orthanc:latest
+    ports:
+      - "${ORTHANC_PORT:-8042}:8042"
+    volumes:
+      - orthanc-data:/var/lib/orthanc/db
+    environment:
+      - ORTHANC__NAME=Parthenon Orthanc
+      - ORTHANC__REMOTE_ACCESS_ALLOWED=true
+      - ORTHANC__AUTHENTICATION_ENABLED=true
+      - 'ORTHANC__REGISTERED_USERS={"${ORTHANC_USER:-parthenon}": "${ORTHANC_PASSWORD:-}"}'
+      - ORTHANC_USER=${ORTHANC_USER:-parthenon}
+      - ORTHANC_PASSWORD=${ORTHANC_PASSWORD:-}
+      - ORTHANC__DICOM_WEB__ENABLE=true
+      - ORTHANC__DICOM_WEB__ROOT=/dicom-web/
+      - ORTHANC__DICOM_WEB__ENABLE_WADO=true
+      - ORTHANC__DICOM_WEB__WADO_ROOT=/wado
+      - ORTHANC__POSTGRESQL__ENABLE_INDEX=true
+      - ORTHANC__POSTGRESQL__ENABLE_STORAGE=false
+      - ORTHANC__POSTGRESQL__HOST=${ORTHANC_DB_HOST:-postgres}
+      - ORTHANC__POSTGRESQL__PORT=${ORTHANC_DB_PORT:-5432}
+      - ORTHANC__POSTGRESQL__DATABASE=${DB_DATABASE:-parthenon}
+      - ORTHANC__POSTGRESQL__USERNAME=${DB_USERNAME:-parthenon}
+      - ORTHANC__POSTGRESQL__PASSWORD=${DB_PASSWORD:-}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request,base64,os; urllib.request.urlopen(urllib.request.Request('http://localhost:8042/system', headers={'Authorization': 'Basic ' + base64.b64encode((os.environ.get('ORTHANC_USER','parthenon') + ':' + os.environ.get('ORTHANC_PASSWORD','')).encode()).decode()}))"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+    networks:
+      - parthenon
+    restart: unless-stopped
+
+volumes:
+  postgres-data:
+  redis-data:
+  solr_data:
+  orthanc-data:
+  qdrant-data:
+  study-agent-data:
+  parthenon-storage:
+  finngen-artifacts:
+    name: parthenon_finngen_artifacts
+  ohif-dist:
+
+networks:
+  parthenon:
+    name: parthenon
+    driver: bridge

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:22-alpine AS frontend-builder
+
+WORKDIR /frontend
+
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --legacy-peer-deps
+
+COPY frontend/ ./
+ENV VITE_STUDY_AGENT_ENABLED=false
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY docker/nginx/default.conf.template /etc/nginx/templates/default.conf.template
+COPY --from=frontend-builder /frontend/dist /var/www/frontend
+
+RUN mkdir -p \
+      /var/www/docs-dist \
+      /var/www/html/storage/app/public \
+      /var/www/ohif \
+      /opt/finngen-artifacts \
+    && printf '%s\n' '<!doctype html><html><body><h1>Parthenon documentation</h1><p>Documentation is packaged separately for this release image.</p></body></html>' \
+      > /var/www/docs-dist/index.html \
+    && chown -R nginx:nginx /var/www /opt/finngen-artifacts

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -2,3 +2,5 @@ FROM pgvector/pgvector:pg16
 RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-16-postgis-3 \
     && rm -rf /var/lib/apt/lists/*
+
+COPY docker/postgres/init.sql /docker-entrypoint-initdb.d/01-init.sql

--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -1,0 +1,3 @@
+FROM solr:9.7
+
+COPY --chown=8983:8983 solr/configsets /opt/solr/server/solr/configsets

--- a/docs/devlog/process/rust-installer-v2-bootstrapper-todo.md
+++ b/docs/devlog/process/rust-installer-v2-bootstrapper-todo.md
@@ -11,7 +11,7 @@ target, and guide vocabulary loading without requiring a repo checkout.
       states.
 - [x] Offer local PostgreSQL as the default alternative when the user does not
       have a target database server.
-- [ ] Stop requiring users to clone the full Parthenon repository before
+- [x] Stop requiring users to clone the full Parthenon repository before
       installing.
 - [x] Define the first versioned installer bundle manifest with checksums,
       phases, and DBMS support tiers.
@@ -20,7 +20,7 @@ target, and guide vocabulary loading without requiring a repo checkout.
 - [x] Download a versioned installer bundle containing only required compose
       files, templates, helper scripts, and manifests.
 - [x] Verify downloaded installer bundle checksums before running any phase.
-- [ ] Keep technical JSON and internal config files behind advanced details.
+- [x] Keep technical JSON and internal config files behind advanced details.
 
 ## Data Setup Paths
 
@@ -60,6 +60,8 @@ target, and guide vocabulary loading without requiring a repo checkout.
       installer bundle.
 - [x] Support Windows bundle setup through WSL from either a URL or local
       archive path.
+- [x] Use the verified bundle path with a prebuilt-image Community runtime
+      compose profile instead of backend/frontend source bind mounts.
 - [x] Show the manifest-backed installer bundle readiness check in the Rust
       system check without exposing JSON.
 - [ ] Add resume/rollback for each phase.

--- a/installer/README.md
+++ b/installer/README.md
@@ -114,7 +114,7 @@ python3 install.py --contract bundle-manifest --community --contract-redact
 file list, sizes, SHA-256 hashes, validation results, and bundle digest. It is
 the source of truth for the Rust app's no-repo bootstrapper work.
 
-Create and verify the source-backed installer bundle artifact with:
+Create and verify the Community runtime installer bundle artifact with:
 
 ```bash
 python3 -m installer.bundle_manifest --validate --bundle-dir dist/installer-bundle
@@ -129,6 +129,9 @@ python3 -m installer.bundle_manifest \
 
 The Rust desktop installer can consume the resulting `.tar.gz` from a local
 path or URL, verify it, and run the Python installer from the extracted bundle.
+Bundle-based installs set `PARTHENON_RUNTIME_PROFILE=community-release`, which
+selects `docker-compose.community.yml` and uses prebuilt Community runtime
+images instead of backend/frontend source bind mounts.
 
 ## Modules
 

--- a/installer/bootstrap.py
+++ b/installer/bootstrap.py
@@ -36,17 +36,21 @@ def run_laravel_bootstrap() -> None:
     console.rule("[bold]Phase 4 — Laravel Bootstrap[/bold]")
 
     # Step 1 — composer install
-    # The PHP Dockerfile installs vendor/ into the image, but docker-compose bind-mounts
-    # ./backend:/var/www/html at runtime, which shadows the image's vendor/. On a fresh
-    # clone the host backend/vendor/ doesn't exist, so artisan fails immediately.
-    console.print("[bold]Step 1/7:[/bold] Installing PHP dependencies (composer install)…")
-    rc = utils.run_stream(
-        ["docker", "compose", "exec", "-T", "php",
-         "composer", "install", "--no-dev", "--optimize-autoloader", "--no-interaction"]
-    )
-    if rc != 0:
-        console.print("[red]composer install failed.[/red]")
-        sys.exit(1)
+    # The PHP Dockerfile installs vendor/ into the image. Source-backed installs
+    # bind-mount ./backend over that image path, so they still need composer
+    # install on a fresh checkout. Release-runtime installs keep the baked app
+    # and vendor tree from the image, so this step would only add network risk.
+    if utils.release_runtime_enabled():
+        console.print("[bold]Step 1/7:[/bold] PHP dependencies are packaged in the runtime image.")
+    else:
+        console.print("[bold]Step 1/7:[/bold] Installing PHP dependencies (composer install)…")
+        rc = utils.run_stream(
+            ["docker", "compose", "exec", "-T", "php",
+             "composer", "install", "--no-dev", "--optimize-autoloader", "--no-interaction"]
+        )
+        if rc != 0:
+            console.print("[red]composer install failed.[/red]")
+            sys.exit(1)
 
     # Step 2 — key:generate (skip if already set — re-generating would invalidate
     # encrypted DB data if Phase 4 is being resumed after a partial run).

--- a/installer/cli.py
+++ b/installer/cli.py
@@ -49,6 +49,10 @@ def _clear_state() -> None:
 
 def _build_frontend() -> None:
     console.rule("[bold]Phase 6 — Frontend Build[/bold]")
+    if utils.release_runtime_enabled():
+        console.print("[dim]Using frontend assets packaged in the Community runtime image.[/dim]\n")
+        return
+
     console.print("  [cyan]▶[/cyan] Building React frontend via ./deploy.sh --frontend…")
     rc = utils.run_stream(
         ["env", "DEPLOY_SKIP_SMOKE=true", "bash", "./deploy.sh", "--frontend"]
@@ -147,8 +151,11 @@ def _print_summary(cfg: dict[str, Any]) -> None:
 
     next_steps = [
         f"  • Open {display_url} to log in",
-        "  • Run [bold]./deploy.sh[/bold] after code changes",
     ]
+    if utils.release_runtime_enabled():
+        next_steps.append("  • Update by downloading a newer installer release or pulling newer Community runtime images")
+    else:
+        next_steps.append("  • Run [bold]./deploy.sh[/bold] after code changes")
     if not cfg.get("vocab_zip_path"):
         next_steps.append(
             "  • [bold]Load OMOP vocabulary:[/bold] download from https://athena.ohdsi.org,\n"

--- a/installer/data_probe.py
+++ b/installer/data_probe.py
@@ -7,6 +7,8 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from . import utils
+
 
 LOCAL_POSTGRES_MODE = "Create local PostgreSQL OMOP database"
 EXISTING_CDM_MODE = "Use an existing OMOP CDM"
@@ -176,12 +178,13 @@ def _postgres_checks(cfg: dict[str, Any], *, repo_root: Path) -> list[dict[str, 
 
 
 def _local_postgres_check(repo_root: Path) -> dict[str, str]:
-    compose_file = repo_root / "docker-compose.yml"
+    compose_name = utils.active_compose_file()
+    compose_file = repo_root / compose_name
     if not compose_file.exists():
         return _check(
             "Local PostgreSQL service",
             "warn",
-            "docker-compose.yml was not found; bundle download will need to provide the local database service.",
+            f"{compose_name} was not found; bundle download will need to provide the local database service.",
         )
     if shutil.which("docker") is None:
         return _check(

--- a/installer/docker_ops.py
+++ b/installer/docker_ops.py
@@ -116,11 +116,17 @@ def pull(cfg: dict[str, Any] | None = None) -> None:
     console.print(f"[cyan][1/3] Pulling Docker images for {len(services)} service(s)…[/cyan]")
     rc = utils.run_stream(["docker", "compose", "pull", *services])
     if rc != 0:
+        if utils.release_runtime_enabled():
+            console.print("[red]✗ Could not pull required release images.[/red]")
+            sys.exit(1)
         console.print("[yellow]⚠ Some images failed to pull — continuing with local images.[/yellow]")
 
 
 def build(cfg: dict[str, Any] | None = None) -> None:
     """docker compose build — only builds services we'll actually start."""
+    if utils.release_runtime_enabled():
+        console.print("[cyan][2/3] Using prebuilt Community runtime images.[/cyan]")
+        return
     services = _compose_service_names(cfg)
     console.print(f"[cyan][2/3] Building Docker images for {len(services)} service(s)…[/cyan]")
     rc = utils.run_stream(["docker", "compose", "build", *services])

--- a/installer/installer_manifest.json
+++ b/installer/installer_manifest.json
@@ -4,12 +4,12 @@
   "bundle_version": "0.1.0",
   "target_edition": "Community Edition",
   "checksum_algorithm": "sha256",
-  "description": "Source-backed bootstrap manifest for the Parthenon Community installer. The Rust installer will use this contract as the boundary for downloading and verifying a minimal installer bundle.",
+  "description": "Runtime bootstrap manifest for the Parthenon Community installer. The Rust installer uses this contract as the boundary for downloading and verifying a minimal installer bundle.",
   "source_policy": {
     "goal": "Stop requiring end users to clone the full Parthenon repository before install.",
-    "current_mode": "source-backed",
-    "next_mode": "prebuilt-image bundle",
-    "known_gap": "The current compose file still has source bind mounts for backend, frontend, and selected service contexts. A prebuilt-image compose profile is the next step before the bundle can be truly repo-free."
+    "current_mode": "prebuilt-image runtime compose",
+    "next_mode": "signed release manifest with pinned image digests",
+    "known_gap": "The Community runtime compose profile removes backend/frontend source bind mounts for normal installs, but release channels still need signed artifacts and pinned image digests."
   },
   "file_groups": [
     {
@@ -47,6 +47,7 @@
       "required": true,
       "include": [
         "docker-compose.yml",
+        "docker-compose.community.yml",
         ".env.example",
         "backend/.env.example",
         "frontend/.env.example"

--- a/installer/preflight.py
+++ b/installer/preflight.py
@@ -185,10 +185,11 @@ def _check_disk() -> CheckResult:
 
 
 def _check_repo() -> CheckResult:
-    compose = utils.REPO_ROOT / "docker-compose.yml"
+    compose_name = utils.active_compose_file()
+    compose = utils.REPO_ROOT / compose_name
     if compose.exists():
         return CheckResult("Repo complete", "ok", str(utils.REPO_ROOT))
-    return CheckResult("Repo complete", "fail", "docker-compose.yml not found — run from Parthenon repo root")
+    return CheckResult("Repo complete", "fail", f"{compose_name} not found — run from Parthenon repo root")
 
 
 def _check_existing_install() -> CheckResult:

--- a/installer/rust-gui/src/main.rs
+++ b/installer/rust-gui/src/main.rs
@@ -105,6 +105,9 @@ struct InstallFinished {
     message: String,
 }
 
+const COMMUNITY_RUNTIME_PROFILE: &str = "community-release";
+const COMMUNITY_RUNTIME_COMPOSE_FILE: &str = "docker-compose.community.yml";
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 struct InstallRequest {
     source_mode: String,
@@ -249,6 +252,21 @@ fn resolve_install_source(
 
 fn uses_installer_bundle(request: &InstallRequest) -> bool {
     request.source_mode.trim() == "Use installer bundle"
+}
+
+fn apply_runtime_profile_env(command: &mut Command, request: &InstallRequest) {
+    if uses_installer_bundle(request) {
+        command.env("PARTHENON_RUNTIME_PROFILE", COMMUNITY_RUNTIME_PROFILE);
+        command.env("PARTHENON_COMPOSE_FILE", COMMUNITY_RUNTIME_COMPOSE_FILE);
+    }
+}
+
+fn runtime_profile_exports(request: &InstallRequest) -> &'static str {
+    if uses_installer_bundle(request) {
+        "export PARTHENON_RUNTIME_PROFILE=community-release\nexport PARTHENON_COMPOSE_FILE=docker-compose.community.yml\n"
+    } else {
+        ""
+    }
 }
 
 fn prepare_local_bundle(
@@ -951,6 +969,7 @@ fn build_local_command(
     command.args(["install.py", "--defaults-file"]);
     command.arg(&defaults_path);
     command.arg("--non-interactive");
+    apply_runtime_profile_env(&mut command, request);
 
     Ok(CommandPlan {
         command,
@@ -973,6 +992,7 @@ fn build_windows_wsl_command(
             "Windows installs require a WSL repo path, such as /home/user/Parthenon".to_string()
         })?;
 
+    let runtime_exports = runtime_profile_exports(request);
     let script = format!(
         r#"set -e
 defaults_file=$(mktemp)
@@ -980,6 +1000,7 @@ cat > "$defaults_file" <<'PARTHENON_DEFAULTS'
 {defaults_json}
 PARTHENON_DEFAULTS
 cd {repo}
+{runtime_exports}
 set +e
 python3 install.py --defaults-file "$defaults_file" --non-interactive
 rc=$?
@@ -987,6 +1008,7 @@ rm -f "$defaults_file"
 exit "$rc"
 "#,
         repo = shell_quote(repo_linux),
+        runtime_exports = runtime_exports,
     );
 
     let mut command = Command::new("wsl.exe");
@@ -1291,6 +1313,7 @@ fn build_local_contract_command(
         command.arg("--contract-redact");
     }
     command.arg("--contract-pretty");
+    apply_runtime_profile_env(&mut command, request);
 
     Ok(CommandPlan {
         command,
@@ -1323,6 +1346,7 @@ fn build_windows_contract_command(
             String::new()
         };
 
+    let runtime_exports = runtime_profile_exports(request);
     let script = format!(
         r#"set -e
 contract_input=$(mktemp)
@@ -1330,6 +1354,7 @@ cat > "$contract_input" <<'PARTHENON_CONTRACT_INPUT'
 {seed_json}
 PARTHENON_CONTRACT_INPUT
 cd {repo}
+{runtime_exports}
 set +e
 python3 install.py --contract {action} --community --contract-input "$contract_input"{repo_root_flag}{redact_flag} --contract-pretty
 rc=$?
@@ -1337,6 +1362,7 @@ rm -f "$contract_input"
 exit "$rc"
 "#,
         repo = shell_quote(repo_linux),
+        runtime_exports = runtime_exports,
     );
 
     let mut command = Command::new("wsl.exe");
@@ -1893,6 +1919,43 @@ mod tests {
     }
 
     #[test]
+    fn local_bundle_command_sets_release_runtime_env() {
+        let mut request = request();
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .expect("repo root");
+        request.repo_path = repo_root.to_string_lossy().to_string();
+        request.source_mode = "Use installer bundle".to_string();
+
+        let command_plan =
+            build_local_command(&request, r#"{"edition":"Community Edition"}"#).expect("command");
+        let envs = command_plan
+            .command
+            .get_envs()
+            .filter_map(|(key, value)| {
+                value.map(|value| {
+                    (
+                        key.to_string_lossy().to_string(),
+                        value.to_string_lossy().to_string(),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+
+        assert!(envs.contains(&(
+            "PARTHENON_RUNTIME_PROFILE".to_string(),
+            "community-release".to_string(),
+        )));
+        assert!(envs.contains(&(
+            "PARTHENON_COMPOSE_FILE".to_string(),
+            "docker-compose.community.yml".to_string(),
+        )));
+
+        cleanup_temp_file(command_plan.temp_defaults);
+    }
+
+    #[test]
     fn local_contract_command_uses_python_contract() {
         let mut request = request();
         let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -2222,6 +2285,26 @@ mod tests {
         assert_eq!(args[3], "-lc");
         assert!(args[4].contains("cd '/home/alice'\\''s/Parthenon'"));
         assert!(args[4].contains("python3 install.py --defaults-file"));
+    }
+
+    #[test]
+    fn windows_bundle_command_exports_release_runtime_env() {
+        let mut request = request();
+        request.source_mode = "Use installer bundle".to_string();
+        request.wsl_distro = Some("Ubuntu-24.04".to_string());
+        request.wsl_repo_path = Some("/home/alice/Parthenon".to_string());
+
+        let command_plan =
+            build_windows_wsl_command(&request, r#"{"edition":"Community Edition"}"#)
+                .expect("wsl command");
+        let args = command_plan
+            .command
+            .get_args()
+            .map(|value| value.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+
+        assert!(args[4].contains("export PARTHENON_RUNTIME_PROFILE=community-release"));
+        assert!(args[4].contains("export PARTHENON_COMPOSE_FILE=docker-compose.community.yml"));
     }
 
     #[test]

--- a/installer/tests/test_docker_image_catalog.py
+++ b/installer/tests/test_docker_image_catalog.py
@@ -3,16 +3,21 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from installer import docker_ops
+
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github/workflows/docker-build.yml"
 COMPOSE = ROOT / "docker-compose.yml"
+COMMUNITY_COMPOSE = ROOT / "docker-compose.community.yml"
 JUPYTER_CONFIG = ROOT / "docker/jupyterhub/jupyterhub_config.py"
 
 EXPECTED_WORKFLOW_IMAGES = {
+    "nginx",
     "php",
     "node",
     "postgres",
+    "solr",
     "python-ai",
     "study-agent",
     "jupyterhub",
@@ -62,14 +67,51 @@ def test_workflow_dockerfiles_and_contexts_exist() -> None:
 
 
 def test_compose_ghcr_images_are_buildable_by_workflow() -> None:
-    compose = COMPOSE.read_text(encoding="utf-8")
+    compose = "\n".join(
+        path.read_text(encoding="utf-8") for path in (COMPOSE, COMMUNITY_COMPOSE)
+    )
     workflow_images = _workflow_dispatch_options(_workflow_text()) - {"all"}
     compose_images = set(
-        re.findall(r"ghcr\.io/sudoshi/parthenon-([a-z0-9-]+):latest", compose)
+        re.findall(
+            r"ghcr\.io/sudoshi/parthenon-([a-z0-9-]+):(?:latest|\$\{PARTHENON_IMAGE_TAG:-latest\})",
+            compose,
+        )
     )
 
     assert "morpheus-ingest" not in compose
     assert compose_images <= workflow_images
+
+
+def test_community_runtime_compose_avoids_app_source_mounts() -> None:
+    compose = COMMUNITY_COMPOSE.read_text(encoding="utf-8")
+
+    assert "build:" not in compose
+    assert "./backend:/var/www/html" not in compose
+    assert "./frontend" not in compose
+    assert "./solr/configsets" not in compose
+    assert "ghcr.io/sudoshi/parthenon-nginx:${PARTHENON_IMAGE_TAG:-latest}" in compose
+    assert "ghcr.io/sudoshi/parthenon-solr:${PARTHENON_IMAGE_TAG:-latest}" in compose
+
+
+def test_community_runtime_compose_covers_installer_services() -> None:
+    compose = COMMUNITY_COMPOSE.read_text(encoding="utf-8")
+    compose_services = set(re.findall(r"^  ([a-z0-9-]+):\n", compose, re.MULTILINE))
+    selected_services = set(
+        docker_ops.compose_service_names(
+            {
+                "edition": "Community Edition",
+                "enable_solr": True,
+                "enable_study_agent": True,
+                "enable_hecate": True,
+                "enable_blackrabbit": True,
+                "enable_fhir_to_cdm": True,
+                "enable_orthanc": True,
+            }
+        )
+    )
+
+    assert selected_services <= compose_services
+    assert "horizon" in compose_services
 
 
 def test_jupyterhub_uses_registry_user_image_by_default() -> None:

--- a/installer/tests/test_runtime_profile.py
+++ b/installer/tests/test_runtime_profile.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib
+
+from installer import utils
+
+
+def test_release_runtime_profile_selects_community_compose(monkeypatch) -> None:
+    monkeypatch.delenv("COMPOSE_FILE", raising=False)
+    monkeypatch.delenv("PARTHENON_COMPOSE_FILE", raising=False)
+    monkeypatch.setenv("PARTHENON_RUNTIME_PROFILE", "community-release")
+
+    importlib.reload(utils)
+
+    assert utils.release_runtime_enabled() is True
+    assert utils.active_compose_file() == "docker-compose.community.yml"
+    assert utils.os.environ["COMPOSE_FILE"] == "docker-compose.community.yml"
+
+
+def test_source_runtime_uses_default_compose(monkeypatch) -> None:
+    monkeypatch.delenv("COMPOSE_FILE", raising=False)
+    monkeypatch.delenv("PARTHENON_COMPOSE_FILE", raising=False)
+    monkeypatch.delenv("PARTHENON_RUNTIME_PROFILE", raising=False)
+
+    importlib.reload(utils)
+
+    assert utils.release_runtime_enabled() is False
+    assert utils.active_compose_file() == "docker-compose.yml"
+    assert "COMPOSE_FILE" not in utils.os.environ

--- a/installer/utils.py
+++ b/installer/utils.py
@@ -11,6 +11,47 @@ from pathlib import Path
 from typing import Optional
 
 REPO_ROOT = Path(__file__).parent.parent
+COMMUNITY_RUNTIME_COMPOSE_FILE = "docker-compose.community.yml"
+
+
+# ---------------------------------------------------------------------------
+# Runtime profile helpers
+# ---------------------------------------------------------------------------
+
+def runtime_profile() -> str:
+    return os.environ.get("PARTHENON_RUNTIME_PROFILE", "").strip().lower()
+
+
+def release_runtime_enabled() -> bool:
+    profile = runtime_profile()
+    if profile in {"community", "community-release", "release", "bundle"}:
+        return True
+    return os.environ.get("PARTHENON_RELEASE_COMPOSE", "").strip().lower() in {"1", "true", "yes"}
+
+
+def active_compose_file() -> str:
+    explicit = (
+        os.environ.get("PARTHENON_COMPOSE_FILE")
+        or os.environ.get("COMPOSE_FILE")
+        or ""
+    ).strip()
+    if explicit:
+        return explicit
+    if release_runtime_enabled():
+        return COMMUNITY_RUNTIME_COMPOSE_FILE
+    return "docker-compose.yml"
+
+
+def configure_runtime_environment() -> None:
+    compose_file = active_compose_file()
+    if (
+        (release_runtime_enabled() or os.environ.get("PARTHENON_COMPOSE_FILE"))
+        and "COMPOSE_FILE" not in os.environ
+    ):
+        os.environ["COMPOSE_FILE"] = compose_file
+
+
+configure_runtime_environment()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `docker-compose.community.yml` for the repo-free Community runtime path using prebuilt images and runtime volumes instead of backend/frontend source bind mounts.
- Add runtime images for packaged frontend/nginx assets and Solr configsets, and bake the PostgreSQL init SQL into the Postgres image.
- Wire bundle-based Rust installer runs to set `PARTHENON_RUNTIME_PROFILE=community-release`, so Python selects the runtime compose file, skips local Docker builds, skips frontend compilation, and uses packaged PHP dependencies.
- Expand Docker image CI coverage for `nginx` and `solr`, broaden source watch paths, validate the runtime compose file in installer CI, and update manifest/docs/TODOs.
- Add tests for runtime compose coverage, image catalog coverage, and Rust bundle env wiring.
- Fix the AI Code Review workflow permissions/input name so it can obtain OIDC and use the current Claude action schema.

## Validation

- `python3 -m pytest installer/tests tests/installer`
- `python3 -m py_compile install.py installer/bootstrap.py installer/bundle_manifest.py installer/contract.py installer/data_probe.py installer/docker_ops.py installer/preflight.py installer/utils.py installer/cli.py`
- `cp backend/.env.example backend/.env && docker compose -f docker-compose.community.yml config >/tmp/parthenon-community-compose-config.yml && rm -f backend/.env`
- `cargo fmt --check`
- `cargo test`
- `cargo test python_contract_ -- --ignored`
- `cargo clippy --all-targets -- -D warnings`
- `python3 -m installer.bundle_manifest --validate --bundle-dir /tmp/parthenon-installer-bundle-next --pretty` plus extract-and-validate
- `node --check installer/rust-gui/ui/app.js && node --check installer/web/app.js`
- After rebase/amend: `python3 -m pytest installer/tests/test_docker_image_catalog.py installer/tests/test_runtime_profile.py tests/installer/test_bootstrap_remote.py`, `cargo test bundle_command`, and runtime compose config validation