### PR TITLE
🧹 Clean up unused tempfile import in fhir-to-cdm wrapper

### DIFF
--- a/docker/fhir-to-cdm/wrapper.py
+++ b/docker/fhir-to-cdm/wrapper.py
@@ -13,7 +13,6 @@ import logging
 import os
 import subprocess
 import sys
-import tempfile
 import time
 import uuid
 from http.server import BaseHTTPRequestHandler, HTTPServer


### PR DESCRIPTION
🎯 **What:** Removed unused `tempfile` import from `docker/fhir-to-cdm/wrapper.py`.
💡 **Why:** Reduces clutter and improves maintainability by removing unnecessary dependencies.
✅ **Verification:** Verified by ensuring the script runs properly without the import and passing tests.
✨ **Result:** A cleaner codebase with fewer unused imports.

---
*PR created automatically by Jules for task [4730743491677016377](https://jules.google.com/task/4730743491677016377) started by @sudoshi*