### PR TITLE
Phase 3 Plan 0: sql_node file:// SQL-reference reader (T-021/T-022/T-023/T-024 prerequisite)

### DIFF
--- a/docs/architecture/adr-0015-sql-file-reader.md
+++ b/docs/architecture/adr-0015-sql-file-reader.md
@@ -1,4 +1,4 @@
-# ADR 0015 — `sql_node` `sql_file://` Reader
+# ADR 0015 — `sql_node` `file://` SQL-Reference Reader
 
 **Status:** Accepted (2026-05-06)
 **Deciders:** Phase 3 spec Q10.
@@ -9,28 +9,37 @@
 `sql_node` originally accepted only inline `statements` — a list of SQL
 strings in the manifest YAML. Phase 2 Plan 4 (`load_mimic_iv_omop`) and
 Plan 5 (`artemis_chemo_regimens`) shipped manifests that reference
-`sql_file://` paths for multi-stage SQL bootstrap; these were merged
-with the full testcontainers E2Es deferred until the reader landed.
+`file://` paths for multi-stage SQL bootstrap; these were merged with
+the full testcontainers E2Es deferred until the reader landed.
 
 Inline SQL beyond ~50 lines is unwieldy: loses syntax highlighting,
 breaks line-comment grep, and inflates manifest YAML diffs. Every
 Phase 3 commercial-tier template (claims, registries, lab) needs
 multi-stage SQL too.
 
+> **URI scheme note:** Plan 0 was drafted with the placeholder name
+> `sql_file://`. During execution we aligned with the `file://` URI
+> scheme already shipped in three merged Phase 2 manifests (MIMIC-IV,
+> ARTEMIS, SDTM) rather than re-open those PRs. The schema field is
+> still named `sql_file:` in YAML; only the URI scheme inside the
+> string changed from `sql_file://` to `file://`.
+
 ## Decision
 
-**Add `sql_file://manifests/<id>/sql/<filename>.sql` resolution to
-`sql_node`.** Resolution is:
+**Add `sql_file: file://<rel-path>` resolution to `sql_node`.**
+Resolution is:
 
 1. Relative-only — paths resolve under `NodeContext.manifest_dir`. Any
    `..` traversal or absolute path raises `SqlFileReadError`.
 2. Parameter-expanded — `${parameters.cdm_schema}`-style placeholders
    substitute against the run's parameter dict before execution. The
    substitution helper lives in `runtime.sql_files.resolver` and is the
-   canonical implementation (no prior inline expansion existed in
-   `manifest.py` to extract).
+   canonical implementation for *file content*; the materializer's
+   existing `_interpolate` covers *YAML node-param values* and stays
+   put.
 3. `sql_file` and inline `statements` are mutually exclusive — setting
-   both raises a clear error.
+   both raises a clear error. Same XOR applies to `fetch_query_file` ↔
+   `fetch_query`.
 
 Per Phase 3 spec Q10 = (b), the scope covers inline resolution +
 `${parameters.*}` expansion. SQL caching for re-runs (Q10 option c) is
@@ -40,16 +49,17 @@ deferred to Phase 4.
 
 - All Phase 3 commercial-tier manifests (`claims_to_omop`,
   `registry_to_omop`, `lis_lab_to_omop`, `ai_assisted_mapping`) ship
-  SQL alongside YAML and reference it via `sql_file://`.
-- `NodeContext` gains a `manifest_dir: Path | None` field plumbed
-  through the materializer + Prefect orchestration backend. Existing
-  callers default to `None`; only `sql_file://` consumers require it.
+  SQL alongside YAML and reference it via `sql_file: file://...`.
+- `NodeContext` gains `manifest_dir: Path | None` and `run_parameters:
+  dict[str, Any]` fields, plumbed through the materializer + Prefect
+  orchestration backend. Existing callers default to empty values; only
+  `file://` consumers require them.
 - Phase 2's MIMIC-IV and ARTEMIS testcontainers full-pipeline E2Es
   remain SKIPPED, but the gating reason is updated. Plan 0 unblocked
   one of two original gating items (the reader); the remaining blocker
   is a vocab-seed harness for testcontainers Postgres + a manifest
   run-orchestration driver. Both are tracked as Phase 4 follow-ups.
-- The schema validator (`template.v1.json`) accepts `sql_file` as an
+- The schema validator (`template.v1.json`) documents `sql_file` as an
   alternative to `statements` in `sql` node `params`.
 
 ## Alternatives considered
@@ -61,9 +71,15 @@ deferred to Phase 4.
   into a single inline statement.** Declined — over-engineered for the
   current need; SQL files in the manifest dir are the simplest unit of
   composition.
-- **Allow absolute paths or `file://` (no traversal guard).** Declined
-  — opens the runtime to reading any file the worker process can see,
-  including `/etc/passwd`. Tests assert the guard fires.
+- **Allow absolute paths or unrestricted `file://` (no traversal
+  guard).** Declined — opens the runtime to reading any file the
+  worker process can see, including `/etc/passwd`. Tests assert the
+  guard fires.
+- **Use a custom `sql_file://` URI scheme instead of `file://`.**
+  Declined during execution — three Phase 2 manifests already shipped
+  using `file://`, and re-opening those PRs to rename a URI scheme is
+  far more disruptive than aligning with the convention already on
+  main.
 
 ## Open follow-ups
 

--- a/docs/architecture/adr-0015-sql-file-reader.md
+++ b/docs/architecture/adr-0015-sql-file-reader.md
@@ -1,0 +1,80 @@
+# ADR 0015 — `sql_node` `sql_file://` Reader
+
+**Status:** Accepted (2026-05-06)
+**Deciders:** Phase 3 spec Q10.
+**Implements:** Phase 3 Plan 0 (carry-over follow-up from Phase 0).
+
+## Context
+
+`sql_node` originally accepted only inline `statements` — a list of SQL
+strings in the manifest YAML. Phase 2 Plan 4 (`load_mimic_iv_omop`) and
+Plan 5 (`artemis_chemo_regimens`) shipped manifests that reference
+`sql_file://` paths for multi-stage SQL bootstrap; these were merged
+with the full testcontainers E2Es deferred until the reader landed.
+
+Inline SQL beyond ~50 lines is unwieldy: loses syntax highlighting,
+breaks line-comment grep, and inflates manifest YAML diffs. Every
+Phase 3 commercial-tier template (claims, registries, lab) needs
+multi-stage SQL too.
+
+## Decision
+
+**Add `sql_file://manifests/<id>/sql/<filename>.sql` resolution to
+`sql_node`.** Resolution is:
+
+1. Relative-only — paths resolve under `NodeContext.manifest_dir`. Any
+   `..` traversal or absolute path raises `SqlFileReadError`.
+2. Parameter-expanded — `${parameters.cdm_schema}`-style placeholders
+   substitute against the run's parameter dict before execution. The
+   substitution helper lives in `runtime.sql_files.resolver` and is the
+   canonical implementation (no prior inline expansion existed in
+   `manifest.py` to extract).
+3. `sql_file` and inline `statements` are mutually exclusive — setting
+   both raises a clear error.
+
+Per Phase 3 spec Q10 = (b), the scope covers inline resolution +
+`${parameters.*}` expansion. SQL caching for re-runs (Q10 option c) is
+deferred to Phase 4.
+
+## Consequences
+
+- All Phase 3 commercial-tier manifests (`claims_to_omop`,
+  `registry_to_omop`, `lis_lab_to_omop`, `ai_assisted_mapping`) ship
+  SQL alongside YAML and reference it via `sql_file://`.
+- `NodeContext` gains a `manifest_dir: Path | None` field plumbed
+  through the materializer + Prefect orchestration backend. Existing
+  callers default to `None`; only `sql_file://` consumers require it.
+- Phase 2's MIMIC-IV and ARTEMIS testcontainers full-pipeline E2Es
+  remain SKIPPED, but the gating reason is updated. Plan 0 unblocked
+  one of two original gating items (the reader); the remaining blocker
+  is a vocab-seed harness for testcontainers Postgres + a manifest
+  run-orchestration driver. Both are tracked as Phase 4 follow-ups.
+- The schema validator (`template.v1.json`) accepts `sql_file` as an
+  alternative to `statements` in `sql` node `params`.
+
+## Alternatives considered
+
+- **Heredoc-style YAML multi-line strings.** Declined — loses linting,
+  forces manual escaping of dollar signs, and quoted blocks above ~80
+  lines are illegible in PR diffs.
+- **A separate `parthenon-sql` build step that compiles SQL fragments
+  into a single inline statement.** Declined — over-engineered for the
+  current need; SQL files in the manifest dir are the simplest unit of
+  composition.
+- **Allow absolute paths or `file://` (no traversal guard).** Declined
+  — opens the runtime to reading any file the worker process can see,
+  including `/etc/passwd`. Tests assert the guard fires.
+
+## Open follow-ups
+
+- **Vocab-seed harness for testcontainers Postgres** (Phase 4) — load
+  minimal SNOMED/ICD-10-CM/RxNorm/LOINC concepts so the MIMIC + ARTEMIS
+  full-pipeline E2Es can lift their `pytest.skip`.
+- **Manifest run-orchestration driver** (Phase 4) — a programmatic
+  driver (`runtime.runner.run_manifest(manifest_path, parameters,
+  dsn)`) so E2Es can invoke a manifest end-to-end without the CLI.
+- **SQL caching** (Phase 4) — hash SQL bodies after parameter
+  expansion; skip re-execution for idempotent stages.
+- **`sql_lint` pre-commit hook** — wire `sqlfluff` against
+  `templates/manifests/**/sql/*.sql` once the corpus stabilizes in
+  Phase 3.

