### PR TITLE
Phase 3 Plan 4B: STS National Database (T-022B)

### DIFF
--- a/templates/commercial/manifests/registry_to_omop_sts/README.md
+++ b/templates/commercial/manifests/registry_to_omop_sts/README.md
@@ -1,0 +1,71 @@
+# `registry_to_omop_sts`
+
+Phase 3 Plan 4B (T-022B). Commercial-tier template that ingests
+**Society of Thoracic Surgeons (STS) National Database** CSV exports
+and projects them to OMOP CDM v5.4 PROCEDURE_OCCURRENCE +
+CONDITION_OCCURRENCE + EPISODE.
+
+## License + access notes
+
+STS data is gated behind an **STS Participant Agreement** between the
+customer (a hospital, integrated delivery network, or CV registry
+analyst) and the Society of Thoracic Surgeons. Parthenon does NOT
+redistribute STS data, fixtures, or column-spec excerpts beyond what
+the manifest test fixtures synthesize.
+
+Customers who do not have STS Participant status cannot run this
+template against real data. The synthetic fixture corpus
+(`fixtures/synthetic/build_sts_corpus.py`) is the only data
+Parthenon ships; it's deterministic and PHI-free.
+
+## Spec version
+
+This template targets **STS Adult Cardiac Surgery v4.20.2** column
+shapes. Older versions (v2.81, v2.9) are out of v0.1 scope —
+column-map deltas would be a Phase 4 follow-up if customer demand
+exists.
+
+## Vocabulary prerequisites
+
+- `ICD10CM` (pre-op diagnoses)
+- `CPT4` (procedure codes; primary + secondary)
+- `HCPCS` (some STS procedures use HCPCS over CPT)
+- `SNOMED` (target standard for both conditions and procedures via
+  `concept_relationship 'Maps to'`)
+
+The mapping pipeline tolerates unmapped codes — it emits
+`procedure_concept_id = 0` (OMOP convention) and the source code is
+preserved in `procedure_source_value` for downstream review.
+
+## Person identity
+
+v0.1 hashes `patient_id` via `abs(hashtext(...))` for deterministic
+`person_id` allocation, matching Plans 4A / NCPDP / claims pipelines.
+Proper Master Person Index integration is Phase 4 follow-up.
+
+## Operator workflow
+
+```bash
+# 1. Customer obtains STS export (CSV, ~21 columns per spec)
+# 2. Place at <storage>/sts_export.csv
+# 3. Run the template:
+parthenon-templates run registry_to_omop_sts \
+  --param sts_csv=/storage/sts_export.csv \
+  --param cdm_schema=sts_cdm
+```
+
+## Acceptance gates (validation E2E)
+
+- 100% of CSV rows produce typed STSRecords (or fail-closed)
+- procedure_occurrence row count = primary + secondary procedures
+- condition_occurrence row count = primary dx + secondary dx + each
+  TRUE postop complication
+- One episode per surgery
+- Reader is idempotent on replay
+
+## See also
+
+- ADR 0017 — `registry_to_omop` strategy (extend OHDSI for NAACCR;
+  STS owns its column-map since no upstream ETL exists)
+- `column_map.csv` — STS field → OMOP destination convention
+- Phase 3 Plan 4A — NAACCR sub-template (sister T-022 sub-template)

--- a/templates/commercial/manifests/registry_to_omop_sts/column_map.csv
+++ b/templates/commercial/manifests/registry_to_omop_sts/column_map.csv
@@ -1,0 +1,22 @@
+sts_field,omop_table,omop_column,vocabulary_id,concept_lookup_rule,description
+RecordID,fmt_sts_surgery,record_id,,passthrough,Unique surgery record key
+PatientID,fmt_sts_surgery,patient_id,,passthrough,Patient identifier (de-identified)
+SurgeryDate,fmt_sts_surgery,surgery_date,,passthrough,Date of cardiac surgery (CCYYMMDD)
+PatientAge,fmt_sts_surgery,patient_age,,passthrough,Age at surgery (years)
+Gender,fmt_sts_surgery,gender,,passthrough,M/F
+HospitalID,fmt_sts_surgery,hospital_id,,passthrough,STS-assigned site code
+SurgeonID,fmt_sts_surgery,surgeon_id,,passthrough,STS-assigned surgeon code
+ProcedureID,fmt_sts_surgery,procedure_id,SNOMED,sts_procedure_to_snomed,STS procedure category (CABG/Valve/Aortic/Combined)
+PrimaryDiagnosis,fmt_sts_surgery,primary_diagnosis_icd10,ICD10CM,passthrough,Pre-operative primary diagnosis (ICD-10-CM)
+SecondaryDiagnoses,fmt_sts_surgery,secondary_diagnoses_icd10,ICD10CM,delimited_list,Comorbid diagnoses (semicolon-delimited)
+EjectionFraction,fmt_sts_surgery,ejection_fraction,,passthrough,Pre-op LVEF (percent)
+NyhaClass,fmt_sts_surgery,nyha_class,,passthrough,NYHA functional class (1-4)
+ProcedureCode_Primary,fmt_sts_surgery,primary_procedure_code,CPT4,passthrough,Primary CPT/HCPCS code
+ProcedureCode_Secondary,fmt_sts_surgery,secondary_procedure_codes,CPT4,delimited_list,Secondary CPT codes (semicolon-delimited)
+PostOpComplication_AKI,fmt_sts_surgery,postop_aki,SNOMED,sts_complication_to_snomed,Acute kidney injury (yes/no)
+PostOpComplication_Stroke,fmt_sts_surgery,postop_stroke,SNOMED,sts_complication_to_snomed,Stroke / CVA (yes/no)
+PostOpComplication_Reoperation,fmt_sts_surgery,postop_reoperation,SNOMED,sts_complication_to_snomed,Reoperation for bleeding (yes/no)
+PostOpComplication_Sepsis,fmt_sts_surgery,postop_sepsis,SNOMED,sts_complication_to_snomed,Postop sepsis (yes/no)
+LengthOfStay,fmt_sts_surgery,length_of_stay,,passthrough,Hospital LOS (days)
+DischargeDisposition,fmt_sts_surgery,discharge_disposition,,passthrough,Home/SNF/Hospice/Death code
+Mortality_30Day,fmt_sts_surgery,mortality_30day,,passthrough,30-day mortality (yes/no)

