### PR TITLE
🎨 Palette: Add ARIA labels to chat icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-22 - Added aria-labels to icon-only chat buttons
+**Learning:** Found several icon-only buttons in the chat components lacking aria-labels, making them inaccessible to screen readers.
+**Action:** Always add aria-labels to icon-only buttons, specifically in chat actions menus, emoji pickers, and reference pickers. Use i18n translation keys whenever possible for localized accessibility.

--- a/frontend/src/features/commons/components/chat/EmojiPicker.tsx
+++ b/frontend/src/features/commons/components/chat/EmojiPicker.tsx
@@ -45,6 +45,7 @@ export function EmojiPicker({ onSelect, onClose }: EmojiPickerProps) {
             onClose();
           }}
           title={t(`chat.emoji.${EMOJI_MAP[key].labelKey}`)}
+          aria-label={t(`chat.emoji.${EMOJI_MAP[key].labelKey}`)}
           className="flex h-8 w-8 items-center justify-center rounded-md text-lg hover:bg-muted"
         >
           {EMOJI_MAP[key].emoji}

--- a/frontend/src/features/commons/components/chat/MessageActionMenu.tsx
+++ b/frontend/src/features/commons/components/chat/MessageActionMenu.tsx
@@ -52,6 +52,7 @@ export function MessageActionMenu({
     <div ref={menuRef} className="relative">
       <button
         onClick={() => setOpen(!open)}
+        aria-label={t("chat.actions.more", { defaultValue: "More options" })}
         className="rounded-md p-1 text-muted-foreground/60 hover:bg-white/[0.06] hover:text-foreground transition-all"
       >
         <MoreHorizontal className="h-4 w-4" />

--- a/frontend/src/features/commons/components/chat/MessageItem.tsx
+++ b/frontend/src/features/commons/components/chat/MessageItem.tsx
@@ -250,6 +250,7 @@ function ActionBarButton({
     <button
       onClick={onClick}
       title={label}
+      aria-label={label}
       className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground/60 hover:bg-white/[0.08] hover:text-foreground transition-colors"
     >
       <Icon className="h-3.5 w-3.5" />

--- a/frontend/src/features/commons/components/chat/ReferencePicker.tsx
+++ b/frontend/src/features/commons/components/chat/ReferencePicker.tsx
@@ -46,6 +46,7 @@ export function ReferencePicker({ onSelect, onClose }: ReferencePickerProps) {
         </span>
         <button
           onClick={onClose}
+          aria-label={t("ui.aria.close", { defaultValue: "Close" })}
           className="rounded p-0.5 text-muted-foreground hover:text-foreground"
         >
           <X className="h-3.5 w-3.5" />


### PR DESCRIPTION
## 💡 What
Added `aria-label` attributes to several icon-only buttons within the chat components.

## 🎯 Why
These buttons (such as those in the action bar, action menu, emoji picker, and reference picker) lacked accessible names. Without an `aria-label`, screen readers may announce them poorly or not at all, making the interface confusing for visually impaired users. This change improves the accessibility and overall micro-UX of the application.

## ♿ Accessibility
- Ensured all icon-only buttons in the chat context have descriptive labels.
- Used internationalization features (e.g. `t()`) where appropriate to ensure accessibility features are properly localized.

---
*PR created automatically by Jules for task [5375828030256546633](https://jules.google.com/task/5375828030256546633) started by @sudoshi*