--- a/templates/runtime/api.py
+++ b/templates/runtime/api.py
@@ -158,7 +158,10 @@ def submit_run(
             ),
         )
     try:
-        flow, sanitized = Materializer().materialize(manifest, body.parameters)
+        manifest_dir = registry.get_manifest_dir(body.template_id)
+        flow, sanitized = Materializer().materialize(
+            manifest, body.parameters, manifest_dir=manifest_dir
+        )
     except ParameterValidationError as exc:
         raise HTTPException(status_code=422, detail=f"parameter validation failed: {exc}") from exc
     handle = backend.submit(flow)

--- a/templates/runtime/nodes/base.py
+++ b/templates/runtime/nodes/base.py
@@ -52,6 +52,11 @@ class NodeContext:
     Provides a logger, secret accessor, artifact writer rooted at the run's
     artifact directory, and an optional SQLAlchemy-style DSN. The orchestration
     backend constructs and supplies this object.
+
+    ``manifest_dir`` is the directory containing the source ``manifest.yaml``;
+    nodes that resolve ``file://<rel-path>`` references (e.g. ``SqlNode``'s
+    ``sql_file`` parameter — Phase 3 Plan 0) read it from here. ``None`` when
+    the node is invoked outside the registry-driven path (the dev runner).
     """
 
     run_id: str
@@ -60,6 +65,8 @@ class NodeContext:
     secrets: dict[str, str]
     artifact_dir: Path
     db_dsn: str | None
+    manifest_dir: Path | None = None
+    run_parameters: dict[str, Any] = field(default_factory=dict)
 
     def get_secret(self, key: str) -> str:
         if key not in self.secrets:

--- a/templates/runtime/nodes/sql_node.py
+++ b/templates/runtime/nodes/sql_node.py
@@ -5,6 +5,17 @@ transaction. Optional ``fetch_query`` is run AFTER the transaction commits and
 its rows are returned as ``outputs.rows`` (list of dicts). When
 ``result_artifact`` is set, the rows are also written as a JSON artifact under
 that name so post-conditions like ``artifact_present`` can verify them.
+
+Phase 3 Plan 0 (T-022) added file-backed SQL bodies. Each side of the
+inline/file pair is XOR — exactly one source must be set:
+
+* ``statements: [...]`` (inline) XOR ``sql_file: file://<rel>`` (load from disk)
+* ``fetch_query: "..."`` (inline) XOR ``fetch_query_file: file://<rel>``
+
+File-backed bodies are read via :class:`runtime.sql_files.SqlFileResolver` and
+expanded against the current run's ``params`` (``${parameters.NAME}`` tokens).
+Multi-statement files are split on `;` for the bulk transaction; the
+``fetch_query_file`` body is treated as a single SELECT.
 """
 
 from __future__ import annotations
@@ -18,6 +29,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.exc import SQLAlchemyError
 
 from runtime.nodes.base import Node, NodeContext, NodeResult, NodeStatus
+from runtime.sql_files import SqlFileReadError, SqlFileResolver
 
 
 def _json_default(value: Any) -> Any:
@@ -27,6 +39,16 @@ def _json_default(value: Any) -> Any:
     if isinstance(value, Decimal):
         return str(value)
     raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _split_statements(body: str) -> list[str]:
+    """Split a SQL file body into individual statements on ``;`` boundaries.
+
+    Trims whitespace and drops empty fragments so trailing newlines / comments
+    after the last ``;`` don't produce empty statements.
+    """
+    parts = [s.strip() for s in body.split(";")]
+    return [p for p in parts if p]
 
 
 class SqlNode(Node):
@@ -40,13 +62,78 @@ class SqlNode(Node):
                 status=NodeStatus.FAILED,
                 error_message="SqlNode requires context.db_dsn to be set",
             )
-        statements = list(params.get("statements", []))
+
+        # Run-level parameter dict for ${parameters.NAME} expansion in SQL
+        # files. The orchestration backend supplies these on NodeContext;
+        # when callers don't (the dev runner, ad-hoc tests), fall back to the
+        # node's own params dict so single-call usage still works.
+        param_dict: dict[str, Any] = {**context.run_parameters, **params}
+
+        # ---- Resolve statements: inline 'statements' XOR 'sql_file' ----
+        sql_file = params.get("sql_file")
+        inline_statements = params.get("statements")
+        if sql_file and inline_statements:
+            return NodeResult(
+                status=NodeStatus.FAILED,
+                error_message=(
+                    "SqlNode: exactly one of 'statements' or 'sql_file' may be set, not both"
+                ),
+            )
+        if sql_file:
+            if context.manifest_dir is None:
+                return NodeResult(
+                    status=NodeStatus.FAILED,
+                    error_message=(
+                        "SqlNode: 'sql_file' requires context.manifest_dir to be set "
+                        "(the orchestration backend must plumb the manifest directory through)"
+                    ),
+                )
+            try:
+                body = SqlFileResolver(manifest_dir=context.manifest_dir).resolve(
+                    sql_file, parameters=param_dict
+                )
+            except SqlFileReadError as exc:
+                return NodeResult(
+                    status=NodeStatus.FAILED,
+                    error_message=f"SqlNode sql_file resolution failed: {exc}",
+                )
+            statements = _split_statements(body)
+        else:
+            statements = list(inline_statements or [])
         if not statements:
             return NodeResult(
                 status=NodeStatus.FAILED,
                 error_message="SqlNode requires non-empty 'statements' list",
             )
+
+        # ---- Resolve fetch_query: inline 'fetch_query' XOR 'fetch_query_file' ----
         fetch_query = params.get("fetch_query")
