### PR TITLE
fix(templates): PR-C consent observation count (task #35)

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -100,10 +100,7 @@ jobs:
 
       - name: Pytest
         working-directory: templates
-        # Skip integration-marked tests here; the named E2E steps below
-        # cover them individually with appropriate continue-on-error policy
-        # for the known-broken PR-C consent-observation gap (task #35).
-        run: uv run pytest -q --maxfail=1 -m "not integration"
+        run: uv run pytest -q --maxfail=1
 
       - name: hello_cdm E2E
         working-directory: templates
@@ -195,40 +192,25 @@ jobs:
         # MS .NET CLI via the parthenon-anonymizer sidecar HTTP shim.
         run: uv run pytest tests/e2e/test_fhir_anonymizer_ms.py -v -m integration
 
-      # The PR-A and PR-B E2Es pass on their own branches but produce 1
-      # extra observation row when run against PR-C's full mapper graph
-      # (the map_consents node emits unexpected obs against PR-A/PR-B
-       # fixtures). Tracked as Phase 2 follow-up (task #35); marked
-      # continue-on-error here only on the PR-C branch where the
-      # regression manifests.
       - name: fhir_to_omop PR-A E2E
-        continue-on-error: true
         working-directory: templates
         # Phase 1 PR-A: Patient/Encounter/Condition/Observation -> OMOP CDM.
         # Bootstraps vocab + omop, seeds 9 concepts the mappers need, runs
-        # the full 7-stage pipeline against 10 fixture FHIR resources, and
-        # asserts 2/2/2/2/2 row counts for PERSON/VISIT/CONDITION/MEASUREMENT/
-        # OBSERVATION.
+        # the full 7-stage pipeline against 4 PR-A-scoped fixture types
+        # (Patient/Encounter/Condition/Observation), and asserts 2/2/2/2/2
+        # row counts for PERSON/VISIT/CONDITION/MEASUREMENT/OBSERVATION.
         run: uv run pytest tests/e2e/test_fhir_to_omop_pra.py -v -m integration
 
       - name: fhir_to_omop PR-B E2E
-        continue-on-error: true
         working-directory: templates
         # Phase 1 PR-B: extends PR-A with Procedure/Medication/Immunization.
         # Seeds 12 concepts (PR-A 9 + CPT 44950, RxNorm 6809, CVX 141), drops
         # and recreates omop.drug_exposure (Phase 0 ships a barebones table
-        # without SERIAL), runs the 10-stage pipeline against 13 fixture FHIR
-        # resources, and asserts 2/2/2/2/2/1/2 row counts.
+        # without SERIAL), runs the 10-stage pipeline against 7 PR-B-scoped
+        # fixture types, and asserts 2/2/2/2/2/1/2 row counts.
         run: uv run pytest tests/e2e/test_fhir_to_omop_prb.py -v -m integration
 
       - name: fhir_to_omop PR-C E2E
-        # Test currently expects 5 OBSERVATION rows of type 32856 but the
-        # map_consents node emits fewer than expected, yielding "expected 5
-        # observations, got 3". Tracked as a Phase 2 follow-up; does not
-        # affect PR-A/PR-B which are the primary value of this stack.
-        # Marked continue-on-error so Phase 1 can land while the consent
-        # observation count is investigated.
-        continue-on-error: true
         working-directory: templates
         # Phase 1 PR-C: extends PR-A + PR-B with DiagnosticReport + Consent.
         # Seeds 15 concepts (PR-B 12 + LOINC 24331-1 lipid panel, OMOP 4055893

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -100,7 +100,12 @@ jobs:
 
       - name: Pytest
         working-directory: templates
-        run: uv run pytest -q --maxfail=1
+        # Skip the slow lane — the throughput perf harness lives at
+        # tests/performance/ marked `slow + integration`; it has its own
+        # dedicated `perf` job gated to schedule + workflow_dispatch
+        # (see PR #262). The named E2E steps below cover the integration
+        # tests that should always gate.
+        run: uv run pytest -q --maxfail=1 -m "not slow"
 
       - name: hello_cdm E2E
         working-directory: templates

--- a/templates/runtime/nodes/profile_packs/us-core.json
+++ b/templates/runtime/nodes/profile_packs/us-core.json
@@ -15,6 +15,7 @@
     {"type": "DiagnosticReport", "must_support": ["status", "category", "code", "subject", "effective"]},
     {"type": "AllergyIntolerance", "must_support": ["clinicalStatus", "verificationStatus", "code", "patient"]},
     {"type": "DocumentReference", "must_support": ["status", "type", "subject", "content"]},
-    {"type": "QuestionnaireResponse", "must_support": ["status", "questionnaire", "subject", "authored", "item"]}
+    {"type": "QuestionnaireResponse", "must_support": ["status", "questionnaire", "subject", "authored", "item"]},
+    {"type": "Consent", "must_support": ["status", "category", "patient", "dateTime", "provision"]}
   ]
 }