--- a/templates/commercial/manifests/registry_to_omop_sts/fixtures/synthetic/build_sts_corpus.py
+++ b/templates/commercial/manifests/registry_to_omop_sts/fixtures/synthetic/build_sts_corpus.py
@@ -1,0 +1,181 @@
+"""Synthetic STS corpus builder — deterministic with seed=42.
+
+Phase 3 Plan 4B Task 6 (T-022B). Produces a 50-surgery STS CSV corpus
+for the validation E2E. Mix:
+
+- 50 surgeries across 50 patients
+- 5 procedure categories (CABG, Valve, Aortic, Combined, Other)
+- AKI / stroke / sepsis / reoperation complications spread across rows
+  (deterministic mod-N pattern)
+- 10% mortality (5 of 50)
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import random
+from dataclasses import dataclass
+from typing import Final
+
+# (procedure_category, primary_cpt) pool.
+_PROCEDURES: Final[list[tuple[str, str]]] = [
+    ("CABG", "33533"),
+    ("Valve", "33405"),
+    ("Aortic", "33860"),
+    ("Combined", "33536"),
+    ("Other", "33675"),
+]
+
+_DIAGNOSES_PRIMARY: Final[list[str]] = [
+    "I25.10",  # ASHD without angina
+    "I35.0",  # Aortic stenosis
+    "I71.4",  # AAA without rupture
+    "I05.0",  # Mitral stenosis
+    "I50.32",  # Chronic diastolic HF
+]
+
+
+@dataclass(frozen=True)
+class _SurgerySpec:
+    seed_idx: int
+    record_id: str
+    patient_id: str
+    surgery_date: str  # CCYYMMDD
+    patient_age: int
+    gender: str
+    hospital_id: str
+    surgeon_id: str
+    ejection_fraction: str
+    nyha_class: int
+    primary_diagnosis: str
+    secondary_diagnoses: str
+    procedure_category: str
+    primary_procedure_code: str
+    secondary_procedure_codes: str
+    postop_aki: str
+    postop_stroke: str
+    postop_reoperation: str
+    postop_sepsis: str
+    length_of_stay: int
+    discharge_disposition: str
+    mortality_30day: str
+
+
+def build_corpus(*, seed: int = 42, n_surgeries: int = 50) -> str:
+    """Build a deterministic STS CSV corpus.
+
+    Args:
+        seed: RNG seed; same seed -> same output.
+        n_surgeries: Total surgeries to generate. Must be >= 1.
+
+    Returns:
+        A CSV string with the 21-column STS header + n_surgeries data rows.
+    """
+    if n_surgeries < 1:
+        raise ValueError(f"n_surgeries must be >= 1; got {n_surgeries}")
+
+    rng = random.Random(seed)
+    specs: list[_SurgerySpec] = []
+    for i in range(1, n_surgeries + 1):
+        proc = _PROCEDURES[(i - 1) % len(_PROCEDURES)]
+        primary_dx = _DIAGNOSES_PRIMARY[(i - 1) % len(_DIAGNOSES_PRIMARY)]
+        # Vary secondary codes a little.
+        secondary_dx = "I50.32;E11.9" if i % 2 == 0 else ""
+        secondary_proc = "33510" if proc[0] == "CABG" else ""
+        # Complications spread by mod-N so the fixture has variety.
+        aki = "yes" if i % 7 == 0 else "no"
+        stroke = "yes" if i % 11 == 0 else "no"
+        reop = "yes" if i % 13 == 0 else "no"
+        sepsis = "yes" if i % 9 == 0 else "no"
+        mortality = "yes" if i % 10 == 0 else "no"
+        disposition = "Death" if mortality == "yes" else "Home" if i % 3 != 0 else "SNF"
+        specs.append(
+            _SurgerySpec(
+                seed_idx=i,
+                record_id=f"STS-{i:05d}",
+                patient_id=f"PAT{i:05d}",
+                surgery_date=f"2024{((i - 1) % 12) + 1:02d}{((i - 1) % 28) + 1:02d}",
+                patient_age=50 + rng.randint(0, 35),
+                gender=rng.choice(("M", "F")),
+                hospital_id=f"H{(i % 10) + 1:03d}",
+                surgeon_id=f"S{(i % 25) + 1:03d}",
+                ejection_fraction=f"{30 + rng.randint(0, 40):.1f}",
+                nyha_class=rng.randint(1, 4),
+                primary_diagnosis=primary_dx,
+                secondary_diagnoses=secondary_dx,
+                procedure_category=proc[0],
+                primary_procedure_code=proc[1],
+                secondary_procedure_codes=secondary_proc,
+                postop_aki=aki,
+                postop_stroke=stroke,
+                postop_reoperation=reop,
+                postop_sepsis=sepsis,
+                length_of_stay=4 + rng.randint(0, 14),
+                discharge_disposition=disposition,
+                mortality_30day=mortality,
+            )
+        )
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "RecordID",
+            "PatientID",
+            "SurgeryDate",
+            "PatientAge",
+            "Gender",
+            "HospitalID",
+            "SurgeonID",
+            "EjectionFraction",
+            "NyhaClass",
+            "PrimaryDiagnosis",
+            "SecondaryDiagnoses",
+            "ProcedureID",
+            "ProcedureCode_Primary",
+            "ProcedureCode_Secondary",
+            "PostOpComplication_AKI",
+            "PostOpComplication_Stroke",
+            "PostOpComplication_Reoperation",
+            "PostOpComplication_Sepsis",
+            "LengthOfStay",
+            "DischargeDisposition",
+            "Mortality_30Day",
+        ]
+    )
+    for s in specs:
+        writer.writerow(
+            [
+                s.record_id,
+                s.patient_id,
+                s.surgery_date,
+                str(s.patient_age),
+                s.gender,
+                s.hospital_id,
+                s.surgeon_id,
+                s.ejection_fraction,
+                str(s.nyha_class),
+                s.primary_diagnosis,
+                s.secondary_diagnoses,
+                s.procedure_category,
+                s.primary_procedure_code,
+                s.secondary_procedure_codes,
+                s.postop_aki,
+                s.postop_stroke,
+                s.postop_reoperation,
+                s.postop_sepsis,
+                str(s.length_of_stay),
+                s.discharge_disposition,
+                s.mortality_30day,
+            ]
+        )
+
+    return buf.getvalue()
+
+
+__all__ = ["build_corpus"]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(build_corpus(seed=42, n_surgeries=50))

--- a/templates/commercial/manifests/registry_to_omop_sts/manifest.yaml
+++ b/templates/commercial/manifests/registry_to_omop_sts/manifest.yaml
@@ -1,0 +1,99 @@
+apiVersion: parthenon.acumenus.net/v1
+kind: Template
+metadata:
+  id: registry_to_omop_sts
+  name: STS Adult Cardiac Surgery → OMOP CDM v5.4
+  version: "0.1.0"
+  category: ingestion
+  tier: commercial
+  cdm_versions: ["5.4"]
+  tags: ["registry", "sts", "cardiac-surgery", "omop", "etl", "phase-3", "commercial"]
+  author: "Acumenus Data Sciences"
+  description: |
+    Phase 3 Plan 4B (T-022B). Reads STS National Database CSV exports
+    (one row per cardiac surgery) and projects to OMOP PROCEDURE_OCCURRENCE
+    + CONDITION_OCCURRENCE + EPISODE. Unlike Plan 4A (NAACCR), no upstream
+    OHDSI ETL exists for STS — we maintain the column-mapping table
+    (column_map.csv) ourselves against STS Adult Cardiac Surgery v4.20.2.
+
+    License caveats: STS exports require an STS Participant Agreement
+    between the customer and the Society of Thoracic Surgeons. Parthenon
+    does not redistribute STS data; we ingest exports the customer
+    provides. See README.md for operator guidance.
+spec:
+  parameters:
+    type: object
+    properties:
+      sts_csv:
+        type: string
+        description: Path to the STS CSV export.
+      source_schema:
+        type: string
+        default: sts_source
+      cdm_schema:
+        type: string
+        default: sts_cdm
+      vocab_schema:
+        type: string
+        default: vocab
+      app_schema:
+        type: string
+        default: app
+      run_id:
+        type: string
+        default: "00000000-0000-0000-0000-000000000000"
+    required: ["sts_csv"]
+  requires:
+    cdm_initialized: false
+    vocabularies: ["ICD10CM", "CPT4", "HCPCS", "SNOMED"]
+  nodes:
+    - node_id: bootstrap_source
+      type: sql
+      params:
+        statements: ["SELECT 1"]
+        sql_file: file://sql/00_bootstrap_sts_source.sql
+
+    - node_id: load_sts
+      type: sql
+      depends_on: [bootstrap_source]
+      params:
+        statements: ["SELECT 1"]
+        sql_file: file://sql/01_load_sts_csv.sql
+
+    - node_id: map_procedure_occurrence
+      type: sql
+      depends_on: [load_sts]
+      params:
+        statements: ["SELECT 1"]
+        sql_file: file://sql/02a_map_procedure_occurrence.sql
+
+    - node_id: map_condition_occurrence
+      type: sql
+      depends_on: [load_sts]
+      params:
+        statements: ["SELECT 1"]
+        sql_file: file://sql/02b_map_condition_occurrence.sql
+
+    - node_id: map_episode
+      type: sql
+      depends_on: [load_sts, map_procedure_occurrence]
+      params:
+        statements: ["SELECT 1"]
+        sql_file: file://sql/02c_map_episode.sql
+
+    - node_id: summarize
+      type: sql
+      depends_on:
+        - map_procedure_occurrence
+        - map_condition_occurrence
+        - map_episode
+      params:
+        statements: ["SELECT 1"]
+        fetch_query_file: file://sql/03_summarize.sql
+        result_artifact: registry_to_omop_sts_summary
+
+  post_conditions:
+    - kind: artifact_present
+      params:
+        artifact: registry_to_omop_sts_summary.json
+        min_rows: 1

--- a/templates/commercial/manifests/registry_to_omop_sts/sql/00_bootstrap_sts_source.sql
+++ b/templates/commercial/manifests/registry_to_omop_sts/sql/00_bootstrap_sts_source.sql
@@ -1,0 +1,38 @@
+-- Phase 3 Plan 4B Task 4 (T-022B): bootstrap fmt_sts_surgery source table.
+-- Mirrors STSRecord (templates/commercial/runtime/commercial/registry/sts/types.py).
+
+CREATE SCHEMA IF NOT EXISTS ${parameters.source_schema};
+
+CREATE TABLE IF NOT EXISTS ${parameters.source_schema}.fmt_sts_surgery (
+    id BIGSERIAL PRIMARY KEY,
+    record_id VARCHAR(40) NOT NULL,
+    patient_id VARCHAR(40) NOT NULL,
+    surgery_date DATE NOT NULL,
+    patient_age INT NOT NULL CHECK (patient_age BETWEEN 0 AND 120),
+    gender CHAR(1) NOT NULL CHECK (gender IN ('M', 'F', 'U')),
+    hospital_id VARCHAR(40) NOT NULL,
+    surgeon_id VARCHAR(40) NOT NULL,
+    ejection_fraction NUMERIC(5, 2) NOT NULL CHECK (ejection_fraction BETWEEN 0 AND 100),
+    nyha_class INT NOT NULL CHECK (nyha_class BETWEEN 1 AND 4),
+    primary_diagnosis_icd10 VARCHAR(10) NOT NULL,
+    secondary_diagnoses_icd10 TEXT[],
+    procedure_category VARCHAR(20) NOT NULL CHECK (procedure_category IN ('CABG', 'Valve', 'Aortic', 'Combined', 'Other')),
+    primary_procedure_code VARCHAR(10) NOT NULL,
+    secondary_procedure_codes TEXT[],
+    postop_aki BOOLEAN NOT NULL DEFAULT FALSE,
+    postop_stroke BOOLEAN NOT NULL DEFAULT FALSE,
+    postop_reoperation BOOLEAN NOT NULL DEFAULT FALSE,
+    postop_sepsis BOOLEAN NOT NULL DEFAULT FALSE,
+    length_of_stay INT NOT NULL CHECK (length_of_stay >= 0),
+    discharge_disposition VARCHAR(40) NOT NULL,
+    mortality_30day BOOLEAN NOT NULL DEFAULT FALSE,
+    source_file VARCHAR(512),
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (record_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_fmt_sts_surgery_date
+    ON ${parameters.source_schema}.fmt_sts_surgery (surgery_date);
+
+CREATE INDEX IF NOT EXISTS ix_fmt_sts_surgery_proc
+    ON ${parameters.source_schema}.fmt_sts_surgery (procedure_category);

--- a/templates/commercial/manifests/registry_to_omop_sts/sql/01_load_sts_csv.sql
+++ b/templates/commercial/manifests/registry_to_omop_sts/sql/01_load_sts_csv.sql
@@ -1,0 +1,14 @@
+-- Phase 3 Plan 4B Task 4 (T-022B): COPY STS CSV into fmt_sts_surgery.
+-- The reader (production path) writes here directly via psycopg's COPY;
+-- the validation E2E populates via INSERT VALUES.
+
+COPY ${parameters.source_schema}.fmt_sts_surgery (
+    record_id, patient_id, surgery_date, patient_age, gender,
+    hospital_id, surgeon_id, ejection_fraction, nyha_class,
+    primary_diagnosis_icd10, secondary_diagnoses_icd10,
+    procedure_category, primary_procedure_code, secondary_procedure_codes,
+    postop_aki, postop_stroke, postop_reoperation, postop_sepsis,
+    length_of_stay, discharge_disposition, mortality_30day, source_file
+)
+FROM '${parameters.sts_csv}'
+WITH (FORMAT csv, HEADER true, NULL '');

--- a/templates/commercial/manifests/registry_to_omop_sts/sql/02a_map_procedure_occurrence.sql
+++ b/templates/commercial/manifests/registry_to_omop_sts/sql/02a_map_procedure_occurrence.sql
@@ -1,0 +1,50 @@
+-- Phase 3 Plan 4B Task 4 (T-022B): STS -> PROCEDURE_OCCURRENCE.
+-- One row per primary procedure (CPT/HCPCS) per surgery. Secondary
+-- procedure codes also fan out as separate procedure_occurrence rows
+-- via the LATERAL unnest, sharing the same surgery_date but carrying
+-- their own concept_id.
+
+INSERT INTO ${parameters.cdm_schema}.procedure_occurrence (
+    person_id,
+    procedure_concept_id,
+    procedure_date,
+    procedure_type_concept_id,
+    procedure_source_value,
+    procedure_source_concept_id
+)
+-- Primary procedure
+SELECT
+    abs(hashtext(s.patient_id)) AS person_id,
+    COALESCE(snomed.concept_id, 0) AS procedure_concept_id,
+    s.surgery_date AS procedure_date,
+    32861 AS procedure_type_concept_id,  -- 'Registry-derived procedure'
+    s.primary_procedure_code AS procedure_source_value,
+    cpt.concept_id AS procedure_source_concept_id
+FROM ${parameters.source_schema}.fmt_sts_surgery s
+LEFT JOIN ${parameters.vocab_schema}.concept cpt
+    ON cpt.concept_code = s.primary_procedure_code
+       AND cpt.vocabulary_id IN ('CPT4', 'HCPCS')
+LEFT JOIN ${parameters.vocab_schema}.concept_relationship cr
+    ON cr.concept_id_1 = cpt.concept_id AND cr.relationship_id = 'Maps to'
+LEFT JOIN ${parameters.vocab_schema}.concept snomed
+    ON snomed.concept_id = cr.concept_id_2 AND snomed.standard_concept = 'S'
+
+UNION ALL
+
+-- Secondary procedures (one row per code in the array)
+SELECT
+    abs(hashtext(s.patient_id)) AS person_id,
+    COALESCE(snomed2.concept_id, 0) AS procedure_concept_id,
+    s.surgery_date AS procedure_date,
+    32861 AS procedure_type_concept_id,
+    sec_code AS procedure_source_value,
+    cpt2.concept_id AS procedure_source_concept_id
+FROM ${parameters.source_schema}.fmt_sts_surgery s
+CROSS JOIN LATERAL unnest(COALESCE(s.secondary_procedure_codes, ARRAY[]::TEXT[])) AS sec_code
+LEFT JOIN ${parameters.vocab_schema}.concept cpt2
+    ON cpt2.concept_code = sec_code
+       AND cpt2.vocabulary_id IN ('CPT4', 'HCPCS')
+LEFT JOIN ${parameters.vocab_schema}.concept_relationship cr2
+    ON cr2.concept_id_1 = cpt2.concept_id AND cr2.relationship_id = 'Maps to'
+LEFT JOIN ${parameters.vocab_schema}.concept snomed2
+    ON snomed2.concept_id = cr2.concept_id_2 AND snomed2.standard_concept = 'S';

--- a/templates/commercial/manifests/registry_to_omop_sts/sql/02b_map_condition_occurrence.sql
+++ b/templates/commercial/manifests/registry_to_omop_sts/sql/02b_map_condition_occurrence.sql
@@ -1,0 +1,76 @@
+-- Phase 3 Plan 4B Task 4 (T-022B): STS -> CONDITION_OCCURRENCE.
+-- Two passes: pre-op diagnoses (primary + secondary ICD-10-CM) and
+-- postop complications (booleans -> SNOMED concepts).
+
+-- Pass 1: pre-op primary diagnosis
+INSERT INTO ${parameters.cdm_schema}.condition_occurrence (
+    person_id,
+    condition_concept_id,
+    condition_start_date,
+    condition_type_concept_id,
+    condition_source_value,
+    condition_source_concept_id
+)
+SELECT
+    abs(hashtext(s.patient_id)) AS person_id,
+    COALESCE(snomed.concept_id, 0) AS condition_concept_id,
+    s.surgery_date - INTERVAL '1 day' AS condition_start_date,
+    32865 AS condition_type_concept_id,  -- 'Pre-op condition (registry)'
+    s.primary_diagnosis_icd10 AS condition_source_value,
+    icd.concept_id AS condition_source_concept_id
+FROM ${parameters.source_schema}.fmt_sts_surgery s
+LEFT JOIN ${parameters.vocab_schema}.concept icd
+    ON icd.concept_code = s.primary_diagnosis_icd10 AND icd.vocabulary_id = 'ICD10CM'
+LEFT JOIN ${parameters.vocab_schema}.concept_relationship cr
+    ON cr.concept_id_1 = icd.concept_id AND cr.relationship_id = 'Maps to'
+LEFT JOIN ${parameters.vocab_schema}.concept snomed
+    ON snomed.concept_id = cr.concept_id_2 AND snomed.standard_concept = 'S';
+
+-- Pass 2: secondary diagnoses
+INSERT INTO ${parameters.cdm_schema}.condition_occurrence (
+    person_id,
+    condition_concept_id,
+    condition_start_date,
+    condition_type_concept_id,
+    condition_source_value,
+    condition_source_concept_id
+)
+SELECT
+    abs(hashtext(s.patient_id)) AS person_id,
+    COALESCE(snomed.concept_id, 0) AS condition_concept_id,
+    s.surgery_date - INTERVAL '1 day' AS condition_start_date,
+    32865 AS condition_type_concept_id,
+    sec_dx AS condition_source_value,
+    icd.concept_id AS condition_source_concept_id
+FROM ${parameters.source_schema}.fmt_sts_surgery s
+CROSS JOIN LATERAL unnest(COALESCE(s.secondary_diagnoses_icd10, ARRAY[]::TEXT[])) AS sec_dx
+LEFT JOIN ${parameters.vocab_schema}.concept icd
+    ON icd.concept_code = sec_dx AND icd.vocabulary_id = 'ICD10CM'
+LEFT JOIN ${parameters.vocab_schema}.concept_relationship cr
+    ON cr.concept_id_1 = icd.concept_id AND cr.relationship_id = 'Maps to'
+LEFT JOIN ${parameters.vocab_schema}.concept snomed
+    ON snomed.concept_id = cr.concept_id_2 AND snomed.standard_concept = 'S';
+
+-- Pass 3: postop complications (one row per TRUE flag).
+-- We use SNOMED hard-coded standard concepts because postop complication
+-- categories don't have ICD-10-CM source codes in the STS export — the
+-- STS Definition encodes them as booleans.
+
+INSERT INTO ${parameters.cdm_schema}.condition_occurrence (
+    person_id,
+    condition_concept_id,
+    condition_start_date,
+    condition_type_concept_id,
+    condition_source_value
+)
+SELECT abs(hashtext(s.patient_id)), 4126706, s.surgery_date, 32865, 'STS:postop_aki'
+FROM ${parameters.source_schema}.fmt_sts_surgery s WHERE s.postop_aki = TRUE
+UNION ALL
+SELECT abs(hashtext(s.patient_id)), 4007650, s.surgery_date, 32865, 'STS:postop_stroke'
+FROM ${parameters.source_schema}.fmt_sts_surgery s WHERE s.postop_stroke = TRUE
+UNION ALL
+SELECT abs(hashtext(s.patient_id)), 4131606, s.surgery_date, 32865, 'STS:postop_reoperation'
+FROM ${parameters.source_schema}.fmt_sts_surgery s WHERE s.postop_reoperation = TRUE
+UNION ALL
+SELECT abs(hashtext(s.patient_id)), 132797, s.surgery_date, 32865, 'STS:postop_sepsis'
+FROM ${parameters.source_schema}.fmt_sts_surgery s WHERE s.postop_sepsis = TRUE;

--- a/templates/commercial/manifests/registry_to_omop_sts/sql/02c_map_episode.sql
+++ b/templates/commercial/manifests/registry_to_omop_sts/sql/02c_map_episode.sql
@@ -1,0 +1,22 @@
+-- Phase 3 Plan 4B Task 4 (T-022B): STS -> EPISODE (one per surgery).
+-- Each surgery is a Disease First Occurrence-style episode with the
+-- procedure as the anchor. Episode end = discharge date approximated
+-- as surgery_date + length_of_stay.
+
+INSERT INTO ${parameters.cdm_schema}.episode (
+    person_id,
+    episode_concept_id,
+    episode_start_date,
+    episode_end_date,
+    episode_type_concept_id,
+    episode_source_value
+)
+SELECT
+    abs(hashtext(s.patient_id)) AS person_id,
+    32873 AS episode_concept_id,  -- 'Procedure-Anchored Episode' (Oncology Extension semantics)
+    s.surgery_date AS episode_start_date,
+    s.surgery_date + (s.length_of_stay || ' days')::INTERVAL AS episode_end_date,
+    32861 AS episode_type_concept_id,  -- 'Registry-derived'
+    -- Canonical assembly: procedure category + primary CPT code (no PHI).
+    (s.procedure_category || ':' || s.primary_procedure_code) AS episode_source_value
+FROM ${parameters.source_schema}.fmt_sts_surgery s;

--- a/templates/commercial/manifests/registry_to_omop_sts/sql/03_summarize.sql
+++ b/templates/commercial/manifests/registry_to_omop_sts/sql/03_summarize.sql
@@ -1,0 +1,11 @@
+-- Phase 3 Plan 4B Task 7 (T-022B): summary query for the post-condition.
+
+SELECT
+    (SELECT COUNT(*) FROM ${parameters.source_schema}.fmt_sts_surgery) AS sts_records,
+    (SELECT COUNT(*) FROM ${parameters.cdm_schema}.procedure_occurrence) AS procedure_occurrence_rows,
+    (SELECT COUNT(*) FROM ${parameters.cdm_schema}.condition_occurrence) AS condition_occurrence_rows,
+    (SELECT COUNT(*) FROM ${parameters.cdm_schema}.episode) AS episode_rows,
+    (SELECT COUNT(*) FROM ${parameters.cdm_schema}.procedure_occurrence WHERE procedure_concept_id = 0)
+        AS unmapped_procedure_rows,
+    (SELECT COUNT(*) FROM ${parameters.cdm_schema}.condition_occurrence WHERE condition_concept_id = 0)
+        AS unmapped_condition_rows;

--- a/templates/commercial/runtime/commercial/registry/sts/__init__.py
+++ b/templates/commercial/runtime/commercial/registry/sts/__init__.py
@@ -1,0 +1,15 @@
+"""STS Adult Cardiac Surgery Database ETL — Phase 3 Plan 4B (T-022B).
+
+Projects STS National Database CSV exports to OMOP CDM v5.4
+PROCEDURE_OCCURRENCE + CONDITION_OCCURRENCE + EPISODE. No upstream
+OHDSI ETL exists for STS; we maintain the column-mapping table
+(``column_map.csv``) ourselves against the STS Adult Cardiac Surgery
+v4.20.2 spec.
+
+License caveats: STS exports require an STS Participant Agreement
+between the customer and the Society of Thoracic Surgeons. Parthenon
+does not redistribute STS data; we ingest exports the customer
+provides.
+"""
+
+from __future__ import annotations

--- a/templates/commercial/runtime/commercial/registry/sts/reader.py
+++ b/templates/commercial/runtime/commercial/registry/sts/reader.py
@@ -1,0 +1,150 @@
+"""STS CSV reader — materializes ``STSRecord`` per surgery.
+
+Phase 3 Plan 4B Task 3 (T-022B). STS National Database exports are
+CSV files with column shapes defined by the v4.20.2 spec; the reader
+parses each row per the column-map convention documented at
+``templates/commercial/manifests/registry_to_omop_sts/column_map.csv``.
+
+PHI handling: STS records contain patient-id + DOB (via age) + site
+identifiers. The reader's logger uses ``_RedactingFilter`` mirroring
+Plans 1-3 + 4A's pattern.
+
+CSV input shape: header row required, one surgery per data row.
+Diagnoses + procedure-codes columns hold semicolon-delimited lists
+(STS export convention) for secondary entries.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import re
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from typing import TextIO
+
+from pydantic import ValidationError
+
+from runtime.commercial.registry.sts.types import STSRecord
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class STSReadError(ValueError):
+    """Raised when an STS CSV row cannot be parsed.
+
+    Sanitized per HIGHSEC §7 — patient_id, surgery_date, surgeon_id
+    MUST never appear in error messages.
+    """
+
+
+class _RedactingFilter(logging.Filter):
+    """HIGHSEC §7: scrub identifiers from STS log records."""
+
+    _ID_TOKEN = re.compile(r"\b[A-Z0-9]{6,15}\b")
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            msg = record.getMessage()
+        except Exception:  # pragma: no cover - defensive
+            return True
+        record.msg = self._ID_TOKEN.sub("***REDACTED***", msg)
+        record.args = ()
+        return True
+
+
+def _parse_date(value: str) -> object:
+    """STS dates are CCYYMMDD when 8 chars."""
+    value = (value or "").strip()
+    if len(value) != 8 or not value.isdigit():
+        raise STSReadError("invalid STS date")
+    try:
+        return datetime.strptime(value, "%Y%m%d").date()
+    except ValueError as exc:
+        raise STSReadError("unparseable STS date") from exc
+
+
+def _parse_int(value: str, *, name: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise STSReadError(f"non-integer STS field {name}") from exc
+
+
+def _parse_decimal(value: str, *, name: str) -> Decimal:
+    try:
+        return Decimal(value)
+    except (InvalidOperation, ValueError) as exc:
+        raise STSReadError(f"non-numeric STS field {name}") from exc
+
+
+def _parse_bool(value: str) -> bool:
+    """STS booleans: 'yes'/'no' (case-insensitive) or '1'/'0'."""
+    s = (value or "").strip().lower()
+    if s in {"yes", "y", "1", "true"}:
+        return True
+    if s in {"no", "n", "0", "false", ""}:
+        return False
+    raise STSReadError(f"unparseable STS boolean: {value!r}")
+
+
+def _parse_delimited(value: str) -> list[str]:
+    """STS delimited lists are semicolon-separated."""
+    if not value:
+        return []
+    return [v.strip() for v in value.split(";") if v.strip()]
+
+
+class STSReader:
+    """Read an STS CSV export."""
+
+    type_name = "sts_reader"
+
+    def __init__(self) -> None:
+        self._filter = _RedactingFilter()
+        if not any(isinstance(f, _RedactingFilter) for f in _LOGGER.filters):
+            _LOGGER.addFilter(self._filter)
+
+    def read(self, source: TextIO) -> list[STSRecord]:
+        """Parse an STS CSV (header row required) into typed records."""
+        reader = csv.DictReader(source)
+        if reader.fieldnames is None:
+            raise STSReadError("STS CSV is missing the header row")
+
+        out: list[STSRecord] = []
+        for row in reader:
+            try:
+                out.append(self._materialize(row))
+            except STSReadError:
+                raise
+            except ValidationError as exc:
+                raise STSReadError("STS record validation failed") from exc
+        return out
+
+    def _materialize(self, row: dict[str, str]) -> STSRecord:
+        return STSRecord(
+            record_id=row["RecordID"].strip(),
+            patient_id=row["PatientID"].strip(),
+            surgery_date=_parse_date(row["SurgeryDate"]),  # type: ignore[arg-type]
+            patient_age=_parse_int(row["PatientAge"], name="PatientAge"),
+            gender=row["Gender"].strip(),  # type: ignore[arg-type]
+            hospital_id=row["HospitalID"].strip(),
+            surgeon_id=row["SurgeonID"].strip(),
+            ejection_fraction=_parse_decimal(row["EjectionFraction"], name="EjectionFraction"),
+            nyha_class=_parse_int(row["NyhaClass"], name="NyhaClass"),
+            primary_diagnosis_icd10=row["PrimaryDiagnosis"].strip(),
+            secondary_diagnoses_icd10=_parse_delimited(row.get("SecondaryDiagnoses", "")),
+            procedure_category=row["ProcedureID"].strip(),  # type: ignore[arg-type]
+            primary_procedure_code=row["ProcedureCode_Primary"].strip(),
+            secondary_procedure_codes=_parse_delimited(row.get("ProcedureCode_Secondary", "")),
+            postop_aki=_parse_bool(row.get("PostOpComplication_AKI", "")),
+            postop_stroke=_parse_bool(row.get("PostOpComplication_Stroke", "")),
+            postop_reoperation=_parse_bool(row.get("PostOpComplication_Reoperation", "")),
+            postop_sepsis=_parse_bool(row.get("PostOpComplication_Sepsis", "")),
+            length_of_stay=_parse_int(row["LengthOfStay"], name="LengthOfStay"),
+            discharge_disposition=row["DischargeDisposition"].strip(),
+            mortality_30day=_parse_bool(row.get("Mortality_30Day", "")),
+        )
+
+
+__all__ = ["STSReadError", "STSReader"]

--- a/templates/commercial/runtime/commercial/registry/sts/types.py
+++ b/templates/commercial/runtime/commercial/registry/sts/types.py
@@ -1,0 +1,73 @@
+"""STS Adult Cardiac Surgery typed Pydantic model.
+
+Phase 3 Plan 4B Task 2 (T-022B). Mirrors ~150 STS data items per the
+v4.20.2 spec, focused on fields that drive PROCEDURE_OCCURRENCE +
+CONDITION_OCCURRENCE + EPISODE projection.
+
+The STS National Database is a Society of Thoracic Surgeons clinical
+quality registry. Exports come as CSV (one row per surgery) with
+column shapes defined by the STS Data Specification. We maintain the
+``column_map.csv`` (next to the manifest) ourselves since no upstream
+OHDSI ETL exists for STS.
+
+Out of scope for v0.1:
+
+- Site-specific data quality flags
+- Long-term follow-up beyond 30-day mortality
+- ECMO / VAD device-tracking fields
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# STS procedure categories (a curated v0.1 subset).
+ProcedureCategory = Literal["CABG", "Valve", "Aortic", "Combined", "Other"]
+
+
+class STSRecord(BaseModel):
+    """One STS Adult Cardiac Surgery record (one surgery)."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    # Record identity
+    record_id: str = Field(min_length=1)
+    patient_id: str = Field(min_length=1)
+    surgery_date: date
+
+    # Demographics + setting
+    patient_age: int = Field(ge=0, le=120)
+    gender: Literal["M", "F", "U"]
+    hospital_id: str
+    surgeon_id: str
+
+    # Pre-op risk factors
+    ejection_fraction: Decimal = Field(ge=0, le=100)
+    nyha_class: int = Field(ge=1, le=4)
+
+    # Diagnosis (ICD-10-CM)
+    primary_diagnosis_icd10: str = Field(min_length=1)
+    secondary_diagnoses_icd10: list[str] = Field(default_factory=list)
+
+    # Procedures (CPT/HCPCS)
+    procedure_category: ProcedureCategory
+    primary_procedure_code: str = Field(min_length=1)
+    secondary_procedure_codes: list[str] = Field(default_factory=list)
+
+    # Postop complications (boolean per STS Definition)
+    postop_aki: bool = False
+    postop_stroke: bool = False
+    postop_reoperation: bool = False
+    postop_sepsis: bool = False
+
+    # Outcome
+    length_of_stay: int = Field(ge=0)
+    discharge_disposition: str  # 'Home' / 'SNF' / 'Hospice' / 'Death' / etc.
+    mortality_30day: bool = False
+
+
+__all__ = ["ProcedureCategory", "STSRecord"]

--- a/templates/tests/e2e/commercial/test_registry_to_omop_sts.py
+++ b/templates/tests/e2e/commercial/test_registry_to_omop_sts.py
@@ -1,0 +1,94 @@
+"""Phase 3 Plan 4B Task 7 (T-022B): registry_to_omop_sts validation E2E.
+
+In-process reader against the seed=42 / n_surgeries=50 corpus. Same
+gating as Plans 1-3 + 4A — full SQL pipeline against testcontainers
+Postgres lands once the runner gains a programmatic ``run_manifest``
+driver (Phase 4 follow-up).
+
+Acceptance per plan §7:
+
+1. 100% of CSV rows produce typed STSRecords (50 in / 50 out).
+2. Every surgery has a procedure category in the v0.1 enum.
+3. Postop complications fan out as expected (AKI on >=7, mortality=5).
+4. Episode source value is assembled from procedure_category + CPT only
+   (HIGHSEC §7 — verified via the manifest test, complementary here).
+5. Reader is idempotent on replay.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+from runtime.commercial.registry.sts.reader import STSReader
+
+_REPO = Path(__file__).resolve().parents[3]
+_FIXTURE_DIR = (
+    _REPO / "commercial" / "manifests" / "registry_to_omop_sts" / "fixtures" / "synthetic"
+)
+
+
+def _load_builder():  # type: ignore[no-untyped-def]
+    builder_path = _FIXTURE_DIR / "build_sts_corpus.py"
+    spec = importlib.util.spec_from_file_location("build_sts_corpus", builder_path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["build_sts_corpus"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.slow
+def test_sts_e2e_meets_acceptance_gates() -> None:
+    builder = _load_builder()
+    csv_payload: str = builder.build_corpus(seed=42, n_surgeries=50)  # type: ignore[attr-defined]
+    records = STSReader().read(io.StringIO(csv_payload))
+
+    # Gate 1: 50 in / 50 out
+    assert len(records) == 50
+
+    # Gate 2: every record has a known procedure category.
+    valid_cats = {"CABG", "Valve", "Aortic", "Combined", "Other"}
+    for r in records:
+        assert r.procedure_category in valid_cats
+
+    # Gate 3: postop complications + mortality fan out.
+    aki = sum(1 for r in records if r.postop_aki)
+    mortality = sum(1 for r in records if r.mortality_30day)
+    assert aki >= 7
+    assert mortality == 5
+
+    # Gate 5 (gate 4 = SQL-side; covered in manifest tests):
+    # Idempotency.
+    a = STSReader().read(io.StringIO(csv_payload))
+    b = STSReader().read(io.StringIO(csv_payload))
+    assert a == b
+
+
+@pytest.mark.slow
+def test_sts_e2e_handles_full_complication_matrix() -> None:
+    """Edge case: a surgery with all 4 complications + death.
+
+    The fixture's mod-N spread doesn't naturally produce one of these,
+    but we can exercise it with custom CSV input to confirm the reader
+    handles the worst case correctly.
+    """
+    csv_payload = (
+        "RecordID,PatientID,SurgeryDate,PatientAge,Gender,HospitalID,SurgeonID,"
+        "EjectionFraction,NyhaClass,PrimaryDiagnosis,SecondaryDiagnoses,"
+        "ProcedureID,ProcedureCode_Primary,ProcedureCode_Secondary,"
+        "PostOpComplication_AKI,PostOpComplication_Stroke,"
+        "PostOpComplication_Reoperation,PostOpComplication_Sepsis,"
+        "LengthOfStay,DischargeDisposition,Mortality_30Day\n"
+        "STS-WORST,PAT99999,20240601,72,M,H001,S001,30.0,4,I50.32,"
+        "I25.10;E11.9,Combined,33536,33510,yes,yes,yes,yes,21,Death,yes\n"
+    )
+    records = STSReader().read(io.StringIO(csv_payload))
+    r = records[0]
+    assert r.postop_aki and r.postop_stroke and r.postop_reoperation and r.postop_sepsis
+    assert r.mortality_30day
+    assert r.discharge_disposition == "Death"

--- a/templates/tests/unit/commercial/registry/test_sts_column_map.py
+++ b/templates/tests/unit/commercial/registry/test_sts_column_map.py
@@ -1,0 +1,63 @@
+"""Phase 3 Plan 4B Task 1 (T-022B): STS column-mapping table."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+_MAP_FILE = (
+    Path(__file__).resolve().parents[4]
+    / "commercial"
+    / "manifests"
+    / "registry_to_omop_sts"
+    / "column_map.csv"
+)
+
+
+def test_column_map_exists() -> None:
+    assert _MAP_FILE.is_file()
+
+
+def test_column_map_has_required_columns() -> None:
+    with _MAP_FILE.open("r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        cols = set(reader.fieldnames or [])
+    expected = {
+        "sts_field",
+        "omop_table",
+        "omop_column",
+        "vocabulary_id",
+        "concept_lookup_rule",
+        "description",
+    }
+    assert expected <= cols
+
+
+def test_column_map_covers_required_sts_fields() -> None:
+    """v0.1 acceptance — must include the fields the model + reader use."""
+    with _MAP_FILE.open("r", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    sts_fields = {r["sts_field"] for r in rows}
+    for required in (
+        "RecordID",
+        "PatientID",
+        "SurgeryDate",
+        "PatientAge",
+        "Gender",
+        "ProcedureID",
+        "PrimaryDiagnosis",
+        "EjectionFraction",
+        "Mortality_30Day",
+    ):
+        assert required in sts_fields, f"missing column-map row for {required}"
+
+
+def test_column_map_uses_known_omop_vocabularies() -> None:
+    """vocabulary_id must be empty (passthrough) or one of the OMOP-blessed ids."""
+    with _MAP_FILE.open("r", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    allowed = {"", "SNOMED", "ICD10CM", "CPT4", "HCPCS", "RxNorm", "LOINC"}
+    for r in rows:
+        assert (
+            r["vocabulary_id"] in allowed
+        ), f"unknown vocabulary_id {r['vocabulary_id']!r} for {r['sts_field']}"

--- a/templates/tests/unit/commercial/registry/test_sts_fixtures.py
+++ b/templates/tests/unit/commercial/registry/test_sts_fixtures.py
@@ -1,0 +1,75 @@
+"""Phase 3 Plan 4B Task 6 (T-022B): synthetic STS corpus fixture."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+from runtime.commercial.registry.sts.reader import STSReader
+
+_FIXTURE_DIR = (
+    Path(__file__).resolve().parents[4]
+    / "commercial"
+    / "manifests"
+    / "registry_to_omop_sts"
+    / "fixtures"
+    / "synthetic"
+)
+
+
+def _load_builder() -> object:
+    spec = importlib.util.spec_from_file_location(
+        "build_sts_corpus", _FIXTURE_DIR / "build_sts_corpus.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["build_sts_corpus"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fixture_exists() -> None:
+    assert (_FIXTURE_DIR / "build_sts_corpus.py").is_file()
+
+
+def test_build_corpus_is_deterministic() -> None:
+    builder = _load_builder()
+    a = builder.build_corpus(seed=42, n_surgeries=10)  # type: ignore[attr-defined]
+    b = builder.build_corpus(seed=42, n_surgeries=10)  # type: ignore[attr-defined]
+    assert a == b
+
+
+def test_corpus_yields_n_surgeries() -> None:
+    builder = _load_builder()
+    csv_payload: str = builder.build_corpus(seed=42, n_surgeries=50)  # type: ignore[attr-defined]
+    records = STSReader().read(io.StringIO(csv_payload))
+    assert len(records) == 50
+
+
+def test_corpus_covers_5_procedure_categories() -> None:
+    builder = _load_builder()
+    csv_payload: str = builder.build_corpus(seed=42, n_surgeries=50)  # type: ignore[attr-defined]
+    records = STSReader().read(io.StringIO(csv_payload))
+    cats = {r.procedure_category for r in records}
+    assert cats == {"CABG", "Valve", "Aortic", "Combined", "Other"}
+
+
+def test_corpus_includes_some_complications_and_mortality() -> None:
+    builder = _load_builder()
+    csv_payload: str = builder.build_corpus(seed=42, n_surgeries=50)  # type: ignore[attr-defined]
+    records = STSReader().read(io.StringIO(csv_payload))
+    aki_count = sum(1 for r in records if r.postop_aki)
+    mortality_count = sum(1 for r in records if r.mortality_30day)
+    assert aki_count >= 1  # mod-7 spread on n=50 -> 7 events
+    assert mortality_count == 5  # mod-10 -> exactly 5 of 50
+
+
+def test_corpus_distinct_patients() -> None:
+    builder = _load_builder()
+    csv_payload: str = builder.build_corpus(seed=42, n_surgeries=50)  # type: ignore[attr-defined]
+    records = STSReader().read(io.StringIO(csv_payload))
+    pids = {r.patient_id for r in records}
+    assert len(pids) == 50

--- a/templates/tests/unit/commercial/registry/test_sts_manifest.py
+++ b/templates/tests/unit/commercial/registry/test_sts_manifest.py
@@ -1,0 +1,116 @@
+"""Phase 3 Plan 4B Tasks 4 + 5 (T-022B): registry_to_omop_sts manifest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+MANIFEST_DIR = (
+    Path(__file__).resolve().parents[4] / "commercial" / "manifests" / "registry_to_omop_sts"
+)
+SQL_DIR = MANIFEST_DIR / "sql"
+
+
+def _load() -> dict[str, object]:
+    raw = (MANIFEST_DIR / "manifest.yaml").read_text(encoding="utf-8")
+    parsed = yaml.safe_load(raw)
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def test_manifest_loads() -> None:
+    cfg = _load()
+    assert cfg["apiVersion"] == "parthenon.acumenus.net/v1"
+    assert cfg["kind"] == "Template"
+    metadata = cfg["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["id"] == "registry_to_omop_sts"
+
+
+def test_manifest_marks_commercial_tier() -> None:
+    cfg = _load()
+    metadata = cfg["metadata"]
+    assert isinstance(metadata, dict)
+    tags = metadata.get("tags", [])
+    assert "commercial" in tags
+    assert "sts" in tags
+    assert "cardiac-surgery" in tags
+
+
+def test_manifest_requires_cardiac_vocabularies() -> None:
+    cfg = _load()
+    spec = cfg["spec"]
+    assert isinstance(spec, dict)
+    required = spec["requires"]["vocabularies"]
+    for vocab in ("ICD10CM", "CPT4", "HCPCS", "SNOMED"):
+        assert vocab in required
+
+
+def test_manifest_has_six_stages() -> None:
+    cfg = _load()
+    spec = cfg["spec"]
+    assert isinstance(spec, dict)
+    nodes = spec["nodes"]
+    assert isinstance(nodes, list)
+    assert len(nodes) == 6
+
+
+@pytest.mark.parametrize(
+    "node_id",
+    [
+        "bootstrap_source",
+        "load_sts",
+        "map_procedure_occurrence",
+        "map_condition_occurrence",
+        "map_episode",
+        "summarize",
+    ],
+)
+def test_manifest_declares_required_node(node_id: str) -> None:
+    cfg = _load()
+    spec = cfg["spec"]
+    assert isinstance(spec, dict)
+    ids = {n["node_id"] for n in spec["nodes"]}
+    assert node_id in ids
+
+
+def test_required_sql_files_exist() -> None:
+    for filename in (
+        "00_bootstrap_sts_source.sql",
+        "01_load_sts_csv.sql",
+        "02a_map_procedure_occurrence.sql",
+        "02b_map_condition_occurrence.sql",
+        "02c_map_episode.sql",
+        "03_summarize.sql",
+    ):
+        assert (SQL_DIR / filename).is_file()
+
+
+def test_episode_sql_assembles_source_value_from_canonical_codes() -> None:
+    """HIGHSEC §7: episode_source_value uses procedure category + CPT, no patient ids."""
+    sql = (SQL_DIR / "02c_map_episode.sql").read_text(encoding="utf-8")
+    assert "procedure_category || ':' || s.primary_procedure_code" in sql
+    assert "patient_id" not in sql.replace("hashtext(s.patient_id)", "")  # only inside hashtext
+
+
+def test_procedure_sql_handles_primary_and_secondary() -> None:
+    sql = (SQL_DIR / "02a_map_procedure_occurrence.sql").read_text(encoding="utf-8")
+    assert "primary_procedure_code" in sql
+    assert "secondary_procedure_codes" in sql
+    assert "UNION ALL" in sql
+
+
+def test_condition_sql_includes_postop_complications() -> None:
+    sql = (SQL_DIR / "02b_map_condition_occurrence.sql").read_text(encoding="utf-8")
+    for col in ("postop_aki", "postop_stroke", "postop_reoperation", "postop_sepsis"):
+        assert col in sql
+
+
+def test_readme_exists_and_documents_license() -> None:
+    readme = MANIFEST_DIR / "README.md"
+    assert readme.is_file()
+    text = readme.read_text(encoding="utf-8")
+    assert "STS Participant Agreement" in text
+    assert "v4.20.2" in text

--- a/templates/tests/unit/commercial/registry/test_sts_reader.py
+++ b/templates/tests/unit/commercial/registry/test_sts_reader.py
@@ -1,0 +1,131 @@
+"""Phase 3 Plan 4B Task 3 (T-022B): STSReader CSV parser."""
+
+from __future__ import annotations
+
+import io
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from runtime.commercial.registry.sts.reader import STSReader, STSReadError
+
+_HEADER = (
+    "RecordID,PatientID,SurgeryDate,PatientAge,Gender,HospitalID,SurgeonID,"
+    "EjectionFraction,NyhaClass,PrimaryDiagnosis,SecondaryDiagnoses,"
+    "ProcedureID,ProcedureCode_Primary,ProcedureCode_Secondary,"
+    "PostOpComplication_AKI,PostOpComplication_Stroke,"
+    "PostOpComplication_Reoperation,PostOpComplication_Sepsis,"
+    "LengthOfStay,DischargeDisposition,Mortality_30Day"
+)
+
+
+def _row(**overrides: str) -> str:
+    base: dict[str, str] = {
+        "RecordID": "STS-0001",
+        "PatientID": "PAT00001",
+        "SurgeryDate": "20240515",
+        "PatientAge": "67",
+        "Gender": "M",
+        "HospitalID": "H001",
+        "SurgeonID": "S001",
+        "EjectionFraction": "55.0",
+        "NyhaClass": "2",
+        "PrimaryDiagnosis": "I25.10",
+        "SecondaryDiagnoses": "I50.32;E11.9",
+        "ProcedureID": "CABG",
+        "ProcedureCode_Primary": "33533",
+        "ProcedureCode_Secondary": "33510",
+        "PostOpComplication_AKI": "no",
+        "PostOpComplication_Stroke": "no",
+        "PostOpComplication_Reoperation": "no",
+        "PostOpComplication_Sepsis": "no",
+        "LengthOfStay": "7",
+        "DischargeDisposition": "Home",
+        "Mortality_30Day": "no",
+    }
+    base.update(overrides)
+    fields = (
+        "RecordID,PatientID,SurgeryDate,PatientAge,Gender,HospitalID,SurgeonID,"
+        "EjectionFraction,NyhaClass,PrimaryDiagnosis,SecondaryDiagnoses,"
+        "ProcedureID,ProcedureCode_Primary,ProcedureCode_Secondary,"
+        "PostOpComplication_AKI,PostOpComplication_Stroke,"
+        "PostOpComplication_Reoperation,PostOpComplication_Sepsis,"
+        "LengthOfStay,DischargeDisposition,Mortality_30Day"
+    ).split(",")
+    return ",".join(base[f] for f in fields)
+
+
+def _payload(*rows: str) -> str:
+    return _HEADER + "\n" + "\n".join(rows) + "\n"
+
+
+def test_reader_parses_one_row() -> None:
+    records = STSReader().read(io.StringIO(_payload(_row())))
+    assert len(records) == 1
+    r = records[0]
+    assert r.record_id == "STS-0001"
+    assert r.surgery_date == date(2024, 5, 15)
+    assert r.ejection_fraction == Decimal("55.0")
+    assert r.procedure_category == "CABG"
+    assert r.secondary_diagnoses_icd10 == ["I50.32", "E11.9"]
+    assert r.secondary_procedure_codes == ["33510"]
+    assert r.postop_aki is False
+
+
+def test_reader_parses_multiple_rows() -> None:
+    records = STSReader().read(
+        io.StringIO(
+            _payload(
+                _row(),
+                _row(RecordID="STS-0002", ProcedureID="Valve", ProcedureCode_Primary="33405"),
+                _row(RecordID="STS-0003", ProcedureID="Aortic", ProcedureCode_Primary="33860"),
+            )
+        )
+    )
+    assert len(records) == 3
+    assert records[1].procedure_category == "Valve"
+    assert records[2].procedure_category == "Aortic"
+
+
+def test_reader_handles_yes_no_and_numeric_booleans() -> None:
+    records = STSReader().read(
+        io.StringIO(_payload(_row(PostOpComplication_AKI="yes", Mortality_30Day="1")))
+    )
+    assert records[0].postop_aki is True
+    assert records[0].mortality_30day is True
+
+
+def test_reader_handles_empty_secondary_lists() -> None:
+    records = STSReader().read(
+        io.StringIO(_payload(_row(SecondaryDiagnoses="", ProcedureCode_Secondary="")))
+    )
+    assert records[0].secondary_diagnoses_icd10 == []
+    assert records[0].secondary_procedure_codes == []
+
+
+def test_reader_raises_on_missing_header() -> None:
+    with pytest.raises(STSReadError):
+        STSReader().read(io.StringIO(""))
+
+
+def test_reader_raises_on_invalid_date() -> None:
+    with pytest.raises(STSReadError):
+        STSReader().read(io.StringIO(_payload(_row(SurgeryDate="BADDATE0"))))
+
+
+def test_reader_raises_on_unknown_procedure_category() -> None:
+    with pytest.raises(STSReadError):
+        STSReader().read(io.StringIO(_payload(_row(ProcedureID="Brain"))))
+
+
+def test_reader_raises_on_unparseable_boolean() -> None:
+    with pytest.raises(STSReadError):
+        STSReader().read(io.StringIO(_payload(_row(PostOpComplication_AKI="maybe"))))
+
+
+def test_reader_idempotent() -> None:
+    payload = _payload(_row(), _row(RecordID="STS-0002"))
+    a = STSReader().read(io.StringIO(payload))
+    b = STSReader().read(io.StringIO(payload))
+    assert a == b

--- a/templates/tests/unit/commercial/registry/test_sts_types.py
+++ b/templates/tests/unit/commercial/registry/test_sts_types.py
@@ -1,0 +1,99 @@
+"""Phase 3 Plan 4B Task 2 (T-022B): STSRecord typed model."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from runtime.commercial.registry.sts.types import STSRecord
+
+
+def _kwargs(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "record_id": "STS-0001",
+        "patient_id": "PAT00001",
+        "surgery_date": date(2024, 5, 15),
+        "patient_age": 67,
+        "gender": "M",
+        "hospital_id": "STS-H001",
+        "surgeon_id": "STS-S001",
+        "ejection_fraction": Decimal("55.0"),
+        "nyha_class": 2,
+        "primary_diagnosis_icd10": "I25.10",
+        "secondary_diagnoses_icd10": ["I50.32", "E11.9"],
+        "procedure_category": "CABG",
+        "primary_procedure_code": "33533",
+        "secondary_procedure_codes": ["33510"],
+        "postop_aki": False,
+        "postop_stroke": False,
+        "postop_reoperation": False,
+        "postop_sepsis": False,
+        "length_of_stay": 7,
+        "discharge_disposition": "Home",
+        "mortality_30day": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_constructs_minimal_cabg_record() -> None:
+    r = STSRecord(**_kwargs())
+    assert r.record_id == "STS-0001"
+    assert r.procedure_category == "CABG"
+    assert r.length_of_stay == 7
+    assert r.mortality_30day is False
+
+
+def test_extra_fields_rejected() -> None:
+    with pytest.raises(ValidationError):
+        STSRecord(**_kwargs(unexpected_field="oops"))
+
+
+def test_frozen_after_construction() -> None:
+    r = STSRecord(**_kwargs())
+    with pytest.raises(ValidationError):
+        r.length_of_stay = 14  # type: ignore[misc]
+
+
+def test_unknown_procedure_category_rejected() -> None:
+    with pytest.raises(ValidationError):
+        STSRecord(**_kwargs(procedure_category="Brain"))  # not a thoracic procedure
+
+
+def test_unknown_gender_rejected() -> None:
+    with pytest.raises(ValidationError):
+        STSRecord(**_kwargs(gender="X"))
+
+
+def test_nyha_out_of_range_rejected() -> None:
+    with pytest.raises(ValidationError):
+        STSRecord(**_kwargs(nyha_class=5))
+
+
+def test_ef_out_of_range_rejected() -> None:
+    with pytest.raises(ValidationError):
+        STSRecord(**_kwargs(ejection_fraction=Decimal("150")))
+
+
+def test_handles_postop_complications_and_mortality() -> None:
+    r = STSRecord(
+        **_kwargs(
+            postop_aki=True,
+            postop_stroke=True,
+            mortality_30day=True,
+            discharge_disposition="Death",
+        )
+    )
+    assert r.postop_aki is True
+    assert r.postop_stroke is True
+    assert r.mortality_30day is True
+
+
+def test_aortic_combined_categories_accepted() -> None:
+    """v0.1 supports CABG / Valve / Aortic / Combined / Other."""
+    for cat in ("Valve", "Aortic", "Combined", "Other"):
+        r = STSRecord(**_kwargs(procedure_category=cat))
+        assert r.procedure_category == cat


### PR DESCRIPTION
Implements **Phase 3 Plan 4B (T-022B)** — second slice of T-022. Adds the Society of Thoracic Surgeons National Database sub-template. Unlike Plan 4A (NAACCR), no upstream OHDSI ETL exists for STS — we maintain the column-mapping table ourselves against STS Adult Cardiac Surgery v4.20.2.

Plan: \`docs/superpowers/plans/2026-05-06-parthenon-ingestion-templates-phase-3-plan-4b-sts.md\`. Same registry strategy as ADR 0017.

## Summary

### STS ingestion (Tasks 1-3)
- \`column_map.csv\` — 21 STS field rows mapping to OMOP destinations + concept-lookup rules
- \`STSRecord\` typed model (~25 fields, frozen, Pydantic constraints on age/EF/NYHA/category)
- \`STSReader\` CSV parser with HIGHSEC §7 redaction filter

### OMOP projection (Task 4, 5 SQL stages)
- \`00_bootstrap_sts_source.sql\` — fmt_sts_surgery table with check constraints
- \`01_load_sts_csv.sql\` — COPY production path
- \`02a_map_procedure_occurrence.sql\` — primary CPT/HCPCS + secondary via LATERAL unnest, both → SNOMED
- \`02b_map_condition_occurrence.sql\` — three-pass: pre-op primary ICD-10, secondary, postop complications (SNOMED-coded booleans)
- \`02c_map_episode.sql\` — Procedure-Anchored Episode per surgery, source_value from category+CPT (no PHI)

### Manifest (Task 5)
- 6-stage pipeline; required vocabularies ICD10CM / CPT4 / HCPCS / SNOMED

### Synthetic corpus (Task 6)
- 50-surgery deterministic CSV (seed=42), 5 procedure categories, complications spread mod-N, exactly 5 mortality (mod-10)

### Validation E2E (Task 7)
- 2 @pytest.mark.slow E2Es asserting 50 in/out, procedure category coverage, complication + mortality fan-out, idempotency, plus a worst-case-matrix edge test

### README (Task 8)
- License caveats (STS Participant Agreement required), v4.20.2 spec target, vocab prerequisites, operator workflow

## Test plan

- [x] **45 new tests** (4 column-map + 9 types + 9 reader + 10 manifest + 6 fixture + 2 e2e + 5 misc)
- [x] All gates green: ruff, black, mypy --strict, import-linter contract
- [x] Community wheel isolation verified locally (no commercial paths leak)

## Plan deviations (per audit-remediation contract)

1. **Postop complication SNOMED concept_ids hard-coded** in 02b SQL because STS export encodes complications as booleans, not as source codes. The 4 IDs are documented inline; Phase 4 may extend with a lookup table.
2. **Episode end-date approximated** as surgery + length_of_stay (STS export doesn't carry a discharge-date column). Phase 4 if customers need truer dates.

## Process

Direct execution (post-audit pattern). Atomic-commit-per-task with full gate verification before each commit. Pre-PR sanity: `git ls-files` matches expected new-file set (caught the gitignore class of bug from PR #287).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)