+        fetch_query_file = params.get("fetch_query_file")
+        if fetch_query and fetch_query_file:
+            return NodeResult(
+                status=NodeStatus.FAILED,
+                error_message=(
+                    "SqlNode: exactly one of 'fetch_query' or 'fetch_query_file' may be set, "
+                    "not both"
+                ),
+            )
+        if fetch_query_file:
+            if context.manifest_dir is None:
+                return NodeResult(
+                    status=NodeStatus.FAILED,
+                    error_message=(
+                        "SqlNode: 'fetch_query_file' requires context.manifest_dir to be set"
+                    ),
+                )
+            try:
+                fetch_query = SqlFileResolver(manifest_dir=context.manifest_dir).resolve(
+                    fetch_query_file, parameters=param_dict
+                )
+            except SqlFileReadError as exc:
+                return NodeResult(
+                    status=NodeStatus.FAILED,
+                    error_message=f"SqlNode fetch_query_file resolution failed: {exc}",
+                )
         result_artifact = params.get("result_artifact")
 
         engine = create_engine(context.db_dsn, future=True)

--- a/templates/runtime/orchestration/flow_spec.py
+++ b/templates/runtime/orchestration/flow_spec.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 
@@ -35,25 +36,34 @@ class FlowNode:
 
 @dataclass
 class FlowSpec:
-    """A directed acyclic graph of FlowNode plus run metadata."""
+    """A directed acyclic graph of FlowNode plus run metadata.
+
+    ``manifest_dir`` is the on-disk directory of the source manifest; nodes
+    that resolve ``file://<rel-path>`` references (Phase 3 Plan 0 ``sql_file``)
+    use it as the security root. ``None`` for hand-built FlowSpecs (tests).
+    """
 
     flow_id: str
     nodes: list[FlowNode] = field(default_factory=list)
     parameters: dict[str, Any] = field(default_factory=dict)
+    manifest_dir: Path | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "flow_id": self.flow_id,
             "nodes": [n.to_dict() for n in self.nodes],
             "parameters": dict(self.parameters),
+            "manifest_dir": str(self.manifest_dir) if self.manifest_dir is not None else None,
         }
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> FlowSpec:
+        manifest_dir_raw = payload.get("manifest_dir")
         return cls(
             flow_id=str(payload["flow_id"]),
             nodes=[FlowNode.from_dict(n) for n in payload.get("nodes", [])],
             parameters=dict(payload.get("parameters") or {}),
+            manifest_dir=Path(manifest_dir_raw) if manifest_dir_raw is not None else None,
         )
 
     def validate(self) -> None:

--- a/templates/runtime/orchestration/prefect_backend.py
+++ b/templates/runtime/orchestration/prefect_backend.py
@@ -142,6 +142,8 @@ class PrefectBackend(OrchestrationBackend):
                 secrets={},
                 artifact_dir=artifact_dir,
                 db_dsn=backend.db_dsn,
+                manifest_dir=flow_spec.manifest_dir,
+                run_parameters=dict(flow_spec.parameters),
             )
             cls = get_node_class(node.type_name)
             backend._append_log(backend_id, node.node_id, "INFO", f"start {node.type_name}")

--- a/templates/runtime/registry/materializer.py
+++ b/templates/runtime/registry/materializer.py
@@ -9,6 +9,7 @@ Two sanitization layers:
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import Any
 
 from jsonschema import Draft202012Validator
@@ -73,9 +74,18 @@ class Materializer:
     """Build a FlowSpec from a Manifest and user-supplied parameters."""
 
     def materialize(
-        self, manifest: Manifest, parameters: dict[str, Any]
+        self,
+        manifest: Manifest,
+        parameters: dict[str, Any],
+        *,
+        manifest_dir: Path | None = None,
     ) -> tuple[FlowSpec, dict[str, Any]]:
-        """Validate parameters, redact secrets, and return ``(flow_spec, sanitized_params)``."""
+        """Validate parameters, redact secrets, and return ``(flow_spec, sanitized_params)``.
+
+        ``manifest_dir`` is propagated to :class:`FlowSpec` so downstream
+        nodes (e.g. SqlNode) can resolve ``file://<rel-path>`` references
+        relative to the source manifest directory (Phase 3 Plan 0).
+        """
         param_schema = {
             "type": "object",
             "properties": manifest.spec.parameters.properties,
@@ -109,6 +119,7 @@ class Materializer:
             flow_id=manifest.metadata.id,
             nodes=nodes,
             parameters=sanitized,
+            manifest_dir=manifest_dir,
         )
         flow.validate()
         return flow, sanitized

--- a/templates/runtime/registry/registry.py
+++ b/templates/runtime/registry/registry.py
@@ -43,3 +43,14 @@ class Registry:
         if not manifest_file.exists():
             raise TemplateNotFoundError(template_id)
         return load_manifest_from_path(manifest_file)
+
+    def get_manifest_dir(self, template_id: str) -> Path:
+        """Return the directory containing the manifest for ``template_id``.
+
+        Phase 3 Plan 0: nodes that resolve ``file://<rel-path>`` references
+        (e.g. SqlNode's ``sql_file``) need this as the security root.
+        """
+        manifest_file = self.root / template_id / "manifest.yaml"
+        if not manifest_file.exists():
+            raise TemplateNotFoundError(template_id)
+        return (self.root / template_id).resolve()

--- a/templates/runtime/registry/schema/template.v1.json
+++ b/templates/runtime/registry/schema/template.v1.json
@@ -78,7 +78,10 @@
                   "regimen_matcher"
                 ]
               },
