### PR TITLE
fix(docker): scispacy en_core_sci_md wheel URL (404)

### DIFF
--- a/docker/parthenon-scispacy/Dockerfile
+++ b/docker/parthenon-scispacy/Dockerfile
@@ -10,9 +10,12 @@ RUN addgroup --system scisvc && adduser --system --ingroup scisvc scisvc
 WORKDIR /app
 
 COPY requirements.txt .
+# scispacy 0.5.5 ships without v0.5.5 model wheels — the upstream
+# README points at v0.5.4 model artifacts (which are compatible).
+# Per https://github.com/allenai/scispacy/blob/v0.5.5/README.md.
 RUN pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir \
-      https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.5/en_core_sci_md-0.5.5.tar.gz
+      https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_md-0.5.4.tar.gz
 
 # Smoke-load the model so the build fails if the wheel is incompatible
 # with the spacy version, not a customer pulling the image.


### PR DESCRIPTION
## Summary

- The \`parthenon-scispacy\` Dockerfile pinned a v0.5.5 model wheel URL that doesn't exist — \`scispacy 0.5.5\` shipped without v0.5.5-tagged model artifacts.
- Per the [upstream README](https://github.com/allenai/scispacy/blob/v0.5.5/README.md), the v0.5.4 model wheels are the compatible target for scispacy 0.5.5. Updating the URL to point at v0.5.4 unblocks the build.

## Test plan

- [x] \`docker build docker/parthenon-scispacy/\` completes with the new URL
- [x] In-build smoke step \`python -c "import spacy; spacy.load('en_core_sci_md')"\` passes
- [x] No code changes to the runtime — pure Docker fix; existing SciSpaCy backend tests cover the rest

## Background

Surfaced as task #41 (deferred follow-up) during Phase 2 Plan 2 execution. Phase 2 itself completed via PRs #271–#276; this is a small follow-up burn-down before kicking off Phase 3.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)