--- a/templates/tests/e2e/test_fhir_to_omop_pra.py
+++ b/templates/tests/e2e/test_fhir_to_omop_pra.py
@@ -213,8 +213,17 @@ def test_fhir_to_omop_pra_runs_to_completion(
 
     fixture_dir = tmp_path / "fhir_in"
     fixture_dir.mkdir()
+    # PR-A scope is Patient/Encounter/Condition/Observation. Exclude PR-B and
+    # PR-C resource types so the OBSERVATION count stays honest at 2.
+    pra_resource_types = {
+        "Patient.ndjson",
+        "Encounter.ndjson",
+        "Condition.ndjson",
+        "Observation.ndjson",
+    }
     for f in (MANIFEST_DIR / "fixtures" / "sample").glob("*.ndjson"):
-        shutil.copy(f, fixture_dir / f.name)
+        if f.name in pra_resource_types:
+            shutil.copy(f, fixture_dir / f.name)
 
     with PostgresContainer("postgres:16") as pg:
         db_url = _normalize_psycopg(pg.get_connection_url())

--- a/templates/tests/e2e/test_fhir_to_omop_prb.py
+++ b/templates/tests/e2e/test_fhir_to_omop_prb.py
@@ -189,8 +189,20 @@ def test_fhir_to_omop_prb_runs_to_completion(
 
     fixture_dir = tmp_path / "fhir_in"
     fixture_dir.mkdir()
+    # PR-B scope is PR-A + Procedure/Medication/Immunization. Exclude PR-C
+    # resource types (DiagnosticReport, Consent) so counts stay honest.
+    prb_resource_types = {
+        "Patient.ndjson",
+        "Encounter.ndjson",
+        "Condition.ndjson",
+        "Observation.ndjson",
+        "Procedure.ndjson",
+        "MedicationRequest.ndjson",
+        "Immunization.ndjson",
+    }
     for f in (MANIFEST_DIR / "fixtures" / "sample").glob("*.ndjson"):
-        shutil.copy(f, fixture_dir / f.name)
+        if f.name in prb_resource_types:
+            shutil.copy(f, fixture_dir / f.name)
 
     with PostgresContainer("postgres:16") as pg:
         db_url = _normalize_psycopg(pg.get_connection_url())


### PR DESCRIPTION
## Summary

Closes the Phase 1 PR-C E2E gap that was masked with \`continue-on-error\` during the merge cascade (PRs #257/#258/#259).

**Root cause:** the \`us-core\` profile pack at \`templates/runtime/nodes/profile_packs/us-core.json\` did not include \`Consent\` in its \`resources\` list. The FHIR ingest node uses the profile pack to gate which NDJSON files get converted to parquet — so \`Consent.ndjson\` was silently skipped, no \`consent.parquet\` was produced, the \`map_consents\` node returned 0 rows, and the 2 expected Consent OBSERVATION rows (type 32856) never reached \`omop.observation\`. Total OBSERVATION count came out at 3 (PR-A 2 social-history + 1 DiagnosticReport panel) instead of the expected 5 (+ 2 Consent).

## Fix

1. **Add \`Consent\` to the \`us-core\` profile pack** with the must_support fields from the US Core Consent profile (status, category, patient, dateTime, provision). Reference: https://hl7.org/fhir/us/core/StructureDefinition-us-core-consent.html
2. **Filter PR-A and PR-B fixture copies** to their respective resource scopes (PR-A: Patient/Encounter/Condition/Observation; PR-B: PR-A + Procedure/MedicationRequest/Immunization). Previously they copied ALL ndjson files which now (post-fix) means they would ingest Consent + DiagnosticReport too, breaking their scoped row-count assertions. Filtering keeps each test's scope honest and matches the documented intent in their docstrings.
3. **Remove the \`continue-on-error\` masks** on the Pytest step and the fhir_to_omop PR-A/B/C E2E steps in \`.github/workflows/templates.yml\` — the underlying bug is fixed, no need to silence anything. The 4 MS-sidecar continue-on-error markers stay (separate issue, task #34).

## Verification

All three FHIR-to-OMOP E2Es pass locally against testcontainers Postgres:
- \`tests/e2e/test_fhir_to_omop_pra.py\` PASSED
- \`tests/e2e/test_fhir_to_omop_prb.py\` PASSED
- \`tests/e2e/test_fhir_to_omop_prc.py\` PASSED

Plus all gates green: ruff + black --line-length 100 + mypy --strict + 470 unit tests.

## Test plan

- [ ] CI \`Lint + Test (parthenon-templates)\` passes without continue-on-error masks
- [ ] PR-C E2E asserts \`observations == 5\` (instead of the 3-with-mask state)
- [ ] PR-A E2E still asserts \`observations == 2\` (PR-A scope unchanged)
- [ ] PR-B E2E still asserts \`observations == 2\` (PR-B scope unchanged)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)