-              "params": {"type": "object"},
+              "params": {
+                "type": "object",
+                "description": "Node-specific parameters. SQL nodes accept either inline 'statements' (list[str]) or 'sql_file: file://<rel-path>' to load the body from disk; the SqlNode runtime enforces XOR. Same pattern applies to 'fetch_query' vs 'fetch_query_file'."
+              },
               "depends_on": {
                 "type": "array",
                 "items": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$"}

--- a/templates/runtime/runner.py
+++ b/templates/runtime/runner.py
@@ -74,6 +74,11 @@ def run_node(
     db_dsn: str | None = typer.Option(None, "--db-dsn", help="SQLAlchemy DSN, optional."),
     run_id: str = typer.Option("local", "--run-id"),
     node_id: str = typer.Option("local-node", "--node-id"),
+    manifest_dir: Path | None = typer.Option(
+        None,
+        "--manifest-dir",
+        help="Directory of the source manifest; required for sql_node sql_file.",
+    ),
 ) -> None:
     """Execute a single node and print the JSON result to stdout."""
     cls = _REGISTRY.get(node_class)
@@ -93,6 +98,7 @@ def run_node(
         secrets={},
         artifact_dir=resolved_artifact_dir,
         db_dsn=db_dsn,
+        manifest_dir=manifest_dir,
     )
     node = cls()
     result = node.run(context, payload)

--- a/templates/runtime/sql_files/__init__.py
+++ b/templates/runtime/sql_files/__init__.py
@@ -1,0 +1,14 @@
+"""SQL file resolution for sql_node — reads bodies from disk with parameter expansion.
+
+Public API:
+* :class:`SqlFileResolver` — reads ``file://<rel-path>`` references inside a
+  manifest directory, with traversal guard + ``${parameters.NAME}`` expansion.
+* :class:`SqlFileReadError` — raised on any I/O or security failure.
+"""
+
+from __future__ import annotations
+
+from runtime.sql_files.exceptions import SqlFileReadError
+from runtime.sql_files.resolver import SqlFileReference, SqlFileResolver
+
+__all__ = ["SqlFileReadError", "SqlFileReference", "SqlFileResolver"]

--- a/templates/runtime/sql_files/exceptions.py
+++ b/templates/runtime/sql_files/exceptions.py
@@ -1,0 +1,13 @@
+"""Exceptions raised by the sql_files resolver."""
+
+from __future__ import annotations
+
+
+class SqlFileReadError(ValueError):
+    """Raised when a ``file://`` SQL reference cannot be safely read.
+
+    Wraps the underlying cause (path traversal attempt, missing file,
+    permission error, unknown scheme, etc.) into a single error type the
+    SqlNode runtime can branch on without leaking absolute paths into
+    error messages bound for clients.
+    """

--- a/templates/runtime/sql_files/resolver.py
+++ b/templates/runtime/sql_files/resolver.py
@@ -1,0 +1,134 @@
+"""Resolve ``file://<rel-path>`` SQL references inside a manifest directory.
+
+Security posture (ADR 0015):
+* Only the ``file://`` scheme is accepted.
+* Absolute paths and ``..`` segments that would escape the manifest dir
+  are rejected via ``Path.resolve() + is_relative_to``.
+* Files are read as UTF-8 text. Any I/O failure becomes :class:`SqlFileReadError`.
+
+Parameter expansion uses the same ``${parameters.NAME}`` token format as the
+materializer (see :mod:`runtime.registry.materializer`). Phase 3 Plan 0 Task 4
+will extract a shared helper; today the resolver substitutes inline.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from runtime.sql_files.exceptions import SqlFileReadError
+
+_PARAM_REF_PATTERN = re.compile(r"\$\{parameters\.([a-zA-Z_][a-zA-Z0-9_]*)\}")
+_SUPPORTED_SCHEMES = frozenset({"file"})
+
+
+@dataclass(frozen=True)
+class SqlFileReference:
+    """Parsed view of a ``file://<rel-path>`` reference.
+
+    ``relative_path`` is normalized to a forward-slash POSIX path (no leading
+    slash) regardless of the host OS, so manifests stay portable.
+    """
+
+    scheme: str
+    relative_path: str
+
+    @classmethod
+    def parse(cls, reference: str) -> SqlFileReference:
+        """Parse a string into a SqlFileReference.
+
+        Raises:
+            SqlFileReadError: on unknown scheme or malformed URI.
+        """
+        parsed = urlparse(reference)
+        if not parsed.scheme:
+            raise SqlFileReadError(f"missing scheme in SQL reference {reference!r}")
+        if parsed.scheme not in _SUPPORTED_SCHEMES:
+            raise SqlFileReadError(
+                f"unsupported scheme {parsed.scheme!r} in SQL reference {reference!r}; "
+                f"only 'file://' is allowed"
+            )
+        # urlparse('file://sql/x.sql') -> netloc='sql', path='/x.sql'
+        # urlparse('file:///abs/path') -> netloc='', path='/abs/path'  (absolute)
+        # urlparse('file://./sql/x.sql') -> netloc='.', path='/sql/x.sql'
+        if parsed.netloc in ("", None):
+            # No netloc means the URI started with file:/// — an absolute path.
+            raise SqlFileReadError(
+                f"absolute paths are not allowed in SQL references: {reference!r}"
+            )
+        rel = f"{parsed.netloc}{parsed.path}"
+        return cls(scheme=parsed.scheme, relative_path=rel)
+
+
+class SqlFileResolver:
+    """Read SQL bodies from disk relative to a manifest directory."""
+
+    def __init__(self, *, manifest_dir: Path) -> None:
+        self._manifest_dir = manifest_dir.resolve()
+
+    @property
+    def manifest_dir(self) -> Path:
+        return self._manifest_dir
+
+    def resolve(self, reference: str, *, parameters: dict[str, Any]) -> str:
+        """Read ``reference`` and return its body with parameters expanded.
+
+        Args:
+            reference: A ``file://<relative-path>`` URI under the manifest dir.
+            parameters: The run's parameter dict; ``${parameters.NAME}``
+                placeholders are substituted with the corresponding values.
+
+        Returns:
+            The file body as a UTF-8 string with placeholders substituted.
+            Unknown placeholders are left in place to match the materializer's
+            interpolation behavior.
+
+        Raises:
+            SqlFileReadError: on any parse, security, or I/O failure.
+        """
+        ref = SqlFileReference.parse(reference)
+        target = self._safe_resolve(ref.relative_path)
+        try:
+            body = target.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise SqlFileReadError(
+                f"SQL file not found at {ref.relative_path!r} under manifest dir"
+            ) from exc
+        except PermissionError as exc:
+            raise SqlFileReadError(
+                f"permission denied reading SQL file {ref.relative_path!r}"
+            ) from exc
+        except OSError as exc:
+            raise SqlFileReadError(f"failed to read SQL file {ref.relative_path!r}: {exc}") from exc
+        return _expand_parameters(body, parameters)
+
+    def _safe_resolve(self, relative_path: str) -> Path:
+        candidate = Path(relative_path)
+        if candidate.is_absolute():
+            raise SqlFileReadError(
+                f"absolute paths are not allowed in SQL references: {relative_path!r}"
+            )
+        target = (self._manifest_dir / candidate).resolve()
+        try:
+            target.relative_to(self._manifest_dir)
+        except ValueError as exc:
+            raise SqlFileReadError(
+                f"resolved SQL path is outside manifest dir: {relative_path!r}"
+            ) from exc
+        return target
+
+
+def _expand_parameters(template: str, parameters: dict[str, Any]) -> str:
+    """Substitute ``${parameters.NAME}`` placeholders.
+
+    Mirrors the partial-string branch of
+    :func:`runtime.registry.materializer._interpolate`. Unknown placeholders
+    pass through unchanged.
+    """
+    return _PARAM_REF_PATTERN.sub(
+        lambda m: (str(parameters[m.group(1)]) if m.group(1) in parameters else m.group(0)),
+        template,
+    )

--- a/templates/tests/e2e/test_artemis_chemo_regimens.py
+++ b/templates/tests/e2e/test_artemis_chemo_regimens.py
@@ -1,9 +1,12 @@
 """Plan 5 Task 10: ARTEMIS E2E shape — recall ≥80% against gold standard.
 
 Drives the matcher in-process against the synthetic cohort fixture and
-asserts ≥0.80 recall vs the gold-standard regimens CSV. The full
-testcontainers Postgres run is gated until the Phase 0 sql_node gains
-the file:// reader (same gating as Plan 4's E2E).
+asserts ≥0.80 recall vs the gold-standard regimens CSV.
+
+Phase 3 Plan 0 unblocked the sql_file:// reader path; the remaining
+work to lift this to a full testcontainers Postgres run is a vocab-seed
+harness + manifest run-orchestration scaffolding (same shape as Plan 4's
+follow-up — Phase 4 work).
 """
 
 from __future__ import annotations

--- a/templates/tests/e2e/test_load_mimic_iv_omop.py
+++ b/templates/tests/e2e/test_load_mimic_iv_omop.py
@@ -50,18 +50,20 @@ def test_synthetic_fixture_has_expected_row_counts() -> None:
 
 @pytest.mark.integration
 @pytest.mark.skip(
-    reason="Full testcontainers E2E requires vocab seed + manifest run-orchestration; "
-    "structural SQL tests (test_mimic_iv_bootstrap.py + test_mimic_iv_mappers.py) and "
-    "fixture tests above provide the unit-level coverage. Full E2E lands in a "
-    "follow-up commit once the Phase 0 sql_node has the file:// reader required by "
-    "this template's manifest."
+    reason="Full testcontainers E2E still requires vocab seeding + manifest "
+    "run-orchestration scaffolding. Phase 3 Plan 0 landed the sql_node "
+    "sql_file:// reader (one of two original gating items); the remaining "
+    "blocker is a vocab-seed harness for testcontainers Postgres, tracked "
+    "as a Phase 4 follow-up. Structural SQL tests (test_mimic_iv_bootstrap "
+    "+ test_mimic_iv_mappers) and fixture tests above provide unit-level "
+    "coverage in the meantime."
 )
 def test_load_mimic_iv_omop_runs_to_completion() -> None:
     """Full E2E placeholder.
 
-    The manifest references file://sql/*.sql for per-stage SQL bodies via
-    ``sql_file`` parameter. The Phase 0 sql_node does not yet support the
-    ``sql_file`` parameter — currently it only accepts inline ``statements``.
-    Adding the file:// reader is a small follow-up; this test stays SKIPPED
-    until then so the structural assertions above can land green.
+    Phase 3 Plan 0 unblocked the ``sql_file://`` reader path. The remaining
+    work to lift this skip is a vocab-seed harness that loads minimal
+    SNOMED/ICD/RxNorm/LOINC concepts into a testcontainers Postgres + a
+    materializer driver that runs the full manifest end-to-end against
+    that DB. Tracked as a Phase 4 follow-up.
     """

--- a/templates/tests/fixtures/manifests_valid/sql_file_node.yaml
+++ b/templates/tests/fixtures/manifests_valid/sql_file_node.yaml
@@ -1,0 +1,33 @@
+apiVersion: parthenon.acumenus.net/v1
+kind: Template
+metadata:
+  id: sql_file_demo
+  name: sql_file Demo
+  version: 0.1.0
+  category: ingestion
+  cdm_versions: ["5.4"]
+  author: parthenon
+spec:
+  parameters:
+    type: object
+    properties:
+      cdm_schema:
+        type: string
+        default: "omop"
+    required: []
+  requires:
+    cdm_initialized: false
+    vocabularies: []
+  nodes:
+    - node_id: bootstrap
+      type: sql
+      params:
+        sql_file: file://sql/00_bootstrap.sql
+    - node_id: report
+      type: sql
+      depends_on: [bootstrap]
+      params:
+        statements: ["SELECT 1"]
+        fetch_query_file: file://sql/01_report.sql
+        result_artifact: report
+  post_conditions: []

--- a/templates/tests/integration/test_sql_node_with_files.py
+++ b/templates/tests/integration/test_sql_node_with_files.py
@@ -1,0 +1,153 @@
+"""Integration tests: sql_node end-to-end via the Materializer + FlowSpec path.
+
+Phase 3 Plan 0 Task 3 (T-022). The unit suite in
+``tests/unit/test_sql_node.py`` covers the in-process resolver wiring; here
+we stress the Materializer → FlowSpec → SqlNode handoff so a regression in
+``manifest_dir`` plumbing surfaces immediately.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from runtime.nodes.base import NodeContext, NodeStatus
+from runtime.nodes.sql_node import SqlNode
+from runtime.registry.manifest import load_manifest_from_path
+from runtime.registry.materializer import Materializer
+
+
+@pytest.fixture()
+def manifest_with_sql_files(tmp_path: Path) -> Path:
+    """Synthesize a complete manifest dir + bootstrap SQL on disk."""
+    manifest_dir = tmp_path / "demo_template"
+    sql_dir = manifest_dir / "sql"
+    sql_dir.mkdir(parents=True)
+    (sql_dir / "00_bootstrap.sql").write_text(
+        "CREATE TABLE ${parameters.target_schema}_orders (id INTEGER, status TEXT);",
+        encoding="utf-8",
+    )
+    (sql_dir / "01_seed.sql").write_text(
+        "INSERT INTO ${parameters.target_schema}_orders (id, status) VALUES (1, 'open');",
+        encoding="utf-8",
+    )
+    (sql_dir / "99_summary.sql").write_text(
+        "SELECT id, status FROM ${parameters.target_schema}_orders ORDER BY id",
+        encoding="utf-8",
+    )
+
+    manifest_payload = {
+        "apiVersion": "parthenon.acumenus.net/v1",
+        "kind": "Template",
+        "metadata": {
+            "id": "sql_file_integration",
+            "name": "sql_file integration",
+            "version": "0.1.0",
+            "category": "ingestion",
+            "cdm_versions": ["5.4"],
+        },
+        "spec": {
+            "parameters": {
+                "type": "object",
+                "properties": {"target_schema": {"type": "string"}},
+                "required": ["target_schema"],
+            },
+            "requires": {"cdm_initialized": False, "vocabularies": []},
+            "nodes": [
+                {
+                    "node_id": "bootstrap",
+                    "type": "sql",
+                    "params": {"sql_file": "file://sql/00_bootstrap.sql"},
+                },
+                {
+                    "node_id": "seed",
+                    "type": "sql",
+                    "depends_on": ["bootstrap"],
+                    "params": {"sql_file": "file://sql/01_seed.sql"},
+                },
+                {
+                    "node_id": "summarize",
+                    "type": "sql",
+                    "depends_on": ["seed"],
+                    "params": {
+                        "statements": ["SELECT 1"],
+                        "fetch_query_file": "file://sql/99_summary.sql",
+                        "result_artifact": "summary",
+                    },
+                },
+            ],
+            "post_conditions": [],
+        },
+    }
+    (manifest_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(manifest_payload), encoding="utf-8"
+    )
+    return manifest_dir
+
+
+def test_materializer_propagates_manifest_dir(manifest_with_sql_files: Path) -> None:
+    manifest = load_manifest_from_path(manifest_with_sql_files / "manifest.yaml")
+    flow, _ = Materializer().materialize(
+        manifest, {"target_schema": "demo"}, manifest_dir=manifest_with_sql_files
+    )
+    assert flow.manifest_dir == manifest_with_sql_files
+
+
+def test_full_pipeline_against_sqlite(
+    manifest_with_sql_files: Path, tmp_path: Path
+) -> None:
+    """End-to-end: each FlowNode runs SqlNode.run with the manifest_dir set.
+
+    Mirrors what the Prefect backend does, minus the Prefect runtime.
+    """
+    manifest = load_manifest_from_path(manifest_with_sql_files / "manifest.yaml")
+    flow, _ = Materializer().materialize(
+        manifest, {"target_schema": "demo"}, manifest_dir=manifest_with_sql_files
+    )
+    sqlite_url = f"sqlite:///{tmp_path / 'integration.db'}"
+
+    rows: list[dict[str, Any]] = []
+    for fnode in flow.nodes:
+        ctx = NodeContext(
+            run_id="run-1",
+            node_id=fnode.node_id,
+            logger=logging.getLogger(f"test.integration.{fnode.node_id}"),
+            secrets={},
+            artifact_dir=tmp_path,
+            db_dsn=sqlite_url,
+            manifest_dir=flow.manifest_dir,
+            run_parameters=dict(flow.parameters),
+        )
+        result = SqlNode().run(ctx, dict(fnode.params))
+        assert result.status == NodeStatus.SUCCESS, (
+            f"node {fnode.node_id} failed: {result.error_message}"
+        )
+        if "rows" in result.outputs:
+            rows = list(result.outputs["rows"])
+
+    assert rows == [{"id": 1, "status": "open"}]
+
+
+def test_sql_file_traversal_blocked_through_full_pipeline(
+    tmp_path: Path,
+) -> None:
+    """A manifest that asks for ../etc/passwd fails fast at SqlNode."""
+    manifest_dir = tmp_path / "evil"
+    manifest_dir.mkdir()
+    ctx = NodeContext(
+        run_id="run-evil",
+        node_id="bad",
+        logger=logging.getLogger("test.evil"),
+        secrets={},
+        artifact_dir=tmp_path,
+        db_dsn=f"sqlite:///{tmp_path / 'e.db'}",
+        manifest_dir=manifest_dir,
+    )
+    result = SqlNode().run(ctx, {"sql_file": "file://../../etc/passwd"})
+    assert result.status == NodeStatus.FAILED
+    msg = (result.error_message or "").lower()
+    assert "outside manifest dir" in msg

--- a/templates/tests/integration/test_sql_node_with_files.py
+++ b/templates/tests/integration/test_sql_node_with_files.py
@@ -83,9 +83,7 @@ def manifest_with_sql_files(tmp_path: Path) -> Path:
             "post_conditions": [],
         },
     }
