### PR TITLE
🎨 Palette: Minor UX and a11y improvements

### DIFF
--- a/frontend/src/components/ui/FilterChip.tsx
+++ b/frontend/src/components/ui/FilterChip.tsx
@@ -35,7 +35,7 @@ export function FilterChip({
             onRemove();
           }}
           role="button"
-          aria-label={`Remove ${label}`}
+          aria-label={`Remove ${label} filter`}
         >
           <X size={12} />
         </span>

--- a/frontend/src/components/ui/__tests__/FilterChip.snapshot.test.tsx
+++ b/frontend/src/components/ui/__tests__/FilterChip.snapshot.test.tsx
@@ -28,7 +28,7 @@ describe("FilterChip snapshots (dark clinical theme)", () => {
       >
         SNOMED
         <span
-          aria-label="Remove SNOMED"
+          aria-label="Remove SNOMED filter"
           class="chip-close"
           role="button"
         >

--- a/frontend/src/i18n/dataSourceIngestionResources.ts
+++ b/frontend/src/i18n/dataSourceIngestionResources.ts
@@ -432,7 +432,7 @@ const enDataSourceIngestion: MessageTree = {
       conceptMapping: "Concept Mapping",
       review: "Review",
       cdmWriting: "CDM Writing",
-      validation: "Validation des donnees",
+      validation: "Validation",
     },
     schemaMapping: {
       title: "Schema Mapping",


### PR DESCRIPTION
This PR introduces two minor micro-UX and accessibility improvements to the interface:

1.  **Accessibility:** Updated the `aria-label` in the `FilterChip` component to append "filter" (e.g. `Remove SNOMED filter` rather than `Remove SNOMED`), providing screen reader users with clearer context about the action.
2.  **Localization:** Corrected a typo in the English translation for the Ingestion Pipeline where the "Validation" step was incorrectly appearing in French ("Validation des donnees").

Tested with `vitest` and validated snapshot changes.

---
*PR created automatically by Jules for task [15872494328316653744](https://jules.google.com/task/15872494328316653744) started by @sudoshi*