### PR TITLE
fix(security): patch SQL safety bypass in DataInterrogationService

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** A static Orthanc password (`GixsEIl0hpOAeOwKdmmlAMe04SQ0CKih`) was hardcoded across multiple deployment scripts (`ingest_orthanc.py`, `ingest_dicom.sh`, `link_dicom.py`) and leaked in developer markdown documentation.
 **Learning:** Hardcoding credentials in script files creates a severe risk, as any user or process with access to the source code can interact with sensitive imaging servers. Even internal utility scripts or scripts running in isolated environments must be treated as public artifacts.
 **Prevention:** Always read credentials from environment variables (e.g., `os.environ.get()` or `$VAR`) and provide explicit error messaging when they are missing. Never paste sensitive credentials into documentation or planning files.
+
+## 2025-02-23 - Fix SQL comment bypass in query validation
+**Vulnerability:** A query validation function (`checkSqlSafety`) intended to block destructive queries (like `DROP`, `INSERT`) could be completely bypassed if the attacker added a comment containing a whitelisted schema name (e.g., `DROP TABLE users; -- temp_abby`).
+**Learning:** Checking for substrings or using simple regexes on raw, un-parsed SQL strings is extremely brittle because SQL comments and string literals can hide tokens or introduce false flags.
+**Prevention:** Always strip SQL comments and string literals (replacing them with spaces to preserve token boundaries) before attempting to identify keywords via regex.

--- a/backend/app/Services/AI/DataInterrogationService.php
+++ b/backend/app/Services/AI/DataInterrogationService.php
@@ -15,7 +15,7 @@ class DataInterrogationService
 
     /** Patterns that are NOT allowed on non-temp schemas. */
     private const FORBIDDEN_PATTERNS = [
-        '/\b(INSERT\s+INTO|UPDATE|DELETE\s+FROM|DROP|ALTER|TRUNCATE|CREATE\s+TABLE|CREATE\s+INDEX)\b(?!.*temp_abby)/i',
+        '/\b(INSERT\s+INTO|UPDATE|DELETE\s+FROM|DROP|ALTER|TRUNCATE|CREATE\s+TABLE|CREATE\s+INDEX)\b/i',
         '/\bpg_/i',
     ];
 
@@ -182,17 +182,23 @@ class DataInterrogationService
 
     private function checkSqlSafety(string $sql): ?string
     {
+        // Remove string literals to prevent matching inside them (replaced with space to preserve token boundaries)
+        $stripped = preg_replace("/'[^']*'/", ' ', $sql) ?? $sql;
+
+        // Remove comments to prevent bypasses like "DROP TABLE omop.concept; -- temp_abby"
+        // Replace with space to preserve token boundaries like "DROP/**/TABLE"
+        $stripped = preg_replace('/--.*$|\/\*[\s\S]*?\*\//m', ' ', $stripped) ?? $stripped;
+
         // Check for multi-statement
-        $stripped = preg_replace("/'[^']*'/", '', $sql) ?? $sql;
         if (substr_count($stripped, ';') > 1) {
             return 'Multiple statements are not allowed. Send one query at a time.';
         }
 
         // Check for forbidden patterns (excluding temp_abby operations)
         foreach (self::FORBIDDEN_PATTERNS as $pattern) {
-            if (preg_match($pattern, $sql)) {
+            if (preg_match($pattern, $stripped)) {
                 // Allow CREATE/INSERT/DROP on temp_abby schema
-                if (preg_match('/temp_abby/i', $sql)) {
+                if (preg_match('/temp_abby\./i', $stripped)) {
                     continue;
                 }
 


### PR DESCRIPTION
Cherry-picks the bot fix from #260 onto current main (originals had disconnected history after the templates cascade). Closes #260.