-    (manifest_dir / "manifest.yaml").write_text(
-        yaml.safe_dump(manifest_payload), encoding="utf-8"
-    )
+    (manifest_dir / "manifest.yaml").write_text(yaml.safe_dump(manifest_payload), encoding="utf-8")
     return manifest_dir
 
 
@@ -97,9 +95,7 @@ def test_materializer_propagates_manifest_dir(manifest_with_sql_files: Path) -> 
     assert flow.manifest_dir == manifest_with_sql_files
 
 
-def test_full_pipeline_against_sqlite(
-    manifest_with_sql_files: Path, tmp_path: Path
-) -> None:
+def test_full_pipeline_against_sqlite(manifest_with_sql_files: Path, tmp_path: Path) -> None:
     """End-to-end: each FlowNode runs SqlNode.run with the manifest_dir set.
 
     Mirrors what the Prefect backend does, minus the Prefect runtime.
@@ -123,9 +119,9 @@ def test_full_pipeline_against_sqlite(
             run_parameters=dict(flow.parameters),
         )
         result = SqlNode().run(ctx, dict(fnode.params))
-        assert result.status == NodeStatus.SUCCESS, (
-            f"node {fnode.node_id} failed: {result.error_message}"
-        )
+        assert (
+            result.status == NodeStatus.SUCCESS
+        ), f"node {fnode.node_id} failed: {result.error_message}"
         if "rows" in result.outputs:
             rows = list(result.outputs["rows"])
 

--- a/templates/tests/unit/test_manifest_schema.py
+++ b/templates/tests/unit/test_manifest_schema.py
@@ -51,6 +51,19 @@ def test_minimal_valid_manifest_passes(schema: dict[str, object]) -> None:
     assert errors == [], errors
 
 
+def test_sql_node_accepts_sql_file_param(schema: dict[str, object]) -> None:
+    """sql nodes may carry ``sql_file: file://...`` as a body source.
+
+    Phase 3 Plan 0 (T-022): sql_node learns to read SQL bodies from disk.
+    The node-level enforcement (``sql_file`` XOR ``statements``) lives in
+    SqlNode itself; the schema must merely accept the parameter.
+    """
+    manifest = yaml.safe_load((VALID_DIR / "sql_file_node.yaml").read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema)
+    errors = list(validator.iter_errors(manifest))
+    assert errors == [], errors
+
+
 @pytest.mark.parametrize(
     "fixture",
     ["missing_required.yaml", "unknown_node_type.yaml", "circular_dependency.yaml"],

--- a/templates/tests/unit/test_sql_file_resolver.py
+++ b/templates/tests/unit/test_sql_file_resolver.py
@@ -1,0 +1,93 @@
+"""SqlFileResolver: read SQL bodies from manifest-relative file:// references.
+
+Phase 3 Plan 0 Task 2 (T-022). The resolver:
+* parses ``file://<relative>`` references,
+* enforces the resolved path stays inside the manifest dir (traversal guard),
+* expands ``${parameters.NAME}`` placeholders against the run's parameters,
+* raises :class:`SqlFileReadError` on any I/O or security failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from runtime.sql_files import SqlFileReadError, SqlFileResolver
+
+
+def test_resolver_reads_relative_path(tmp_path: Path) -> None:
+    manifest_dir = tmp_path / "demo"
+    sql = manifest_dir / "sql" / "00_bootstrap.sql"
+    sql.parent.mkdir(parents=True)
+    sql.write_text("SELECT 1;\n", encoding="utf-8")
+
+    resolver = SqlFileResolver(manifest_dir=manifest_dir)
+    body = resolver.resolve("file://sql/00_bootstrap.sql", parameters={})
+
+    assert body == "SELECT 1;\n"
+
+
+def test_resolver_expands_parameters(tmp_path: Path) -> None:
+    sql = tmp_path / "sql" / "01.sql"
+    sql.parent.mkdir(parents=True)
+    sql.write_text("CREATE SCHEMA ${parameters.cdm_schema};\n", encoding="utf-8")
+
+    resolver = SqlFileResolver(manifest_dir=tmp_path)
+    body = resolver.resolve("file://sql/01.sql", parameters={"cdm_schema": "omop"})
+
+    assert body == "CREATE SCHEMA omop;\n"
+
+
+def test_resolver_rejects_path_traversal(tmp_path: Path) -> None:
+    resolver = SqlFileResolver(manifest_dir=tmp_path)
+    with pytest.raises(SqlFileReadError) as exc:
+        resolver.resolve("file://../../../etc/passwd", parameters={})
+    assert "outside manifest dir" in str(exc.value).lower()
+
+
+def test_resolver_rejects_absolute_path(tmp_path: Path) -> None:
+    resolver = SqlFileResolver(manifest_dir=tmp_path)
+    with pytest.raises(SqlFileReadError):
+        resolver.resolve("file:///etc/passwd", parameters={})
+
+
+def test_resolver_rejects_missing_file(tmp_path: Path) -> None:
+    resolver = SqlFileResolver(manifest_dir=tmp_path)
+    with pytest.raises(SqlFileReadError) as exc:
+        resolver.resolve("file://sql/does_not_exist.sql", parameters={})
+    assert "not found" in str(exc.value).lower() or "no such" in str(exc.value).lower()
+
+
+def test_resolver_rejects_unknown_scheme(tmp_path: Path) -> None:
+    resolver = SqlFileResolver(manifest_dir=tmp_path)
+    with pytest.raises(SqlFileReadError) as exc:
+        resolver.resolve("http://example.com/x.sql", parameters={})
+    assert "scheme" in str(exc.value).lower()
+
+
+def test_resolver_keeps_unknown_param_placeholder_unchanged(tmp_path: Path) -> None:
+    """Match the materializer's interpolation behavior — unknown params pass through."""
+    sql = tmp_path / "x.sql"
+    sql.write_text("-- ${parameters.unknown}", encoding="utf-8")
+
+    resolver = SqlFileResolver(manifest_dir=tmp_path)
+    body = resolver.resolve("file://x.sql", parameters={})
+
+    assert body == "-- ${parameters.unknown}"
+
+
+def test_resolver_handles_multiple_placeholders(tmp_path: Path) -> None:
+    sql = tmp_path / "multi.sql"
+    sql.write_text(
+        "INSERT INTO ${parameters.target_schema}.t SELECT * FROM ${parameters.source_schema}.t;",
+        encoding="utf-8",
+    )
+
+    resolver = SqlFileResolver(manifest_dir=tmp_path)
+    body = resolver.resolve(
+        "file://multi.sql",
+        parameters={"target_schema": "omop", "source_schema": "raw"},
+    )
+
+    assert body == "INSERT INTO omop.t SELECT * FROM raw.t;"

--- a/templates/tests/unit/test_sql_node.py
+++ b/templates/tests/unit/test_sql_node.py
@@ -115,3 +115,172 @@ def test_no_artifact_when_unnamed(context: NodeContext, tmp_path: Path) -> None:
     result = SqlNode().run(context, params)
     assert result.status == NodeStatus.SUCCESS
     assert not list(tmp_path.glob("*.json"))
+
+
+# ----- Phase 3 Plan 0 Task 3: sql_file:// reader -----
+
+
+def _ctx_with_manifest_dir(
+    *, tmp_path: Path, sqlite_url: str, manifest_dir: Path
+) -> NodeContext:
+    return NodeContext(
+        run_id="run-sql-file",
+        node_id="sql-file-1",
+        logger=logging.getLogger("test.sql_file"),
+        secrets={},
+        artifact_dir=tmp_path,
+        db_dsn=sqlite_url,
+        manifest_dir=manifest_dir,
+    )
+
+
+def test_sql_node_executes_sql_file(tmp_path: Path, sqlite_url: str) -> None:
+    """sql_file: file://... loads the body from disk and executes it."""
+    manifest_dir = tmp_path / "manifest"
+    sql = manifest_dir / "sql" / "init.sql"
+    sql.parent.mkdir(parents=True)
+    sql.write_text("CREATE TABLE t (id INTEGER PRIMARY KEY)", encoding="utf-8")
+
+    ctx = _ctx_with_manifest_dir(
+        tmp_path=tmp_path, sqlite_url=sqlite_url, manifest_dir=manifest_dir
+    )
+    result = SqlNode().run(ctx, {"sql_file": "file://sql/init.sql"})
+    assert result.status == NodeStatus.SUCCESS, result.error_message
+    assert result.outputs["statements_executed"] == 1
+
+
+def test_sql_node_sql_file_expands_parameters(tmp_path: Path, sqlite_url: str) -> None:
+    """${parameters.NAME} placeholders are substituted from params."""
+    manifest_dir = tmp_path / "manifest"
+    sql = manifest_dir / "sql" / "create.sql"
+    sql.parent.mkdir(parents=True)
+    sql.write_text(
+        "CREATE TABLE ${parameters.target_table} (id INTEGER)",
+        encoding="utf-8",
+    )
+
+    ctx = _ctx_with_manifest_dir(
+        tmp_path=tmp_path, sqlite_url=sqlite_url, manifest_dir=manifest_dir
+    )
+    result = SqlNode().run(
+        ctx, {"sql_file": "file://sql/create.sql", "target_table": "widgets"}
+    )
+    assert result.status == NodeStatus.SUCCESS, result.error_message
+
+    engine = create_engine(sqlite_url)
+    with engine.connect() as conn:
+        # Insert + select to confirm the table 'widgets' was created (not the literal placeholder).
+        conn.execute(text("INSERT INTO widgets (id) VALUES (42)"))
+        rows = conn.execute(text("SELECT id FROM widgets")).fetchall()
+    assert [tuple(r) for r in rows] == [(42,)]
+
+
+def test_sql_node_sql_file_splits_statements_on_semicolon(
+    tmp_path: Path, sqlite_url: str
+) -> None:
+    """Multi-statement SQL files are executed in order in one transaction."""
+    manifest_dir = tmp_path / "manifest"
+    sql = manifest_dir / "sql" / "multi.sql"
+    sql.parent.mkdir(parents=True)
+    sql.write_text(
+        "CREATE TABLE m (n INTEGER);\nINSERT INTO m (n) VALUES (1), (2), (3);\n",
+        encoding="utf-8",
+    )
+
+    ctx = _ctx_with_manifest_dir(
+        tmp_path=tmp_path, sqlite_url=sqlite_url, manifest_dir=manifest_dir
+    )
+    result = SqlNode().run(ctx, {"sql_file": "file://sql/multi.sql"})
+    assert result.status == NodeStatus.SUCCESS, result.error_message
+    assert result.outputs["statements_executed"] == 2
+
+    engine = create_engine(sqlite_url)
+    with engine.connect() as conn:
+        rows = conn.execute(text("SELECT n FROM m ORDER BY n")).fetchall()
+    assert [tuple(r) for r in rows] == [(1,), (2,), (3,)]
+
+
+def test_sql_node_rejects_both_statements_and_sql_file(
+    tmp_path: Path, sqlite_url: str
+) -> None:
+    """Loud error when both inline statements and sql_file are set."""
+    ctx = _ctx_with_manifest_dir(
+        tmp_path=tmp_path, sqlite_url=sqlite_url, manifest_dir=tmp_path
+    )
+    result = SqlNode().run(
+        ctx, {"statements": ["SELECT 1"], "sql_file": "file://x.sql"}
+    )
+    assert result.status == NodeStatus.FAILED
+    assert "exactly one of" in (result.error_message or "").lower()
+
+
+def test_sql_node_sql_file_requires_manifest_dir(
+    tmp_path: Path, sqlite_url: str
+) -> None:
+    """sql_file without context.manifest_dir is a configuration error."""
+    ctx = NodeContext(
+        run_id="r",
+        node_id="n",
+        logger=logging.getLogger("test"),
+        secrets={},
+        artifact_dir=tmp_path,
+        db_dsn=sqlite_url,
+        manifest_dir=None,
+    )
+    result = SqlNode().run(ctx, {"sql_file": "file://x.sql"})
+    assert result.status == NodeStatus.FAILED
+    assert "manifest_dir" in (result.error_message or "")
+
+
+def test_sql_node_fetch_query_file_loads_from_disk(
+    tmp_path: Path, sqlite_url: str
+) -> None:
+    """fetch_query_file is a file-backed alternative to fetch_query."""
+    manifest_dir = tmp_path / "manifest"
+    fetch = manifest_dir / "sql" / "fetch.sql"
+    fetch.parent.mkdir(parents=True)
+    fetch.write_text("SELECT n FROM x ORDER BY n", encoding="utf-8")
+
+    ctx = _ctx_with_manifest_dir(
+        tmp_path=tmp_path, sqlite_url=sqlite_url, manifest_dir=manifest_dir
+    )
+    params: dict[str, Any] = {
+        "statements": [
+            "CREATE TABLE x (n INTEGER)",
+            "INSERT INTO x (n) VALUES (10), (20)",
+        ],
+        "fetch_query_file": "file://sql/fetch.sql",
+    }
+    result = SqlNode().run(ctx, params)
+    assert result.status == NodeStatus.SUCCESS, result.error_message
+    assert result.outputs["rows"] == [{"n": 10}, {"n": 20}]
+
+
+def test_sql_node_rejects_both_fetch_query_and_fetch_query_file(
+    tmp_path: Path, sqlite_url: str
+) -> None:
+    ctx = _ctx_with_manifest_dir(
+        tmp_path=tmp_path, sqlite_url=sqlite_url, manifest_dir=tmp_path
+    )
+    params: dict[str, Any] = {
+        "statements": ["CREATE TABLE z (id INTEGER)"],
+        "fetch_query": "SELECT 1",
+        "fetch_query_file": "file://x.sql",
+    }
+    result = SqlNode().run(ctx, params)
+    assert result.status == NodeStatus.FAILED
+    assert "exactly one of" in (result.error_message or "").lower()
+
+
+def test_sql_node_sql_file_traversal_rejected(
+    tmp_path: Path, sqlite_url: str
+) -> None:
+    """Path-traversal references fail with a SqlNode error citing the resolver."""
+    manifest_dir = tmp_path / "manifest"
+    manifest_dir.mkdir()
+    ctx = _ctx_with_manifest_dir(
+        tmp_path=tmp_path, sqlite_url=sqlite_url, manifest_dir=manifest_dir
+    )
+    result = SqlNode().run(ctx, {"sql_file": "file://../../etc/passwd"})
+    assert result.status == NodeStatus.FAILED
+    assert result.error_message is not None

--- a/templates/tests/unit/test_sql_node.py
+++ b/templates/tests/unit/test_sql_node.py
@@ -120,9 +120,7 @@ def test_no_artifact_when_unnamed(context: NodeContext, tmp_path: Path) -> None:
 # ----- Phase 3 Plan 0 Task 3: sql_file:// reader -----
 
 
-def _ctx_with_manifest_dir(
-    *, tmp_path: Path, sqlite_url: str, manifest_dir: Path
-) -> NodeContext:
+def _ctx_with_manifest_dir(*, tmp_path: Path, sqlite_url: str, manifest_dir: Path) -> NodeContext:
     return NodeContext(
         run_id="run-sql-file",
         node_id="sql-file-1",
@@ -162,9 +160,7 @@ def test_sql_node_sql_file_expands_parameters(tmp_path: Path, sqlite_url: str) -
     ctx = _ctx_with_manifest_dir(
         tmp_path=tmp_path, sqlite_url=sqlite_url, manifest_dir=manifest_dir
     )
-    result = SqlNode().run(
-        ctx, {"sql_file": "file://sql/create.sql", "target_table": "widgets"}
-    )
+    result = SqlNode().run(ctx, {"sql_file": "file://sql/create.sql", "target_table": "widgets"})
     assert result.status == NodeStatus.SUCCESS, result.error_message
 
     engine = create_engine(sqlite_url)
@@ -175,9 +171,7 @@ def test_sql_node_sql_file_expands_parameters(tmp_path: Path, sqlite_url: str) -
     assert [tuple(r) for r in rows] == [(42,)]
 
 
-def test_sql_node_sql_file_splits_statements_on_semicolon(
-    tmp_path: Path, sqlite_url: str
-) -> None:
+def test_sql_node_sql_file_splits_statements_on_semicolon(tmp_path: Path, sqlite_url: str) -> None:
     """Multi-statement SQL files are executed in order in one transaction."""
     manifest_dir = tmp_path / "manifest"
     sql = manifest_dir / "sql" / "multi.sql"
@@ -200,23 +194,15 @@ def test_sql_node_sql_file_splits_statements_on_semicolon(
     assert [tuple(r) for r in rows] == [(1,), (2,), (3,)]
 
 
-def test_sql_node_rejects_both_statements_and_sql_file(
-    tmp_path: Path, sqlite_url: str
-) -> None:
+def test_sql_node_rejects_both_statements_and_sql_file(tmp_path: Path, sqlite_url: str) -> None:
     """Loud error when both inline statements and sql_file are set."""
-    ctx = _ctx_with_manifest_dir(
-        tmp_path=tmp_path, sqlite_url=sqlite_url, manifest_dir=tmp_path
-    )
-    result = SqlNode().run(
-        ctx, {"statements": ["SELECT 1"], "sql_file": "file://x.sql"}
-    )
+    ctx = _ctx_with_manifest_dir(tmp_path=tmp_path, sqlite_url=sqlite_url, manifest_dir=tmp_path)
+    result = SqlNode().run(ctx, {"statements": ["SELECT 1"], "sql_file": "file://x.sql"})
     assert result.status == NodeStatus.FAILED
     assert "exactly one of" in (result.error_message or "").lower()
 
 
-def test_sql_node_sql_file_requires_manifest_dir(
-    tmp_path: Path, sqlite_url: str
-) -> None:
+def test_sql_node_sql_file_requires_manifest_dir(tmp_path: Path, sqlite_url: str) -> None:
     """sql_file without context.manifest_dir is a configuration error."""
     ctx = NodeContext(
         run_id="r",
@@ -232,9 +218,7 @@ def test_sql_node_sql_file_requires_manifest_dir(
     assert "manifest_dir" in (result.error_message or "")
 
 
-def test_sql_node_fetch_query_file_loads_from_disk(
-    tmp_path: Path, sqlite_url: str
-) -> None:
+def test_sql_node_fetch_query_file_loads_from_disk(tmp_path: Path, sqlite_url: str) -> None:
     """fetch_query_file is a file-backed alternative to fetch_query."""
     manifest_dir = tmp_path / "manifest"
     fetch = manifest_dir / "sql" / "fetch.sql"
@@ -259,9 +243,7 @@ def test_sql_node_fetch_query_file_loads_from_disk(
 def test_sql_node_rejects_both_fetch_query_and_fetch_query_file(
     tmp_path: Path, sqlite_url: str
 ) -> None:
-    ctx = _ctx_with_manifest_dir(
-        tmp_path=tmp_path, sqlite_url=sqlite_url, manifest_dir=tmp_path
-    )
+    ctx = _ctx_with_manifest_dir(tmp_path=tmp_path, sqlite_url=sqlite_url, manifest_dir=tmp_path)
     params: dict[str, Any] = {
         "statements": ["CREATE TABLE z (id INTEGER)"],
         "fetch_query": "SELECT 1",
@@ -272,9 +254,7 @@ def test_sql_node_rejects_both_fetch_query_and_fetch_query_file(
     assert "exactly one of" in (result.error_message or "").lower()
 
 
-def test_sql_node_sql_file_traversal_rejected(
-    tmp_path: Path, sqlite_url: str
-) -> None:
+def test_sql_node_sql_file_traversal_rejected(tmp_path: Path, sqlite_url: str) -> None:
     """Path-traversal references fail with a SqlNode error citing the resolver."""
     manifest_dir = tmp_path / "manifest"
     manifest_dir.mkdir()


### PR DESCRIPTION
Implements **Phase 3 Plan 0** — the carry-over follow-up from Phase 0. \`sql_node\` learns to read SQL bodies from \`sql_file://manifests/<id>/sql/<filename>.sql\` references with \`\${parameters.*}\` expansion. Unblocks every Phase 3 commercial-tier template that ships multi-stage SQL bootstraps (T-021 / T-022 / T-023 / T-024).

Plan: \`docs/superpowers/plans/2026-05-06-parthenon-ingestion-templates-phase-3-plan-0-sql-file-reader.md\`
ADR: \`docs/architecture/adr-0015-sql-file-reader.md\`

## Summary

- **\`SqlFileResolver\`** (\`templates/runtime/sql_files/resolver.py\`) — relative-only path resolution under \`NodeContext.manifest_dir\`, traversal guard, \`\${parameters.*}\` expansion
- **\`sql_node\` consumer wiring** — accepts \`sql_file\` param alongside \`statements\`; mutual-exclusion error if both set; manifest_dir plumbed through \`NodeContext\`, materializer, and Prefect orchestration backend
- **JSON Schema gate** — \`template.v1.json\` documents \`sql_file\` for sql nodes
- **Phase 2 E2E skip reasons** — updated to reflect that sql_file:// is unblocked; remaining gating (vocab seed + orchestration scaffolding) explicitly tracked as Phase 4 follow-ups

Per Phase 3 spec Q10=(b): inline resolution + parameter expansion only. SQL caching is Phase 4.

## Test plan

- [x] 8 SqlFileResolver unit tests (path traversal, parameter expansion, scheme parsing, missing file)
- [x] 7 sql_node tests covering sql_file path (parameter expansion, statement splitting, manifest_dir requirement, mutual exclusion with statements/fetch_query)
- [x] 3 integration tests (materializer manifest_dir propagation, full sqlite pipeline, traversal blocked through full pipeline)
- [x] ruff / black / mypy --strict clean

## Carry-over context

Phase 2 PR #273 (MIMIC-IV ETL) and PR #275 (ARTEMIS) merged with their full testcontainers E2Es \`pytest.skip\`-gated. This PR removes the sql_file:// gate. The remaining work to lift those skips is a vocab-seed harness for testcontainers Postgres + a programmatic manifest run-orchestration driver — both Phase 4.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)