### PR TITLE
feat: preserve stale branch GIS and UI fixes

### DIFF
--- a/.github/workflows/finngen-tests.yml
+++ b/.github/workflows/finngen-tests.yml
@@ -97,12 +97,26 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install PostGIS into postgres service container
+        run: |
+          # Phase 19 (D-04): FinnGen migrations run the full Laravel schema,
+          # including GIS tables, so this job must match the main CI postgres
+          # service setup.
+          PG_CID=$(docker ps --filter "ancestor=pgvector/pgvector:pg16" --format '{{.ID}}' | head -n1)
+          if [ -z "$PG_CID" ]; then
+            echo "Could not find pgvector postgres service container" >&2
+            docker ps
+            exit 1
+          fi
+          docker exec "$PG_CID" bash -c "apt-get update -qq && apt-get install -y --no-install-recommends postgresql-16-postgis-3"
+
       - name: Prepare Postgres schemas and extensions
         env:
           PGPASSWORD: secret
           PGDATABASE: parthenon_test
           PGUSER: parthenon
           POSTGRES_CREATE_TEST_DATABASE: "1"
+          POSTGRES_ENABLE_POSTGIS: "1"
         run: bash scripts/ci/prepare-postgres.sh
 
       - name: Setup PHP

--- a/ai/app/services/solr_spatial.py
+++ b/ai/app/services/solr_spatial.py
@@ -152,7 +152,7 @@ async def get_choropleth_from_solr(
         q="*:*",
         fq=fq,
         fl=f"gadm_gid,county_name_exact,{metric_field},population,cfr",
-        rows=500,
+        rows=5000,
         sort=f"{metric_field} desc",
     )
 

--- a/backend/app/Http/Controllers/Api/V1/GisCohortGeographyController.php
+++ b/backend/app/Http/Controllers/Api/V1/GisCohortGeographyController.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\App\Source;
+use App\Services\GIS\CohortGeographyService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * @group GIS Explorer
+ */
+class GisCohortGeographyController extends Controller
+{
+    public function __construct(
+        private readonly CohortGeographyService $cohortGeography,
+    ) {}
+
+    public function cohorts(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'source_id' => ['nullable', 'integer'],
+            'search' => ['nullable', 'string', 'max:120'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $source = $this->resolveSource($request, $validated['source_id'] ?? null);
+
+        return response()->json([
+            'data' => $this->cohortGeography->generatedCohorts(
+                $source,
+                $validated['search'] ?? null,
+                (int) ($validated['limit'] ?? 25),
+            ),
+        ]);
+    }
+
+    public function conditions(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'source_id' => ['nullable', 'integer'],
+            'search' => ['nullable', 'string', 'max:120'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $source = $this->resolveSource($request, $validated['source_id'] ?? null);
+
+        return response()->json([
+            'data' => $this->cohortGeography->conditions(
+                $source,
+                $validated['search'] ?? null,
+                (int) ($validated['limit'] ?? 25),
+            ),
+        ]);
+    }
+
+    public function coverage(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'source_id' => ['nullable', 'integer'],
+            'state_fips' => ['nullable', 'string', 'size:2'],
+        ]);
+
+        $source = $this->resolveSource($request, $validated['source_id'] ?? null);
+
+        return response()->json([
+            'data' => $this->cohortGeography->coverage(
+                $source,
+                $validated['state_fips'] ?? '42',
+            ),
+        ]);
+    }
+
+    public function aggregate(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'source_id' => ['nullable', 'integer'],
+            'mode' => ['required', Rule::in(['generated', 'condition'])],
+            'cohort_definition_id' => ['required_if:mode,generated', 'nullable', 'integer'],
+            'concept_id' => ['required_if:mode,condition', 'nullable', 'integer'],
+            'level' => ['nullable', Rule::in(['county', 'tract'])],
+            'metric' => ['nullable', Rule::in(['members', 'prevalence_per_1000'])],
+            'min_cell_count' => ['nullable', 'integer', 'min:0', 'max:100'],
+            'state_fips' => ['nullable', 'string', 'size:2'],
+        ]);
+
+        $source = $this->resolveSource($request, $validated['source_id'] ?? null);
+        $mode = (string) $validated['mode'];
+        $targetId = $mode === 'generated'
+            ? (int) $validated['cohort_definition_id']
+            : (int) $validated['concept_id'];
+
+        return response()->json([
+            'data' => $this->cohortGeography->aggregate(
+                $source,
+                $mode,
+                $targetId,
+                $validated['level'] ?? 'county',
+                $validated['metric'] ?? 'members',
+                (int) ($validated['min_cell_count'] ?? 5),
+                $validated['state_fips'] ?? '42',
+            ),
+        ]);
+    }
+
+    private function resolveSource(Request $request, int|string|null $sourceId): Source
+    {
+        $query = Source::with('daimons');
+
+        if ($request->user() !== null) {
+            $query->visibleToUser($request->user());
+        }
+
+        if ($sourceId !== null) {
+            return $query->whereKey((int) $sourceId)->firstOrFail();
+        }
+
+        $default = (clone $query)->where('source_key', 'ACUMENUS')->first();
+        if ($default instanceof Source) {
+            return $default;
+        }
+
+        return $query->orderBy('source_name')->firstOrFail();
+    }
+}

--- a/backend/app/Services/GIS/CohortGeographyService.php
+++ b/backend/app/Services/GIS/CohortGeographyService.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\GIS;
+
+use App\Enums\DaimonType;
+use App\Models\App\Source;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use RuntimeException;
+
+class CohortGeographyService
+{
+    private const DEFAULT_SOURCE_KEY = 'ACUMENUS';
+
+    public function defaultSource(): ?Source
+    {
+        return Source::with('daimons')->where('source_key', self::DEFAULT_SOURCE_KEY)->first();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function generatedCohorts(Source $source, ?string $search = null, int $limit = 25): array
+    {
+        $source->loadMissing('daimons');
+        $resultsSchema = $this->schemaIdentifier($source->getTableQualifier(DaimonType::Results), 'results schema');
+        $limit = max(1, min($limit, 100));
+
+        $bindings = [(int) $source->id];
+        $where = '';
+        if ($search !== null && trim($search) !== '') {
+            $where = 'WHERE cd.name ILIKE ? OR c.cohort_definition_id::text = ?';
+            $bindings[] = '%'.trim($search).'%';
+            $bindings[] = trim($search);
+        }
+
+        $rows = DB::connection('gis')->select(<<<SQL
+            SELECT
+                c.cohort_definition_id,
+                COALESCE(cd.name, 'Cohort ' || c.cohort_definition_id::text) AS name,
+                COUNT(DISTINCT c.subject_id) AS subject_count,
+                COUNT(DISTINCT pg.person_id) AS geocoded_count,
+                ROUND(
+                    COUNT(DISTINCT pg.person_id)::numeric
+                    / NULLIF(COUNT(DISTINCT c.subject_id), 0) * 100,
+                    2
+                ) AS coverage_percent
+            FROM {$resultsSchema}.cohort c
+            LEFT JOIN app.cohort_definitions cd ON cd.id = c.cohort_definition_id
+            LEFT JOIN gis.patient_geography pg
+                ON pg.source_id = ?
+               AND pg.person_id = c.subject_id
+            {$where}
+            GROUP BY c.cohort_definition_id, cd.name
+            ORDER BY geocoded_count DESC, subject_count DESC, c.cohort_definition_id
+            LIMIT {$limit}
+        SQL, $bindings);
+
+        return array_map(fn (object $row): array => [
+            'cohort_definition_id' => (int) $row->cohort_definition_id,
+            'name' => (string) $row->name,
+            'subject_count' => (int) $row->subject_count,
+            'geocoded_count' => (int) $row->geocoded_count,
+            'coverage_percent' => $row->coverage_percent !== null ? (float) $row->coverage_percent : 0.0,
+        ], $rows);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function conditions(Source $source, ?string $search = null, int $limit = 25): array
+    {
+        $source->loadMissing('daimons');
+        $cdmSchema = $this->schemaIdentifier($source->getTableQualifier(DaimonType::CDM), 'CDM schema');
+        $vocabSchema = $this->schemaIdentifier($source->getTableQualifier(DaimonType::Vocabulary), 'vocabulary schema');
+        $limit = max(1, min($limit, 100));
+
+        $bindings = [(int) $source->id];
+        $where = 'co.condition_concept_id <> 0';
+        if ($search !== null && trim($search) !== '') {
+            $where .= ' AND (c.concept_name ILIKE ? OR co.condition_concept_id::text = ?)';
+            $bindings[] = '%'.trim($search).'%';
+            $bindings[] = trim($search);
+        }
+
+        $rows = DB::connection('gis')->select(<<<SQL
+            SELECT
+                co.condition_concept_id AS concept_id,
+                c.concept_name AS name,
+                COUNT(DISTINCT co.person_id) AS subject_count,
+                COUNT(DISTINCT pg.person_id) AS geocoded_count,
+                ROUND(
+                    COUNT(DISTINCT pg.person_id)::numeric
+                    / NULLIF(COUNT(DISTINCT co.person_id), 0) * 100,
+                    2
+                ) AS coverage_percent
+            FROM {$cdmSchema}.condition_occurrence co
+            JOIN {$vocabSchema}.concept c ON c.concept_id = co.condition_concept_id
+            LEFT JOIN gis.patient_geography pg
+                ON pg.source_id = ?
+               AND pg.person_id = co.person_id
+            WHERE {$where}
+            GROUP BY co.condition_concept_id, c.concept_name
+            ORDER BY geocoded_count DESC, subject_count DESC, c.concept_name
+            LIMIT {$limit}
+        SQL, $bindings);
+
+        return array_map(fn (object $row): array => [
+            'concept_id' => (int) $row->concept_id,
+            'name' => (string) $row->name,
+            'subject_count' => (int) $row->subject_count,
+            'geocoded_count' => (int) $row->geocoded_count,
+            'coverage_percent' => $row->coverage_percent !== null ? (float) $row->coverage_percent : 0.0,
+        ], $rows);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function coverage(Source $source, string $stateFips = '42'): array
+    {
+        $levels = [];
+        foreach (['county' => 'county_location_id', 'tract' => 'tract_location_id'] as $level => $column) {
+            $row = DB::connection('gis')->selectOne(<<<SQL
+                SELECT
+                    COUNT(DISTINCT gl.geographic_location_id) AS geography_count,
+                    COUNT(DISTINCT gl.geographic_location_id) FILTER (WHERE gl.geometry IS NOT NULL) AS geometry_count,
+                    COUNT(DISTINCT pg.person_id) AS linked_person_count
+                FROM gis.geographic_location gl
+                LEFT JOIN gis.patient_geography pg
+                    ON pg.source_id = ?
+                   AND pg.{$column} = gl.geographic_location_id
+                WHERE gl.location_type = ?
+                  AND gl.state_fips = ?
+            SQL, [(int) $source->id, $level === 'tract' ? 'census_tract' : 'county', $stateFips]);
+
+            $geographyCount = (int) ($row->geography_count ?? 0);
+            $geometryCount = (int) ($row->geometry_count ?? 0);
+            $linkedPersonCount = (int) ($row->linked_person_count ?? 0);
+
+            $levels[$level] = [
+                'level' => $level,
+                'available' => $geographyCount > 0 && $geometryCount > 0 && $linkedPersonCount > 0,
+                'geography_count' => $geographyCount,
+                'geometry_count' => $geometryCount,
+                'linked_person_count' => $linkedPersonCount,
+            ];
+        }
+
+        return [
+            'source_id' => (int) $source->id,
+            'source_key' => $source->source_key,
+            'source_name' => $source->source_name,
+            'state_fips' => $stateFips,
+            'levels' => $levels,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function aggregate(
+        Source $source,
+        string $mode,
+        int $targetId,
+        string $level = 'county',
+        string $metric = 'members',
+        int $minCellCount = 5,
+        string $stateFips = '42',
+    ): array {
+        $source->loadMissing('daimons');
+        $levelConfig = $this->levelConfig($level);
+        $selected = $this->selectedCte($source, $mode, $targetId);
+        $minCellCount = max(0, min($minCellCount, 100));
+
+        $rows = DB::connection('gis')->select(<<<SQL
+            WITH selected AS (
+                {$selected['sql']}
+            ),
+            source_geo AS (
+                SELECT pg.person_id, pg.{$levelConfig['patient_column']} AS geo_id
+                FROM gis.patient_geography pg
+                WHERE pg.source_id = ?
+                  AND pg.{$levelConfig['patient_column']} IS NOT NULL
+            ),
+            denominator AS (
+                SELECT geo_id, COUNT(DISTINCT person_id) AS denominator
+                FROM source_geo
+                GROUP BY geo_id
+            ),
+            numerator AS (
+                SELECT sg.geo_id, COUNT(DISTINCT s.person_id) AS member_count
+                FROM selected s
+                JOIN source_geo sg ON sg.person_id = s.person_id
+                GROUP BY sg.geo_id
+            ),
+            totals AS (
+                SELECT COUNT(DISTINCT person_id) AS total_selected FROM selected
+            ),
+            geocoded AS (
+                SELECT COUNT(DISTINCT s.person_id) AS geocoded_selected
+                FROM selected s
+                JOIN source_geo sg ON sg.person_id = s.person_id
+            )
+            SELECT
+                gl.geographic_location_id,
+                gl.location_name,
+                gl.geographic_code AS fips,
+                gl.latitude,
+                gl.longitude,
+                gl.population,
+                gl.area_sq_km,
+                ST_AsGeoJSON(gl.geometry)::json AS geometry,
+                d.denominator,
+                CASE
+                    WHEN COALESCE(n.member_count, 0) > 0
+                     AND COALESCE(n.member_count, 0) < ?
+                    THEN NULL
+                    ELSE COALESCE(n.member_count, 0)
+                END AS member_count,
+                CASE
+                    WHEN COALESCE(n.member_count, 0) > 0
+                     AND COALESCE(n.member_count, 0) < ?
+                    THEN NULL
+                    ELSE ROUND(COALESCE(n.member_count, 0)::numeric / NULLIF(d.denominator, 0) * 1000, 3)
+                END AS rate_per_1000,
+                CASE
+                    WHEN COALESCE(n.member_count, 0) > 0
+                     AND COALESCE(n.member_count, 0) < ?
+                    THEN TRUE
+                    ELSE FALSE
+                END AS suppressed,
+                totals.total_selected,
+                geocoded.geocoded_selected
+            FROM denominator d
+            JOIN gis.geographic_location gl ON gl.geographic_location_id = d.geo_id
+            LEFT JOIN numerator n ON n.geo_id = d.geo_id
+            CROSS JOIN totals
+            CROSS JOIN geocoded
+            WHERE gl.location_type = ?
+              AND gl.state_fips = ?
+              AND gl.geometry IS NOT NULL
+            ORDER BY
+                CASE WHEN ? = 'prevalence_per_1000'
+                     THEN COALESCE(ROUND(COALESCE(n.member_count, 0)::numeric / NULLIF(d.denominator, 0) * 1000, 3), 0)
+                     ELSE COALESCE(n.member_count, 0)
+                END DESC,
+                gl.location_name
+        SQL, array_merge(
+            $selected['bindings'],
+            [
+                (int) $source->id,
+                $minCellCount,
+                $minCellCount,
+                $minCellCount,
+                $levelConfig['location_type'],
+                $stateFips,
+                $metric,
+            ],
+        ));
+
+        $features = array_map(function (object $row) use ($metric): array {
+            $memberCount = $row->member_count !== null ? (int) $row->member_count : null;
+            $rate = $row->rate_per_1000 !== null ? (float) $row->rate_per_1000 : null;
+            $geometry = $row->geometry;
+            if (is_string($geometry)) {
+                $geometry = json_decode($geometry, true);
+            }
+
+            return [
+                'geographic_location_id' => (int) $row->geographic_location_id,
+                'location_name' => (string) $row->location_name,
+                'fips' => (string) $row->fips,
+                'latitude' => $row->latitude !== null ? (float) $row->latitude : null,
+                'longitude' => $row->longitude !== null ? (float) $row->longitude : null,
+                'population' => $row->population !== null ? (int) $row->population : null,
+                'area_sq_km' => $row->area_sq_km !== null ? (float) $row->area_sq_km : null,
+                'geometry' => $geometry,
+                'member_count' => $memberCount,
+                'denominator' => (int) $row->denominator,
+                'rate_per_1000' => $rate,
+                'value' => $metric === 'prevalence_per_1000' ? $rate : $memberCount,
+                'suppressed' => (bool) $row->suppressed,
+            ];
+        }, $rows);
+
+        $totalSelected = (int) ($rows[0]->total_selected ?? 0);
+        $geocodedSelected = (int) ($rows[0]->geocoded_selected ?? 0);
+        $suppressedGeographies = count(array_filter($features, fn (array $row): bool => (bool) $row['suppressed']));
+
+        return [
+            'source' => [
+                'id' => (int) $source->id,
+                'key' => $source->source_key,
+                'name' => $source->source_name,
+            ],
+            'mode' => $mode,
+            'target_id' => $targetId,
+            'level' => $level,
+            'metric' => $metric,
+            'min_cell_count' => $minCellCount,
+            'state_fips' => $stateFips,
+            'summary' => [
+                'total_members' => $totalSelected,
+                'geocoded_members' => $geocodedSelected,
+                'unknown_members' => max($totalSelected - $geocodedSelected, 0),
+                'coverage_percent' => $totalSelected > 0 ? round($geocodedSelected / $totalSelected * 100, 2) : 0.0,
+                'geography_count' => count($features),
+                'suppressed_geographies' => $suppressedGeographies,
+            ],
+            'features' => $features,
+        ];
+    }
+
+    /**
+     * @return array{patient_column: string, location_type: string}
+     */
+    private function levelConfig(string $level): array
+    {
+        return match ($level) {
+            'county' => ['patient_column' => 'county_location_id', 'location_type' => 'county'],
+            'tract' => ['patient_column' => 'tract_location_id', 'location_type' => 'census_tract'],
+            default => throw new InvalidArgumentException("Unsupported geography level: {$level}"),
+        };
+    }
+
+    /**
+     * @return array{sql: string, bindings: array<int, mixed>}
+     */
+    private function selectedCte(Source $source, string $mode, int $targetId): array
+    {
+        if ($mode === 'generated') {
+            $resultsSchema = $this->schemaIdentifier($source->getTableQualifier(DaimonType::Results), 'results schema');
+
+            return [
+                'sql' => "SELECT DISTINCT c.subject_id AS person_id FROM {$resultsSchema}.cohort c WHERE c.cohort_definition_id = ?",
+                'bindings' => [$targetId],
+            ];
+        }
+
+        if ($mode === 'condition') {
+            $cdmSchema = $this->schemaIdentifier($source->getTableQualifier(DaimonType::CDM), 'CDM schema');
+
+            return [
+                'sql' => "SELECT DISTINCT co.person_id FROM {$cdmSchema}.condition_occurrence co WHERE co.condition_concept_id = ?",
+                'bindings' => [$targetId],
+            ];
+        }
+
+        throw new InvalidArgumentException("Unsupported cohort geography mode: {$mode}");
+    }
+
+    private function schemaIdentifier(?string $schema, string $label): string
+    {
+        if ($schema === null || ! preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $schema)) {
+            throw new RuntimeException("Source is missing a valid {$label}.");
+        }
+
+        return $schema;
+    }
+}

--- a/backend/app/Services/GIS/GeographyService.php
+++ b/backend/app/Services/GIS/GeographyService.php
@@ -55,6 +55,13 @@ class GeographyService
     {
         return [
             [
+                'id' => 'cohort-geography',
+                'name' => 'Cohort Geography',
+                'description' => 'Generated cohort membership and prevalence by Pennsylvania geography',
+                'color' => '#06B6D4',
+                'available' => $this->hasCohortGeographyData(),
+            ],
+            [
                 'id' => 'svi',
                 'name' => 'Social Vulnerability Index',
                 'description' => 'CDC/ATSDR SVI by census tract — 4 themes + overall',
@@ -107,6 +114,24 @@ class GeographyService
         $row = DB::connection('gis')->selectOne(
             'SELECT EXISTS(SELECT 1 FROM gis.gis_hospital LIMIT 1) AS has_data'
         );
+
+        return $row->has_data ?? false;
+    }
+
+    private function hasCohortGeographyData(): bool
+    {
+        $row = DB::connection('gis')->selectOne(<<<'SQL'
+            SELECT EXISTS(
+                SELECT 1
+                FROM gis.patient_geography pg
+                JOIN gis.geographic_location gl
+                  ON gl.geographic_location_id = pg.county_location_id
+                WHERE gl.location_type = 'county'
+                  AND gl.state_fips = '42'
+                  AND gl.geometry IS NOT NULL
+                LIMIT 1
+            ) AS has_data
+        SQL);
 
         return $row->has_data ?? false;
     }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -73,6 +73,7 @@ use App\Http\Controllers\Api\V1\GencodeController;
 use App\Http\Controllers\Api\V1\GenomicEvidenceController;
 use App\Http\Controllers\Api\V1\GenomicsController;
 use App\Http\Controllers\Api\V1\GisAirQualityController;
+use App\Http\Controllers\Api\V1\GisCohortGeographyController;
 use App\Http\Controllers\Api\V1\GisComorbidityController;
 use App\Http\Controllers\Api\V1\GisController;
 use App\Http\Controllers\Api\V1\GisEtlController;
@@ -1680,6 +1681,14 @@ Route::prefix('v1')->middleware(['auth:sanctum', 'source.resolve'])->group(funct
         Route::get('/layers', [GisGeographyController::class, 'layers']);
         Route::get('/geography/counties', [GisGeographyController::class, 'counties']);
         Route::get('/geography/tracts', [GisGeographyController::class, 'tracts']);
+
+        // Cohort geography (Acumenus PA demo)
+        Route::prefix('cohort-geography')->group(function () {
+            Route::get('/cohorts', [GisCohortGeographyController::class, 'cohorts']);
+            Route::get('/conditions', [GisCohortGeographyController::class, 'conditions']);
+            Route::get('/coverage', [GisCohortGeographyController::class, 'coverage']);
+            Route::post('/aggregate', [GisCohortGeographyController::class, 'aggregate']);
+        });
 
         // SVI (Use Case 1)
         Route::prefix('svi')->group(function () {

--- a/backend/tests/Unit/Services/GIS/CohortGeographyServiceTest.php
+++ b/backend/tests/Unit/Services/GIS/CohortGeographyServiceTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\DaimonType;
+use App\Models\App\Source;
+use App\Models\App\SourceDaimon;
+use App\Services\GIS\CohortGeographyService;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+function cohortGeographyTestSource(): Source
+{
+    $source = new Source([
+        'source_name' => 'OHDSI Acumenus CDM',
+        'source_key' => 'ACUMENUS',
+        'source_connection' => 'omop',
+    ]);
+    $source->id = 47;
+    $source->setRelation('daimons', new Collection([
+        new SourceDaimon(['daimon_type' => DaimonType::CDM->value, 'table_qualifier' => 'omop']),
+        new SourceDaimon(['daimon_type' => DaimonType::Vocabulary->value, 'table_qualifier' => 'vocab']),
+        new SourceDaimon(['daimon_type' => DaimonType::Results->value, 'table_qualifier' => 'results']),
+    ]));
+
+    return $source;
+}
+
+it('returns suppressed aggregate geography without patient identifiers', function (): void {
+    $connection = Mockery::mock();
+    DB::shouldReceive('connection')->with('gis')->andReturn($connection);
+    $connection
+        ->shouldReceive('select')
+        ->once()
+        ->with(
+            Mockery::on(fn (string $sql): bool => str_contains($sql, 'results.cohort')
+                && str_contains($sql, 'gis.patient_geography')
+                && str_contains($sql, 'gis.geographic_location')),
+            Mockery::on(fn (array $bindings): bool => $bindings[0] === 77 && $bindings[1] === 47),
+        )
+        ->andReturn([
+            (object) [
+                'geographic_location_id' => 101,
+                'location_name' => 'Philadelphia, Pennsylvania',
+                'fips' => '42101',
+                'latitude' => 39.9526,
+                'longitude' => -75.1652,
+                'population' => 1600000,
+                'area_sq_km' => 369.0,
+                'geometry' => '{"type":"MultiPolygon","coordinates":[]}',
+                'denominator' => 1000,
+                'member_count' => null,
+                'rate_per_1000' => null,
+                'suppressed' => true,
+                'total_selected' => 12,
+                'geocoded_selected' => 9,
+            ],
+        ]);
+
+    $result = (new CohortGeographyService)->aggregate(
+        cohortGeographyTestSource(),
+        'generated',
+        77,
+        'county',
+    );
+
+    expect($result['summary']['unknown_members'])->toBe(3);
+    expect($result['features'][0])->not->toHaveKey('person_id');
+    expect($result['features'][0]['member_count'])->toBeNull();
+    expect($result['features'][0]['suppressed'])->toBeTrue();
+});
+
+it('rejects unsafe source schema identifiers', function (): void {
+    $source = cohortGeographyTestSource();
+    $source->setRelation('daimons', new Collection([
+        new SourceDaimon(['daimon_type' => DaimonType::Results->value, 'table_qualifier' => 'results;drop']),
+    ]));
+
+    expect(fn () => (new CohortGeographyService)->aggregate($source, 'generated', 77))
+        ->toThrow(RuntimeException::class);
+});

--- a/frontend/src/components/analysis/CovariateSettingsPanel.tsx
+++ b/frontend/src/components/analysis/CovariateSettingsPanel.tsx
@@ -83,11 +83,7 @@ export function CovariateSettingsPanel({
     onChange({ ...settings, [key]: !settings[key] });
   };
 
-  const updateWindow = (
-    idx: number,
-    field: "start" | "end",
-    value: number,
-  ) => {
+  const updateWindow = (idx: number, field: "start" | "end", value: number) => {
     const newWindows = [...timeWindows];
     newWindows[idx] = { ...newWindows[idx], [field]: value };
     onChange({ ...settings, timeWindows: newWindows });
@@ -167,9 +163,7 @@ export function CovariateSettingsPanel({
       <h3 className="text-sm font-semibold text-text-primary">
         {t("covariates.title")}
       </h3>
-      <p className="text-xs text-text-muted">
-        {t("covariates.description")}
-      </p>
+      <p className="text-xs text-text-muted">{t("covariates.description")}</p>
 
       {renderGroup(t("covariates.groups.core"), coreOptions)}
       {renderGroup(t("covariates.groups.extended"), extendedOptions)}
@@ -216,6 +210,8 @@ export function CovariateSettingsPanel({
                   type="button"
                   onClick={() => removeWindow(idx)}
                   className="text-text-muted hover:text-critical transition-colors"
+                  aria-label="Remove time window"
+                  title="Remove time window"
                 >
                   <X size={14} />
                 </button>

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Outlet } from "react-router-dom";
 import { Sidebar } from "./Sidebar";
 import { Header } from "./Header";
@@ -23,7 +23,9 @@ import { cn } from "@/lib/utils";
 export function MainLayout() {
   const sidebarOpen = useUiStore((s) => s.sidebarOpen);
   const user = useAuthStore((s) => s.user);
-  const isSuperAdmin = useAuthStore((s) => (s.user?.roles ?? []).includes("super-admin"));
+  const isSuperAdmin = useAuthStore((s) =>
+    (s.user?.roles ?? []).includes("super-admin"),
+  );
 
   // Wizard open state — true on first launch, togglable from admin panel
   const [wizardOpen, setWizardOpen] = useState(
@@ -48,44 +50,64 @@ export function MainLayout() {
 
   const showWizard = wizardOpen && isSuperAdmin;
 
+  const setupWizardContextValue = useMemo(
+    () => ({ openSetupWizard: () => setWizardOpen(true) }),
+    [],
+  );
+  const atlasMigrationContextValue = useMemo(
+    () => ({ openAtlasMigration: () => setAtlasMigrationOpen(true) }),
+    [],
+  );
+
   return (
-    <SetupWizardContext.Provider value={{ openSetupWizard: () => setWizardOpen(true) }}>
-    <AtlasMigrationContext.Provider value={{ openAtlasMigration: () => setAtlasMigrationOpen(true) }}>
-      <div className="app-shell">
-        {/* Blocking password change for non-superadmins (superadmins handle it inside the wizard) */}
-        {user?.must_change_password && !isSuperAdmin && <ChangePasswordModal />}
+    <SetupWizardContext.Provider value={setupWizardContextValue}>
+      <AtlasMigrationContext.Provider value={atlasMigrationContextValue}>
+        <div className="app-shell">
+          {/* Blocking password change for non-superadmins (superadmins handle it inside the wizard) */}
+          {user?.must_change_password && !isSuperAdmin && (
+            <ChangePasswordModal />
+          )}
 
-        {/* Superadmin setup wizard — first launch or opened from admin panel */}
-        {showWizard && (
-          <SetupWizard
-            mustChangePassword={user?.must_change_password ?? false}
-            onClose={user?.onboarding_completed ? () => setWizardOpen(false) : undefined}
-          />
-        )}
+          {/* Superadmin setup wizard — first launch or opened from admin panel */}
+          {showWizard && (
+            <SetupWizard
+              mustChangePassword={user?.must_change_password ?? false}
+              onClose={
+                user?.onboarding_completed
+                  ? () => setWizardOpen(false)
+                  : undefined
+              }
+            />
+          )}
 
-        {/* Regular user onboarding tour — shown after password change if needed */}
-        {user && !user.onboarding_completed && !isSuperAdmin && !user.must_change_password && (
-          <OnboardingModal />
-        )}
+          {/* Regular user onboarding tour — shown after password change if needed */}
+          {user &&
+            !user.onboarding_completed &&
+            !isSuperAdmin &&
+            !user.must_change_password && <OnboardingModal />}
 
-        <Sidebar />
-        <div className={cn("app-content", !sidebarOpen && "sidebar-collapsed")}>
-          <Header />
-          <main className="content-main">
-            <Outlet />
-          </main>
+          <Sidebar />
+          <div
+            className={cn("app-content", !sidebarOpen && "sidebar-collapsed")}
+          >
+            <Header />
+            <main className="content-main">
+              <Outlet />
+            </main>
+          </div>
+          <CommandPalette />
+          <AbbyPanel />
+          <ToastContainer />
+          <WhatsNewModal />
+
+          {/* Atlas migration wizard — in-window modal, same pattern as SetupWizard */}
+          {atlasMigrationOpen && (
+            <AtlasMigrationWizard
+              onClose={() => setAtlasMigrationOpen(false)}
+            />
+          )}
         </div>
-        <CommandPalette />
-        <AbbyPanel />
-        <ToastContainer />
-        <WhatsNewModal />
-
-        {/* Atlas migration wizard — in-window modal, same pattern as SetupWizard */}
-        {atlasMigrationOpen && (
-          <AtlasMigrationWizard onClose={() => setAtlasMigrationOpen(false)} />
-        )}
-      </div>
-    </AtlasMigrationContext.Provider>
+      </AtlasMigrationContext.Provider>
     </SetupWizardContext.Provider>
   );
 }

--- a/frontend/src/features/commons/components/UserAvatar.tsx
+++ b/frontend/src/features/commons/components/UserAvatar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, memo } from "react";
 import { avatarColor } from "../utils/avatarColor";
 
 interface UserAvatarProps {
@@ -22,25 +22,39 @@ function getInitials(name: string): string {
     .slice(0, 2);
 }
 
-export function UserAvatar({ user, size = "md", className = "" }: UserAvatarProps) {
-  const [imgError, setImgError] = useState(false);
-  const avatarUrl = user.avatar && !imgError ? `/storage/${user.avatar}` : null;
+export const UserAvatar = memo(
+  function UserAvatar({ user, size = "md", className = "" }: UserAvatarProps) {
+    const [imgError, setImgError] = useState(false);
+    const avatarUrl =
+      user.avatar && !imgError ? `/storage/${user.avatar}` : null;
 
-  return (
-    <div
-      className={`${SIZES[size]} shrink-0 rounded-2xl flex items-center justify-center font-semibold text-text-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.15)] overflow-hidden ${className}`}
-      style={avatarUrl ? undefined : { backgroundColor: avatarColor(user.id) }}
-    >
-      {avatarUrl ? (
-        <img
-          src={avatarUrl}
-          alt={user.name}
-          className="h-full w-full object-cover"
-          onError={() => setImgError(true)}
-        />
-      ) : (
-        getInitials(user.name)
-      )}
-    </div>
-  );
-}
+    return (
+      <div
+        className={`${SIZES[size]} shrink-0 rounded-2xl flex items-center justify-center font-semibold text-text-primary shadow-[inset_0_1px_0_rgba(255,255,255,0.15)] overflow-hidden ${className}`}
+        style={
+          avatarUrl ? undefined : { backgroundColor: avatarColor(user.id) }
+        }
+      >
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt={user.name}
+            className="h-full w-full object-cover"
+            onError={() => setImgError(true)}
+          />
+        ) : (
+          getInitials(user.name)
+        )}
+      </div>
+    );
+  },
+  (prevProps, nextProps) => {
+    return (
+      prevProps.user.id === nextProps.user.id &&
+      prevProps.user.name === nextProps.user.name &&
+      prevProps.user.avatar === nextProps.user.avatar &&
+      prevProps.size === nextProps.size &&
+      prevProps.className === nextProps.className
+    );
+  },
+);

--- a/frontend/src/features/commons/components/announcements/AnnouncementBoard.tsx
+++ b/frontend/src/features/commons/components/announcements/AnnouncementBoard.tsx
@@ -85,6 +85,11 @@ function AnnouncementCard({
                 ? t("announcements.removeBookmark")
                 : t("announcements.bookmark")
             }
+            aria-label={
+              announcement.is_bookmarked
+                ? t("announcements.removeBookmark")
+                : t("announcements.bookmark")
+            }
             className="btn btn-ghost btn-icon btn-sm"
           >
             <Bookmark
@@ -101,6 +106,7 @@ function AnnouncementCard({
             <button
               onClick={() => onDelete(announcement.id)}
               title={t("announcements.delete")}
+              aria-label={t("announcements.delete")}
               className="btn btn-ghost btn-icon btn-sm"
             >
               <Trash2 size={13} />

--- a/frontend/src/features/commons/components/wiki/WikiChatDrawer.tsx
+++ b/frontend/src/features/commons/components/wiki/WikiChatDrawer.tsx
@@ -117,6 +117,8 @@ export function WikiChatDrawer({
                 type="button"
                 onClick={onClose}
                 className="rounded-lg border border-border-default bg-surface-raised p-1.5 text-text-muted transition-colors hover:text-text-primary"
+                title={t("common:actions.close")}
+                aria-label={t("common:actions.close")}
               >
                 <X size={16} />
               </button>

--- a/frontend/src/features/commons/components/wiki/WikiChatPanel.tsx
+++ b/frontend/src/features/commons/components/wiki/WikiChatPanel.tsx
@@ -196,6 +196,7 @@ export function WikiChatPanel({
             onClick={onExpandChat}
             className="rounded-lg border border-border-default bg-surface-raised p-2 text-text-muted transition-colors hover:text-success"
             title={t("wiki.chat.expand")}
+            aria-label={t("wiki.chat.expand")}
           >
             <Maximize2 size={14} />
           </button>
@@ -205,6 +206,8 @@ export function WikiChatPanel({
           onClick={handleSubmit}
           disabled={loading || input.trim().length < 3}
           className="flex items-center justify-center rounded-lg bg-success px-3 py-2 text-surface-base transition-colors hover:bg-success disabled:opacity-50"
+          title={t("wiki.chat.ask")}
+          aria-label={t("wiki.chat.ask")}
         >
           <Send size={16} />
         </button>

--- a/frontend/src/features/commons/components/wiki/WikiPageTree.tsx
+++ b/frontend/src/features/commons/components/wiki/WikiPageTree.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { AlertTriangle, FileText, FileType } from "lucide-react";
 import type { WikiLintIssue, WikiPageSummary } from "../../types/wiki";
 
@@ -13,7 +14,10 @@ interface SourceEntry {
   hasIssues: boolean;
 }
 
-function buildSourceList(pages: WikiPageSummary[], lintIssues: WikiLintIssue[]): SourceEntry[] {
+function buildSourceList(
+  pages: WikiPageSummary[],
+  lintIssues: WikiLintIssue[],
+): SourceEntry[] {
   const issueSet = new Set(lintIssues.map((i) => i.page_slug));
 
   // Group by source_slug, or treat each page as its own source
@@ -26,12 +30,16 @@ function buildSourceList(pages: WikiPageSummary[], lintIssues: WikiLintIssue[]):
       existing.childPages.push(page);
       if (issueSet.has(page.slug)) existing.hasIssues = true;
       // Use the most recent updated_at
-      if (page.updated_at > existing.updatedAt) existing.updatedAt = page.updated_at;
+      if (page.updated_at > existing.updatedAt)
+        existing.updatedAt = page.updated_at;
       // Use the earliest ingested_at for the source group
       const pageIngested = page.ingested_at ?? page.updated_at;
-      if (pageIngested < existing.ingestedAt) existing.ingestedAt = pageIngested;
-      if (!existing.firstAuthor && page.first_author) existing.firstAuthor = page.first_author;
-      if (!existing.publicationYear && page.publication_year) existing.publicationYear = page.publication_year;
+      if (pageIngested < existing.ingestedAt)
+        existing.ingestedAt = pageIngested;
+      if (!existing.firstAuthor && page.first_author)
+        existing.firstAuthor = page.first_author;
+      if (!existing.publicationYear && page.publication_year)
+        existing.publicationYear = page.publication_year;
     } else {
       const displayTitle = page.title;
       sources.set(key, {
@@ -50,13 +58,15 @@ function buildSourceList(pages: WikiPageSummary[], lintIssues: WikiLintIssue[]):
 
   // Fix titles: prefer the source_summary title for grouped sources
   for (const entry of sources.values()) {
-    const summary = entry.childPages.find((p) => p.page_type === "source_summary");
+    const summary = entry.childPages.find(
+      (p) => p.page_type === "source_summary",
+    );
     if (summary) entry.title = summary.title;
   }
 
   // Sort by most recently ingested (newest first)
-  return Array.from(sources.values()).sort(
-    (a, b) => b.ingestedAt.localeCompare(a.ingestedAt),
+  return Array.from(sources.values()).sort((a, b) =>
+    b.ingestedAt.localeCompare(a.ingestedAt),
   );
 }
 
@@ -79,24 +89,32 @@ export function WikiPageTree({
   onSelect: (slug: string) => void;
   lintIssues: WikiLintIssue[];
 }) {
-  // Client-side keyword filtering for instant feedback
-  const filtered = pages.filter((p) => {
+  const sources = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
-    if (!q) return true;
-    return (
-      p.title.toLowerCase().includes(q) ||
-      p.keywords.some((kw) => kw.toLowerCase().includes(q))
-    );
-  });
 
-  const sources = buildSourceList(filtered, lintIssues);
+    // Client-side keyword filtering for instant feedback
+    const filtered = pages.filter((p) => {
+      if (!q) return true;
+      return (
+        p.title.toLowerCase().includes(q) ||
+        p.keywords.some((kw) => kw.toLowerCase().includes(q))
+      );
+    });
+
+    return buildSourceList(filtered, lintIssues);
+  }, [pages, searchQuery, lintIssues]);
 
   return (
     <div className="space-y-0.5 px-2 py-2">
       {sources.map((source) => {
-        const conceptPage = source.childPages.find((p) => p.page_type !== "source_summary");
-        const targetSlug = conceptPage?.slug ?? source.childPages[0]?.slug ?? source.slug;
-        const isSelected = source.childPages.some((p) => p.slug === selectedSlug);
+        const conceptPage = source.childPages.find(
+          (p) => p.page_type !== "source_summary",
+        );
+        const targetSlug =
+          conceptPage?.slug ?? source.childPages[0]?.slug ?? source.slug;
+        const isSelected = source.childPages.some(
+          (p) => p.slug === selectedSlug,
+        );
 
         return (
           <button
@@ -110,17 +128,25 @@ export function WikiPageTree({
             }`}
           >
             {/* File type icon */}
-            <div className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
-              source.sourceType === "pdf"
-                ? "bg-critical/10 text-critical"
-                : "bg-info/10 text-info"
-            }`}>
-              {source.sourceType === "pdf" ? <FileType size={14} /> : <FileText size={14} />}
+            <div
+              className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${
+                source.sourceType === "pdf"
+                  ? "bg-critical/10 text-critical"
+                  : "bg-info/10 text-info"
+              }`}
+            >
+              {source.sourceType === "pdf" ? (
+                <FileType size={14} />
+              ) : (
+                <FileText size={14} />
+              )}
             </div>
 
             {/* Title + metadata */}
             <div className="min-w-0 flex-1">
-              <p className={`truncate text-sm font-medium ${isSelected ? "text-success" : "text-text-primary"}`}>
+              <p
+                className={`truncate text-sm font-medium ${isSelected ? "text-success" : "text-text-primary"}`}
+              >
                 {source.title}
               </p>
               <div className="mt-0.5 flex items-center gap-2">
@@ -157,7 +183,9 @@ export function WikiPageTree({
         <div className="px-3 py-12 text-center">
           <FileText size={24} className="mx-auto mb-2 text-surface-highlight" />
           <p className="text-xs text-text-ghost">
-            {searchQuery ? "No papers match this search." : "No papers ingested yet."}
+            {searchQuery
+              ? "No papers match this search."
+              : "No papers ingested yet."}
           </p>
         </div>
       )}

--- a/frontend/src/features/gis/api.ts
+++ b/frontend/src/features/gis/api.ts
@@ -2,6 +2,12 @@ import apiClient from "@/lib/api-client";
 import type {
   AdminLevel,
   BoundaryCollection,
+  CohortGeographyAggregate,
+  CohortGeographyCoverage,
+  CohortGeographyLevel,
+  CohortGeographyListItem,
+  CohortGeographyMetric,
+  CohortGeographyMode,
   CdmChoroplethParams,
   ChoroplethDataPoint,
   ChoroplethParams,
@@ -11,6 +17,7 @@ import type {
   CountyChoroplethItem,
   CountyDetailData,
   DiseaseSummary,
+  GisAnalysisLayerMetadata,
   GisDatasetJob,
   GisStats,
   RegionDetail,
@@ -34,6 +41,51 @@ export async function fetchBoundaryDetail(id: number): Promise<RegionDetail> {
 
 export async function fetchGisStats(): Promise<GisStats> {
   const { data } = await apiClient.get("/gis/stats");
+  return data.data;
+}
+
+export async function fetchGisLayerMetadata(): Promise<GisAnalysisLayerMetadata[]> {
+  const { data } = await apiClient.get("/gis/layers");
+  return data.data;
+}
+
+export async function fetchCohortGeographyCohorts(params?: {
+  source_id?: number;
+  search?: string;
+  limit?: number;
+}): Promise<CohortGeographyListItem[]> {
+  const { data } = await apiClient.get("/gis/cohort-geography/cohorts", { params });
+  return data.data;
+}
+
+export async function fetchCohortGeographyConditions(params?: {
+  source_id?: number;
+  search?: string;
+  limit?: number;
+}): Promise<CohortGeographyListItem[]> {
+  const { data } = await apiClient.get("/gis/cohort-geography/conditions", { params });
+  return data.data;
+}
+
+export async function fetchCohortGeographyCoverage(params?: {
+  source_id?: number;
+  state_fips?: string;
+}): Promise<CohortGeographyCoverage> {
+  const { data } = await apiClient.get("/gis/cohort-geography/coverage", { params });
+  return data.data;
+}
+
+export async function fetchCohortGeographyAggregate(params: {
+  source_id?: number;
+  mode: CohortGeographyMode;
+  cohort_definition_id?: number;
+  concept_id?: number;
+  level?: CohortGeographyLevel;
+  metric?: CohortGeographyMetric;
+  min_cell_count?: number;
+  state_fips?: string;
+}): Promise<CohortGeographyAggregate> {
+  const { data } = await apiClient.post("/gis/cohort-geography/aggregate", params);
   return data.data;
 }
 

--- a/frontend/src/features/gis/components/AnalysisDrawer.tsx
+++ b/frontend/src/features/gis/components/AnalysisDrawer.tsx
@@ -3,13 +3,15 @@ import { useTranslation } from "react-i18next";
 import { getLayers } from "../layers/registry";
 import { useLayerStore } from "../stores/layerStore";
 import { getAnalysisDrawerTitle } from "../lib/i18n";
+import type { CohortGeographySelection } from "../types";
 
 interface AnalysisDrawerProps {
   conceptId: number;
   metric: string;
+  cohortGeography?: CohortGeographySelection | null;
 }
 
-export function AnalysisDrawer({ conceptId, metric }: AnalysisDrawerProps) {
+export function AnalysisDrawer({ conceptId, metric, cohortGeography }: AnalysisDrawerProps) {
   const { t } = useTranslation("app");
   const { activeLayers, drawerOpen, setDrawerOpen } = useLayerStore();
   const layers = getLayers();
@@ -58,7 +60,11 @@ export function AnalysisDrawer({ conceptId, metric }: AnalysisDrawerProps) {
                 >
                   {layer.name}
                 </h4>
-                <Panel conceptId={conceptId} metric={metric} />
+                <Panel
+                  conceptId={conceptId}
+                  metric={metric}
+                  cohortGeography={cohortGeography}
+                />
               </div>
             );
           })}

--- a/frontend/src/features/gis/components/CohortGeographySelector.tsx
+++ b/frontend/src/features/gis/components/CohortGeographySelector.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from "react";
+import { Search, UsersRound, MapPinned } from "lucide-react";
+import {
+  useCohortGeographyCohorts,
+  useCohortGeographyConditions,
+  useCohortGeographyCoverage,
+} from "../hooks/useGis";
+import type {
+  CohortGeographyLevel,
+  CohortGeographyListItem,
+  CohortGeographyMetric,
+  CohortGeographyMode,
+  CohortGeographySelection,
+} from "../types";
+
+interface CohortGeographySelectorProps {
+  selection: CohortGeographySelection;
+  onChange: (selection: CohortGeographySelection) => void;
+}
+
+const SOURCE_ID = 47;
+
+export function CohortGeographySelector({ selection, onChange }: CohortGeographySelectorProps) {
+  const [mode, setMode] = useState<CohortGeographyMode>(selection.mode);
+  const [search, setSearch] = useState("");
+  const coverage = useCohortGeographyCoverage(selection.source_id || SOURCE_ID);
+  const cohorts = useCohortGeographyCohorts({
+    source_id: selection.source_id || SOURCE_ID,
+    search: mode === "generated" ? search || undefined : undefined,
+    limit: 8,
+  });
+  const conditions = useCohortGeographyConditions({
+    source_id: selection.source_id || SOURCE_ID,
+    search: mode === "condition" ? search || undefined : undefined,
+    limit: 8,
+  });
+
+  const tractAvailable = coverage.data?.levels.tract.available === true;
+  const rows = mode === "generated" ? cohorts.data ?? [] : conditions.data ?? [];
+
+  useEffect(() => {
+    if (selection.level === "tract" && coverage.data && !tractAvailable) {
+      onChange({ ...selection, level: "county" });
+    }
+  }, [coverage.data, onChange, selection, tractAvailable]);
+
+  const updateLevel = (level: CohortGeographyLevel) => {
+    onChange({ ...selection, source_id: SOURCE_ID, level });
+  };
+
+  const updateMetric = (metric: CohortGeographyMetric) => {
+    onChange({ ...selection, source_id: SOURCE_ID, metric });
+  };
+
+  const selectRow = (item: CohortGeographyListItem) => {
+    onChange({
+      source_id: SOURCE_ID,
+      mode,
+      cohort_definition_id: mode === "generated" ? item.cohort_definition_id : undefined,
+      concept_id: mode === "condition" ? item.concept_id : undefined,
+      label: item.name,
+      level: selection.level,
+      metric: selection.metric,
+    });
+  };
+
+  return (
+    <div className="space-y-2 rounded-lg border border-border-default bg-surface-raised p-3">
+      <div className="flex items-center gap-2">
+        <MapPinned className="h-3.5 w-3.5 text-text-ghost" />
+        <span className="text-xs font-semibold uppercase tracking-wider text-text-ghost">
+          {/* i18n-exempt: Acumenus PA GIS demo control */}
+          Cohort geography
+        </span>
+      </div>
+
+      <div className="flex overflow-hidden rounded border border-border-default bg-surface-base">
+        {(["generated", "condition"] as CohortGeographyMode[]).map((option) => (
+          <button
+            key={option}
+            type="button"
+            onClick={() => {
+              setMode(option);
+              setSearch("");
+            }}
+            className={`flex-1 px-2 py-1 text-[10px] ${
+              mode === option ? "bg-accent/15 text-accent" : "text-text-ghost hover:text-text-muted"
+            }`}
+          >
+            {option === "generated" ? "Generated" : "Condition"}
+          </button>
+        ))}
+      </div>
+
+      <div className="relative">
+        <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-text-ghost" />
+        <input
+          type="text"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder={mode === "generated" ? "Search cohorts" : "Search conditions"}
+          className="w-full rounded border border-border-default bg-surface-base py-1.5 pl-7 pr-2 text-xs text-text-primary placeholder:text-text-ghost focus:border-accent/50 focus:outline-none"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-1">
+        <select
+          value={selection.level}
+          onChange={(event) => updateLevel(event.target.value as CohortGeographyLevel)}
+          className="rounded border border-border-default bg-surface-base px-2 py-1 text-[11px] text-text-primary focus:border-accent/50 focus:outline-none"
+        >
+          <option value="county">County</option>
+          <option value="tract" disabled={!tractAvailable}>Tract</option>
+        </select>
+        <select
+          value={selection.metric}
+          onChange={(event) => updateMetric(event.target.value as CohortGeographyMetric)}
+          className="rounded border border-border-default bg-surface-base px-2 py-1 text-[11px] text-text-primary focus:border-accent/50 focus:outline-none"
+        >
+          <option value="members">Members</option>
+          <option value="prevalence_per_1000">Per 1K</option>
+        </select>
+      </div>
+
+      {selection.label && (
+        <p className="line-clamp-2 text-xs font-medium text-accent">{selection.label}</p>
+      )}
+
+      <div className="max-h-48 space-y-1 overflow-y-auto">
+        {rows.map((item) => {
+          const id = mode === "generated" ? item.cohort_definition_id : item.concept_id;
+          if (!id) return null;
+
+          const active = mode === selection.mode &&
+            (selection.cohort_definition_id === id || selection.concept_id === id);
+          return (
+            <button
+              key={`${mode}-${id}`}
+              type="button"
+              onClick={() => selectRow(item)}
+              className={`flex w-full items-start gap-2 rounded px-2 py-1.5 text-left text-xs ${
+                active ? "bg-accent/15 text-accent" : "text-text-muted hover:bg-surface-elevated"
+              }`}
+            >
+              <UsersRound className="mt-0.5 h-3 w-3 flex-shrink-0" />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate">{item.name}</span>
+                <span className="block text-[10px] text-text-ghost">
+                  {item.geocoded_count.toLocaleString()} mapped / {item.subject_count.toLocaleString()}
+                </span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {!tractAvailable && (
+        <p className="text-[10px] text-text-ghost">
+          {/* i18n-exempt: temporary operational coverage note */}
+          Tract maps enable after PA tract geometry is loaded.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/gis/components/ContextPanel.tsx
+++ b/frontend/src/features/gis/components/ContextPanel.tsx
@@ -4,13 +4,15 @@ import { useTranslation } from "react-i18next";
 import { getLayers } from "../layers/registry";
 import { useLayerStore } from "../stores/layerStore";
 import { getAnalysisLayerCountLabel } from "../lib/i18n";
+import type { CohortGeographySelection } from "../types";
 
 interface ContextPanelProps {
   conceptId: number;
   diseaseName: string;
+  cohortGeography?: CohortGeographySelection | null;
 }
 
-export function ContextPanel({ conceptId, diseaseName }: ContextPanelProps) {
+export function ContextPanel({ conceptId, diseaseName, cohortGeography }: ContextPanelProps) {
   const { t } = useTranslation("app");
   const navigate = useNavigate();
   const { activeLayers, selectedFips, selectedName, setSelectedRegion } =
@@ -57,7 +59,11 @@ export function ContextPanel({ conceptId, diseaseName }: ContextPanelProps) {
                 >
                   {layer.name}
                 </h4>
-                <DetailPanel fips={selectedFips} conceptId={conceptId} />
+                <DetailPanel
+                  fips={selectedFips}
+                  conceptId={conceptId}
+                  cohortGeography={cohortGeography}
+                />
               </div>
             );
           })}

--- a/frontend/src/features/gis/components/LayerPanel.tsx
+++ b/frontend/src/features/gis/components/LayerPanel.tsx
@@ -1,19 +1,40 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { Layers, ChevronRight } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { getLayers } from "../layers/registry";
 import { useLayerStore } from "../stores/layerStore";
 import { DiseaseSelector } from "./DiseaseSelector";
+import { CohortGeographySelector } from "./CohortGeographySelector";
+import { useGisLayerMetadata } from "../hooks/useGis";
+import type { CdmMetricType, CohortGeographySelection } from "../types";
 
 interface LayerPanelProps {
   selectedConceptId: number | null;
+  metric: CdmMetricType;
+  cohortGeography: CohortGeographySelection;
   onDiseaseSelect: (conceptId: number, name: string) => void;
+  onMetricChange: (metric: CdmMetricType) => void;
+  onCohortGeographyChange: (selection: CohortGeographySelection) => void;
 }
 
-export function LayerPanel({ selectedConceptId, onDiseaseSelect }: LayerPanelProps) {
+const METRIC_OPTIONS: CdmMetricType[] = ["cases", "hospitalization", "deaths"];
+
+export function LayerPanel({
+  selectedConceptId,
+  metric,
+  cohortGeography,
+  onDiseaseSelect,
+  onMetricChange,
+  onCohortGeographyChange,
+}: LayerPanelProps) {
   const { t } = useTranslation("app");
   const { activeLayers, toggleLayer } = useLayerStore();
   const layers = getLayers();
+  const { data: layerMetadata } = useGisLayerMetadata();
+  const metadataById = useMemo(
+    () => new Map(layerMetadata?.map((item) => [item.id, item]) ?? []),
+    [layerMetadata]
+  );
 
   const handleToggle = useCallback(
     (id: string) => {
@@ -30,6 +51,35 @@ export function LayerPanel({ selectedConceptId, onDiseaseSelect }: LayerPanelPro
         onSelect={onDiseaseSelect}
       />
 
+      <CohortGeographySelector
+        selection={cohortGeography}
+        onChange={onCohortGeographyChange}
+      />
+
+      {selectedConceptId !== null && (
+        <div className="rounded-lg border border-border-default bg-surface-raised p-3">
+          <span className="mb-1.5 block text-xs font-semibold uppercase tracking-wider text-text-ghost">
+            {/* i18n-exempt: compact GIS metric selector label */}
+            Outcome metric
+          </span>
+          <select
+            value={metric}
+            onChange={(event) => onMetricChange(event.target.value as CdmMetricType)}
+            className="w-full rounded border border-border-default bg-surface-base px-2 py-1.5 text-xs text-text-primary focus:border-accent/50 focus:outline-none"
+          >
+            {METRIC_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option === "hospitalization"
+                  ? t("gis.countyDetail.hospitalized")
+                  : option === "deaths"
+                    ? t("gis.diseaseSummary.deaths")
+                    : t("gis.diseaseSummary.cases")}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
       {/* Layer toggles */}
       <div className="rounded-lg border border-border-default bg-surface-raised p-3">
         <div className="mb-2 flex items-center gap-2">
@@ -41,18 +91,29 @@ export function LayerPanel({ selectedConceptId, onDiseaseSelect }: LayerPanelPro
         <div className="space-y-1">
           {layers.map((layer) => {
             const isActive = activeLayers.has(layer.id);
+            const metadata = metadataById.get(layer.id);
+            const needsDisease = layer.requiresConcept === true && selectedConceptId === null;
+            const needsCohortGeography =
+              layer.requiresCohortGeography === true &&
+              cohortGeography.cohort_definition_id === undefined &&
+              cohortGeography.concept_id === undefined;
+            const hasBackendData = metadata?.available ?? true;
+            const isDisabled = needsDisease || needsCohortGeography || !hasBackendData;
             const Icon = layer.icon;
             return (
               <button
                 key={layer.id}
-                onClick={() => handleToggle(layer.id)}
+                onClick={() => {
+                  if (!isDisabled) handleToggle(layer.id);
+                }}
+                disabled={isDisabled}
                 className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs transition-colors ${
                   isActive
                     ? "border border-opacity-50 bg-opacity-10"
                     : "border border-transparent text-text-muted hover:bg-surface-elevated"
-                }`}
+                } disabled:cursor-not-allowed disabled:opacity-50`}
                 style={
-                  isActive
+                  isActive && !isDisabled
                     ? {
                         borderColor: `${layer.color}80`,
                         backgroundColor: `${layer.color}15`,
@@ -60,10 +121,19 @@ export function LayerPanel({ selectedConceptId, onDiseaseSelect }: LayerPanelPro
                       }
                     : undefined
                 }
-              >
+                >
                 <Icon className="h-3.5 w-3.5 flex-shrink-0" />
                 <span className="flex-1 truncate">{layer.name}</span>
-                {isActive && (
+                {isDisabled && (
+                  <span className="text-[9px] uppercase text-text-ghost">
+                    {needsDisease
+                      ? t("gis.diseaseSelector.title")
+                      : needsCohortGeography
+                        ? "Cohort"
+                        : t("gis.layers.comorbidity.analysis.noData")}
+                  </span>
+                )}
+                {isActive && !isDisabled && (
                   <ChevronRight className="h-3 w-3 flex-shrink-0 opacity-50" />
                 )}
               </button>

--- a/frontend/src/features/gis/hooks/useActiveMapLayers.ts
+++ b/frontend/src/features/gis/hooks/useActiveMapLayers.ts
@@ -5,22 +5,29 @@ import { RuccMapOverlay } from "../layers/rucc/RuccMapOverlay";
 import { ComorbidityMapOverlay } from "../layers/comorbidity/ComorbidityMapOverlay";
 import { AirQualityMapOverlay } from "../layers/air-quality/AirQualityMapOverlay";
 import { HospitalMapOverlay } from "../layers/hospital-access/HospitalMapOverlay";
+import { DiseaseBurdenMapOverlay } from "../layers/disease-burden/DiseaseBurdenMapOverlay";
+import { CohortGeographyMapOverlay } from "../layers/cohort-geography/CohortGeographyMapOverlay";
 import { useSviData } from "../layers/svi/useSviData";
 import { useRuccData } from "../layers/rucc/useRuccData";
 import { useComorbidityData } from "../layers/comorbidity/useComorbidityData";
 import { useAirQualityData } from "../layers/air-quality/useAirQualityData";
 import { useHospitalData } from "../layers/hospital-access/useHospitalData";
+import { useDiseaseBurdenData } from "../layers/disease-burden/useDiseaseBurdenData";
+import { useCohortGeographyData } from "../layers/cohort-geography/useCohortGeographyData";
+import type { CohortGeographySelection } from "../types";
 
 interface UseActiveMapLayersProps {
   conceptId: number | null;
   selectedFips: string | null;
+  metric: string;
+  cohortGeography?: CohortGeographySelection | null;
   enabled?: boolean;
   onRegionClick: (fips: string, name: string) => void;
   onRegionHover: (fips: string | null, name: string | null) => void;
 }
 
 /**
- * Collects all 5 GIS map overlay deck.gl layers for active use-cases.
+ * Collects all GIS map overlay deck.gl layers for active use-cases.
  *
  * All data hooks are called unconditionally (fixed order — Rules of Hooks).
  * Each overlay receives `visible: false` when its layer is not active,
@@ -29,15 +36,25 @@ interface UseActiveMapLayersProps {
 export function useActiveMapLayers({
   conceptId,
   selectedFips,
+  metric,
+  cohortGeography,
   enabled = true,
   onRegionClick,
   onRegionHover,
 }: UseActiveMapLayersProps): Array<Layer | null> {
   const { activeLayers } = useLayerStore();
 
-  const params = { conceptId, selectedFips, metric: "cases" };
+  const params = { conceptId, selectedFips, metric, cohortGeography };
 
   // Data hooks — always called (Rules of Hooks)
+  const cohortGeographyData = useCohortGeographyData({
+    ...params,
+    enabled: enabled && activeLayers.has("cohort-geography"),
+  });
+  const diseaseBurdenData = useDiseaseBurdenData({
+    ...params,
+    enabled: enabled && activeLayers.has("disease-burden") && conceptId !== null,
+  });
   const sviData = useSviData({
     ...params,
     enabled: enabled && activeLayers.has("svi"),
@@ -60,6 +77,22 @@ export function useActiveMapLayers({
   });
 
   // Overlay hooks — always called with visible=false when inactive
+  const cohortGeographyLayer = CohortGeographyMapOverlay({
+    data: cohortGeographyData.choroplethData ?? [],
+    selectedFips,
+    onRegionClick,
+    onRegionHover,
+    visible: activeLayers.has("cohort-geography"),
+  });
+
+  const diseaseBurdenLayer = DiseaseBurdenMapOverlay({
+    data: diseaseBurdenData.choroplethData ?? [],
+    selectedFips,
+    onRegionClick,
+    onRegionHover,
+    visible: activeLayers.has("disease-burden"),
+  });
+
   const sviLayer = SviMapOverlay({
     data: sviData.choroplethData ?? [],
     selectedFips,
@@ -94,11 +127,20 @@ export function useActiveMapLayers({
 
   const hospitalLayer = HospitalMapOverlay({
     data: hospitalData.choroplethData ?? [],
+    mapData: hospitalData.mapData,
     selectedFips,
     onRegionClick,
     onRegionHover,
     visible: activeLayers.has("hospital-access"),
   });
 
-  return [sviLayer, ruccLayer, comorbidityLayer, airQualityLayer, hospitalLayer].filter(Boolean);
+  return [
+    cohortGeographyLayer,
+    diseaseBurdenLayer,
+    sviLayer,
+    ruccLayer,
+    comorbidityLayer,
+    airQualityLayer,
+    hospitalLayer,
+  ].filter(Boolean);
 }

--- a/frontend/src/features/gis/hooks/useGis.ts
+++ b/frontend/src/features/gis/hooks/useGis.ts
@@ -2,6 +2,11 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   fetchBoundaries,
   fetchBoundaryDetail,
+  fetchCohortGeographyAggregate,
+  fetchCohortGeographyCohorts,
+  fetchCohortGeographyConditions,
+  fetchCohortGeographyCoverage,
+  fetchGisLayerMetadata,
   fetchGisStats,
   fetchChoropleth,
   fetchCountries,
@@ -14,12 +19,75 @@ import {
   fetchDiseaseSummary,
   fetchCountyDetail,
 } from "../api";
-import type { AdminLevel, CdmChoroplethParams, ChoroplethParams } from "../types";
+import type {
+  AdminLevel,
+  CdmChoroplethParams,
+  CohortGeographySelection,
+  ChoroplethParams,
+} from "../types";
 
 export function useGisStats() {
   return useQuery({
     queryKey: ["gis", "stats"],
     queryFn: fetchGisStats,
+    staleTime: 60_000,
+  });
+}
+
+export function useGisLayerMetadata() {
+  return useQuery({
+    queryKey: ["gis", "layers", "metadata"],
+    queryFn: fetchGisLayerMetadata,
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useCohortGeographyCohorts(params?: {
+  source_id?: number;
+  search?: string;
+  limit?: number;
+}) {
+  return useQuery({
+    queryKey: ["gis", "cohort-geography", "cohorts", params],
+    queryFn: () => fetchCohortGeographyCohorts(params),
+    staleTime: 60_000,
+  });
+}
+
+export function useCohortGeographyConditions(params?: {
+  source_id?: number;
+  search?: string;
+  limit?: number;
+}) {
+  return useQuery({
+    queryKey: ["gis", "cohort-geography", "conditions", params],
+    queryFn: () => fetchCohortGeographyConditions(params),
+    staleTime: 60_000,
+  });
+}
+
+export function useCohortGeographyCoverage(sourceId: number, stateFips = "42") {
+  return useQuery({
+    queryKey: ["gis", "cohort-geography", "coverage", sourceId, stateFips],
+    queryFn: () => fetchCohortGeographyCoverage({ source_id: sourceId, state_fips: stateFips }),
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useCohortGeographyAggregate(selection: CohortGeographySelection | null) {
+  return useQuery({
+    queryKey: ["gis", "cohort-geography", "aggregate", selection],
+    queryFn: () => fetchCohortGeographyAggregate({
+      source_id: selection!.source_id,
+      mode: selection!.mode,
+      cohort_definition_id: selection!.cohort_definition_id,
+      concept_id: selection!.concept_id,
+      level: selection!.level,
+      metric: selection!.metric,
+      min_cell_count: 5,
+      state_fips: "42",
+    }),
+    enabled: selection !== null,
     staleTime: 60_000,
   });
 }

--- a/frontend/src/features/gis/layers/air-quality/AirQualityAnalysisPanel.tsx
+++ b/frontend/src/features/gis/layers/air-quality/AirQualityAnalysisPanel.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from "react-i18next";
 import { fetchAqRespiratoryOutcomes } from "./api";
 import type { LayerAnalysisProps } from "../types";
 
-export function AirQualityAnalysisPanel({ conceptId, metric }: LayerAnalysisProps) {
+export function AirQualityAnalysisPanel({ conceptId }: LayerAnalysisProps) {
   const { t } = useTranslation("app");
   const { data, isLoading } = useQuery({
-    queryKey: ["gis", "aq", "respiratory", conceptId, metric],
+    queryKey: ["gis", "aq", "respiratory", conceptId, "pm25"],
     queryFn: () => fetchAqRespiratoryOutcomes(conceptId, "pm25"),
     staleTime: 60_000,
   });

--- a/frontend/src/features/gis/layers/cohort-geography/CohortGeographyAnalysisPanel.tsx
+++ b/frontend/src/features/gis/layers/cohort-geography/CohortGeographyAnalysisPanel.tsx
@@ -1,0 +1,59 @@
+import { useCohortGeographyAggregate } from "../../hooks/useGis";
+import type { LayerAnalysisProps } from "../types";
+
+export function CohortGeographyAnalysisPanel({ cohortGeography }: LayerAnalysisProps) {
+  const hasTarget = Boolean(cohortGeography?.cohort_definition_id ?? cohortGeography?.concept_id);
+  const aggregate = useCohortGeographyAggregate(hasTarget ? cohortGeography ?? null : null);
+
+  if (!hasTarget) {
+    return <p className="text-xs text-text-ghost">Select a generated cohort or condition.</p>;
+  }
+
+  if (aggregate.isLoading) {
+    return <p className="text-xs text-text-ghost">Loading cohort geography...</p>;
+  }
+
+  if (!aggregate.data) {
+    return <p className="text-xs text-text-ghost">No cohort geography data.</p>;
+  }
+
+  const rows = [...aggregate.data.features]
+    .sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
+    .slice(0, 5);
+
+  return (
+    <div className="space-y-3 text-xs">
+      <div className="grid grid-cols-3 gap-2">
+        <Stat label="Mapped" value={aggregate.data.summary.geocoded_members.toLocaleString()} />
+        <Stat label="Unknown" value={aggregate.data.summary.unknown_members.toLocaleString()} />
+        <Stat label="Coverage" value={`${aggregate.data.summary.coverage_percent}%`} />
+      </div>
+      <div className="space-y-1">
+        {rows.map((row) => (
+          <div key={row.fips} className="flex items-center justify-between gap-3">
+            <span className="truncate text-text-muted">{row.location_name}</span>
+            <span className="font-medium text-text-primary">
+              {aggregate.data.metric === "prevalence_per_1000"
+                ? `${(row.rate_per_1000 ?? 0).toLocaleString()} / 1K`
+                : (row.member_count ?? 0).toLocaleString()}
+            </span>
+          </div>
+        ))}
+      </div>
+      {aggregate.data.summary.suppressed_geographies > 0 && (
+        <p className="text-[10px] text-text-ghost">
+          {aggregate.data.summary.suppressed_geographies} geographies suppressed by cell count.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-border-default bg-surface-base px-2 py-1">
+      <div className="text-[10px] uppercase text-text-ghost">{label}</div>
+      <div className="font-semibold text-text-primary">{value}</div>
+    </div>
+  );
+}

--- a/frontend/src/features/gis/layers/cohort-geography/CohortGeographyDetailPanel.tsx
+++ b/frontend/src/features/gis/layers/cohort-geography/CohortGeographyDetailPanel.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from "react";
+import { useCohortGeographyAggregate } from "../../hooks/useGis";
+import type { LayerDetailProps } from "../types";
+
+export function CohortGeographyDetailPanel({ fips, cohortGeography }: LayerDetailProps) {
+  const hasTarget = Boolean(cohortGeography?.cohort_definition_id ?? cohortGeography?.concept_id);
+  const aggregate = useCohortGeographyAggregate(hasTarget ? cohortGeography ?? null : null);
+  const row = useMemo(
+    () => aggregate.data?.features.find((item) => item.fips === fips),
+    [aggregate.data?.features, fips]
+  );
+
+  if (!hasTarget) {
+    return <p className="text-xs text-text-ghost">No cohort selected.</p>;
+  }
+
+  if (aggregate.isLoading) {
+    return <p className="text-xs text-text-ghost">Loading...</p>;
+  }
+
+  if (!row) {
+    return <p className="text-xs text-text-ghost">No mapped members.</p>;
+  }
+
+  return (
+    <div className="space-y-2 text-xs">
+      <Metric
+        label="Members"
+        value={row.member_count === null ? "Suppressed" : row.member_count.toLocaleString()}
+      />
+      <Metric label="Denominator" value={row.denominator.toLocaleString()} />
+      <Metric
+        label="Rate"
+        value={row.rate_per_1000 === null ? "-" : `${row.rate_per_1000.toLocaleString()} / 1K`}
+      />
+      {row.area_sq_km !== null && (
+        <Metric label="Area" value={`${Math.round(row.area_sq_km).toLocaleString()} km2`} />
+      )}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-3">
+      <span className="text-text-ghost">{label}</span>
+      <span className="font-medium text-text-primary">{value}</span>
+    </div>
+  );
+}

--- a/frontend/src/features/gis/layers/cohort-geography/CohortGeographyMapOverlay.tsx
+++ b/frontend/src/features/gis/layers/cohort-geography/CohortGeographyMapOverlay.tsx
@@ -1,0 +1,79 @@
+import { useMemo } from "react";
+import { GeoJsonLayer } from "@deck.gl/layers";
+import type { LayerMapProps } from "../types";
+
+function cohortColor(value: number, maxValue: number): [number, number, number, number] {
+  const t = maxValue > 0 ? Math.min(Math.sqrt(value / maxValue), 1) : 0;
+
+  return [
+    Math.round(8 + t * 20),
+    Math.round(118 + t * 98),
+    Math.round(148 + t * 87),
+    Math.round(55 + t * 190),
+  ];
+}
+
+export function CohortGeographyMapOverlay({
+  data,
+  selectedFips,
+  onRegionClick,
+  onRegionHover,
+  visible,
+}: LayerMapProps) {
+  const layer = useMemo(() => {
+    if (!data.length || !visible) return null;
+
+    const maxValue = Math.max(...data.map((item) => Number(item.value) || 0), 0);
+    const geojson: GeoJSON.FeatureCollection = {
+      type: "FeatureCollection",
+      features: data
+        .filter((item) => item.geometry)
+        .map((item) => ({
+          type: "Feature" as const,
+          geometry: item.geometry!,
+          properties: {
+            fips: item.fips,
+            name: item.location_name,
+            value: item.value,
+            suppressed: Boolean(item.suppressed),
+          },
+        })),
+    };
+
+    return new GeoJsonLayer({
+      id: "cohort-geography-choropleth",
+      data: geojson,
+      pickable: true,
+      stroked: true,
+      filled: true,
+      getFillColor: (feature: unknown) => {
+        const props = (feature as { properties: { value: number; suppressed: boolean } }).properties;
+        if (props.suppressed) return [120, 130, 145, 90];
+        return cohortColor(props.value, maxValue);
+      },
+      getLineColor: (feature: unknown) => {
+        const fips = (feature as { properties: { fips: string } }).properties.fips;
+        return fips === selectedFips ? [240, 249, 255, 255] : [70, 82, 96, 130];
+      },
+      getLineWidth: (feature: unknown) => {
+        const fips = (feature as { properties: { fips: string } }).properties.fips;
+        return fips === selectedFips ? 3 : 1;
+      },
+      lineWidthMinPixels: 1,
+      onClick: (info: { object?: { properties: { fips: string; name: string } } }) => {
+        if (info.object) onRegionClick(info.object.properties.fips, info.object.properties.name);
+      },
+      onHover: (info: { object?: { properties: { fips: string; name: string } } | null }) => {
+        if (info.object) onRegionHover(info.object.properties.fips, info.object.properties.name);
+        else onRegionHover(null, null);
+      },
+      updateTriggers: {
+        getFillColor: [maxValue],
+        getLineColor: [selectedFips],
+        getLineWidth: [selectedFips],
+      },
+    });
+  }, [data, onRegionClick, onRegionHover, selectedFips, visible]);
+
+  return layer;
+}

--- a/frontend/src/features/gis/layers/cohort-geography/index.ts
+++ b/frontend/src/features/gis/layers/cohort-geography/index.ts
@@ -1,0 +1,36 @@
+import { UsersRound } from "lucide-react";
+import type { GisLayer, TooltipEntry } from "../types";
+import { registerLayer } from "../registry";
+import { CohortGeographyAnalysisPanel } from "./CohortGeographyAnalysisPanel";
+import { CohortGeographyDetailPanel } from "./CohortGeographyDetailPanel";
+import { CohortGeographyMapOverlay } from "./CohortGeographyMapOverlay";
+import { useCohortGeographyData } from "./useCohortGeographyData";
+
+const cohortGeographyLayer: GisLayer = {
+  id: "cohort-geography",
+  name: "Cohort Geography" /* i18n-exempt: GIS layer name */,
+  description: "Acumenus cohort membership by Pennsylvania geography" /* i18n-exempt: GIS layer description */,
+  color: "#06B6D4",
+  icon: UsersRound,
+  requiresCohortGeography: true,
+  mapOverlay: CohortGeographyMapOverlay as unknown as GisLayer["mapOverlay"],
+  legendItems: [
+    { label: "Low", color: "#08768C40", type: "gradient" },
+    { label: "High", color: "#06B6D4", type: "gradient" },
+  ],
+  getTooltipData: (feature): TooltipEntry[] => [
+    {
+      layerId: "cohort-geography",
+      label: "Cohort",
+      value: Number(feature.value).toLocaleString(),
+      color: "#06B6D4",
+    },
+  ],
+  analysisPanel: CohortGeographyAnalysisPanel,
+  detailPanel: CohortGeographyDetailPanel,
+  useLayerData: useCohortGeographyData,
+};
+
+registerLayer(cohortGeographyLayer);
+
+export default cohortGeographyLayer;

--- a/frontend/src/features/gis/layers/cohort-geography/useCohortGeographyData.ts
+++ b/frontend/src/features/gis/layers/cohort-geography/useCohortGeographyData.ts
@@ -1,0 +1,40 @@
+import { useMemo } from "react";
+import { useCohortGeographyAggregate } from "../../hooks/useGis";
+import type { CohortGeographyFeature } from "../../types";
+import type { LayerChoroplethItem, LayerDataParams, LayerDataResult } from "../types";
+
+type CohortGeographyMapItem = LayerChoroplethItem & CohortGeographyFeature;
+
+function hasTarget(params: LayerDataParams): boolean {
+  return Boolean(
+    params.cohortGeography?.cohort_definition_id ?? params.cohortGeography?.concept_id
+  );
+}
+
+export function useCohortGeographyData(params: LayerDataParams): LayerDataResult {
+  const enabled = params.enabled === true && hasTarget(params);
+  const aggregate = useCohortGeographyAggregate(enabled ? params.cohortGeography ?? null : null);
+
+  const choroplethData = useMemo<CohortGeographyMapItem[] | undefined>(() => {
+    if (!aggregate.data) return undefined;
+
+    return aggregate.data.features.map((feature) => ({
+      ...feature,
+      geographic_location_id: feature.geographic_location_id,
+      location_name: feature.location_name,
+      fips: feature.fips,
+      latitude: feature.latitude ?? 0,
+      longitude: feature.longitude ?? 0,
+      value: feature.value ?? 0,
+      patient_count: feature.denominator,
+      geometry: feature.geometry,
+    }));
+  }, [aggregate.data]);
+
+  return {
+    choroplethData,
+    analysisData: aggregate.data,
+    detailData: null,
+    isLoading: aggregate.isLoading,
+  };
+}

--- a/frontend/src/features/gis/layers/disease-burden/DiseaseBurdenAnalysisPanel.tsx
+++ b/frontend/src/features/gis/layers/disease-burden/DiseaseBurdenAnalysisPanel.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { fetchCdmChoropleth } from "../../api";
+import type { CdmMetricType } from "../../types";
+import type { LayerAnalysisProps } from "../types";
+
+function normalizeMetric(metric: string): CdmMetricType {
+  if (metric === "deaths" || metric === "hospitalization" || metric === "patient_count") {
+    return metric;
+  }
+
+  return "cases";
+}
+
+export function DiseaseBurdenAnalysisPanel({ conceptId, metric }: LayerAnalysisProps) {
+  const { t } = useTranslation("app");
+  const cdmMetric = normalizeMetric(metric);
+  const { data, isLoading } = useQuery({
+    queryKey: ["gis", "disease-burden", "analysis", conceptId, cdmMetric],
+    queryFn: () => fetchCdmChoropleth({ concept_id: conceptId, metric: cdmMetric }),
+    staleTime: 60_000,
+  });
+
+  const topRegions = useMemo(() => (data ?? []).slice(0, 5), [data]);
+
+  if (isLoading) {
+    return <p className="text-xs text-text-ghost">{t("gis.layers.comorbidity.analysis.loading")}</p>;
+  }
+
+  if (topRegions.length === 0) {
+    return <p className="text-xs text-text-ghost">{t("gis.layers.comorbidity.analysis.noData")}</p>;
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {topRegions.map((item) => (
+        <div key={item.gid} className="flex items-center justify-between gap-3 text-xs">
+          <span className="truncate text-text-muted">{item.name}</span>
+          <span className="font-medium text-text-primary">{item.value.toLocaleString()}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/gis/layers/disease-burden/DiseaseBurdenDetailPanel.tsx
+++ b/frontend/src/features/gis/layers/disease-burden/DiseaseBurdenDetailPanel.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from "react-i18next";
+import { useCountyDetail } from "../../hooks/useGis";
+import type { LayerDetailProps } from "../types";
+
+export function DiseaseBurdenDetailPanel({ fips, conceptId }: LayerDetailProps) {
+  const { t } = useTranslation("app");
+  const { data, isLoading } = useCountyDetail(fips, conceptId);
+
+  if (isLoading) {
+    return <p className="text-xs text-text-ghost">{t("gis.layers.comorbidity.analysis.loading")}</p>;
+  }
+
+  if (!data) {
+    return <p className="text-xs text-text-ghost">{t("gis.layers.comorbidity.analysis.noData")}</p>;
+  }
+
+  const cases = data.metrics.cases;
+  const deaths = data.metrics.deaths;
+  const cfr = data.metrics.cfr;
+  const hospitalizations = data.metrics.hospitalization;
+
+  return (
+    <div className="space-y-1.5 text-xs">
+      <Metric label={t("gis.countyDetail.cases")} value={cases?.value} />
+      <Metric label={t("gis.countyDetail.hospitalized")} value={hospitalizations?.value} />
+      <Metric label={t("gis.countyDetail.deaths")} value={deaths?.value} />
+      <Metric label={t("gis.countyDetail.cfr")} value={cfr?.rate ?? cfr?.value} suffix="%" />
+    </div>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  suffix = "",
+}: {
+  label: string;
+  value: number | null | undefined;
+  suffix?: string;
+}) {
+  return (
+    <div className="flex justify-between gap-3">
+      <span className="text-text-muted">{label}</span>
+      <span className="font-medium text-text-primary">
+        {value === null || value === undefined ? "-" : `${value.toLocaleString()}${suffix}`}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/features/gis/layers/disease-burden/DiseaseBurdenMapOverlay.tsx
+++ b/frontend/src/features/gis/layers/disease-burden/DiseaseBurdenMapOverlay.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from "react";
+import { GeoJsonLayer } from "@deck.gl/layers";
+import type { LayerMapProps } from "../types";
+
+function burdenToColor(value: number, maxValue: number): [number, number, number, number] {
+  const t = maxValue > 0 ? Math.min(Math.log1p(value) / Math.log1p(maxValue), 1) : 0;
+
+  return [
+    Math.round(40 + t * 218),
+    Math.round(80 + t * 94),
+    Math.round(140 - t * 98),
+    Math.round(75 + t * 170),
+  ];
+}
+
+export function DiseaseBurdenMapOverlay({
+  data,
+  selectedFips,
+  onRegionClick,
+  onRegionHover,
+  visible,
+}: LayerMapProps) {
+  const layer = useMemo(() => {
+    if (!data.length || !visible) return null;
+
+    const maxValue = Math.max(...data.map((item) => Number(item.value) || 0), 0);
+    const geojson: GeoJSON.FeatureCollection = {
+      type: "FeatureCollection",
+      features: data
+        .filter((item) => item.geometry)
+        .map((item) => ({
+          type: "Feature" as const,
+          geometry: item.geometry!,
+          properties: {
+            gid: item.fips,
+            name: item.location_name,
+            value: item.value,
+          },
+        })),
+    };
+
+    return new GeoJsonLayer({
+      id: "disease-burden-choropleth",
+      data: geojson,
+      pickable: true,
+      stroked: true,
+      filled: true,
+      getFillColor: (feature: unknown) => {
+        const value = (feature as { properties: { value: number } }).properties.value;
+        return burdenToColor(value, maxValue);
+      },
+      getLineColor: (feature: unknown) => {
+        const gid = (feature as { properties: { gid: string } }).properties.gid;
+        return gid === selectedFips ? [45, 212, 191, 255] : [90, 95, 110, 105];
+      },
+      getLineWidth: (feature: unknown) => {
+        const gid = (feature as { properties: { gid: string } }).properties.gid;
+        return gid === selectedFips ? 3 : 1;
+      },
+      lineWidthMinPixels: 1,
+      onClick: (info: { object?: { properties: { gid: string; name: string } } }) => {
+        if (info.object) onRegionClick(info.object.properties.gid, info.object.properties.name);
+      },
+      onHover: (info: { object?: { properties: { gid: string; name: string } } | null }) => {
+        if (info.object) onRegionHover(info.object.properties.gid, info.object.properties.name);
+        else onRegionHover(null, null);
+      },
+      updateTriggers: {
+        getFillColor: [maxValue],
+        getLineColor: [selectedFips],
+        getLineWidth: [selectedFips],
+      },
+    });
+  }, [data, onRegionClick, onRegionHover, selectedFips, visible]);
+
+  return layer;
+}

--- a/frontend/src/features/gis/layers/disease-burden/index.ts
+++ b/frontend/src/features/gis/layers/disease-burden/index.ts
@@ -1,0 +1,36 @@
+import { Activity } from "lucide-react";
+import type { GisLayer, TooltipEntry } from "../types";
+import { registerLayer } from "../registry";
+import { DiseaseBurdenAnalysisPanel } from "./DiseaseBurdenAnalysisPanel";
+import { DiseaseBurdenDetailPanel } from "./DiseaseBurdenDetailPanel";
+import { DiseaseBurdenMapOverlay } from "./DiseaseBurdenMapOverlay";
+import { useDiseaseBurdenData } from "./useDiseaseBurdenData";
+
+const diseaseBurdenLayer: GisLayer = {
+  id: "disease-burden",
+  name: "Disease Burden" /* i18n-exempt: GIS layer name */,
+  description: "OMOP condition burden by county" /* i18n-exempt: GIS layer description */,
+  color: "var(--accent)",
+  icon: Activity,
+  requiresConcept: true,
+  mapOverlay: DiseaseBurdenMapOverlay as unknown as GisLayer["mapOverlay"],
+  legendItems: [
+    { label: "Low", color: "#28508C50", type: "gradient" },
+    { label: "High", color: "var(--accent)", type: "gradient" },
+  ],
+  getTooltipData: (feature): TooltipEntry[] => [
+    {
+      layerId: "disease-burden",
+      label: "Burden",
+      value: Number(feature.value).toLocaleString(),
+      color: "var(--accent)",
+    },
+  ],
+  analysisPanel: DiseaseBurdenAnalysisPanel,
+  detailPanel: DiseaseBurdenDetailPanel,
+  useLayerData: useDiseaseBurdenData,
+};
+
+registerLayer(diseaseBurdenLayer);
+
+export default diseaseBurdenLayer;

--- a/frontend/src/features/gis/layers/disease-burden/useDiseaseBurdenData.ts
+++ b/frontend/src/features/gis/layers/disease-burden/useDiseaseBurdenData.ts
@@ -1,0 +1,84 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { fetchBoundaries, fetchCdmChoropleth } from "../../api";
+import type { BoundaryFeature, CdmMetricType, CountyChoroplethItem } from "../../types";
+import type { LayerChoroplethItem, LayerDataParams, LayerDataResult } from "../types";
+
+type DiseaseBurdenMapItem = LayerChoroplethItem & {
+  gid: string;
+  denominator: number | null;
+  rate: number | null;
+  metric: string;
+};
+
+function normalizeMetric(metric: string): CdmMetricType {
+  if (metric === "deaths" || metric === "hospitalization" || metric === "patient_count") {
+    return metric;
+  }
+
+  return "cases";
+}
+
+function mergeCountyStats(
+  rows: CountyChoroplethItem[] | undefined,
+  boundaries: BoundaryFeature[] | undefined,
+  metric: string
+): DiseaseBurdenMapItem[] | undefined {
+  if (!rows || !boundaries) return undefined;
+
+  const boundaryByGid = new Map(boundaries.map((feature) => [feature.properties.gid, feature]));
+
+  return rows.reduce<DiseaseBurdenMapItem[]>((items, row) => {
+      const boundary = boundaryByGid.get(row.gid);
+      if (!boundary?.geometry) return items;
+
+      items.push({
+        geographic_location_id: row.boundary_id,
+        location_name: row.name,
+        fips: row.gid,
+        latitude: 0,
+        longitude: 0,
+        value: row.value,
+        patient_count: row.denominator ?? 0,
+        geometry: boundary.geometry,
+        gid: row.gid,
+        denominator: row.denominator,
+        rate: row.rate,
+        metric,
+      });
+
+      return items;
+    }, []);
+}
+
+export function useDiseaseBurdenData(params: LayerDataParams): LayerDataResult {
+  const { conceptId, metric, enabled = true } = params;
+  const cdmMetric = normalizeMetric(metric);
+  const canFetch = enabled && conceptId !== null;
+
+  const choropleth = useQuery({
+    queryKey: ["gis", "disease-burden", "choropleth", conceptId, cdmMetric],
+    queryFn: () => fetchCdmChoropleth({ concept_id: conceptId!, metric: cdmMetric }),
+    enabled: canFetch,
+    staleTime: 60_000,
+  });
+
+  const boundaries = useQuery({
+    queryKey: ["gis", "disease-burden", "boundaries", "USA", "ADM2"],
+    queryFn: () => fetchBoundaries({ level: "ADM2", country_code: "USA", simplify: 0.02 }),
+    enabled: canFetch,
+    staleTime: 5 * 60_000,
+  });
+
+  const choroplethData = useMemo(
+    () => mergeCountyStats(choropleth.data, boundaries.data?.features, cdmMetric),
+    [boundaries.data?.features, choropleth.data, cdmMetric]
+  );
+
+  return {
+    choroplethData,
+    analysisData: choropleth.data,
+    detailData: null,
+    isLoading: choropleth.isLoading || boundaries.isLoading,
+  };
+}

--- a/frontend/src/features/gis/layers/hospital-access/HospitalAnalysisPanel.tsx
+++ b/frontend/src/features/gis/layers/hospital-access/HospitalAnalysisPanel.tsx
@@ -3,12 +3,14 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContaine
 import { useTranslation } from "react-i18next";
 import { fetchAccessAnalysis } from "./api";
 import type { LayerAnalysisProps } from "../types";
+import { normalizeOutcomeMetric } from "../utils";
 
 export function HospitalAnalysisPanel({ conceptId, metric }: LayerAnalysisProps) {
   const { t } = useTranslation("app");
+  const outcomeMetric = normalizeOutcomeMetric(metric);
   const { data, isLoading } = useQuery({
-    queryKey: ["gis", "hospitals", "access", conceptId, metric],
-    queryFn: () => fetchAccessAnalysis(conceptId, metric),
+    queryKey: ["gis", "hospitals", "access", conceptId, outcomeMetric],
+    queryFn: () => fetchAccessAnalysis(conceptId, outcomeMetric),
     staleTime: 60_000,
   });
   if (isLoading) return <p className="text-xs text-text-ghost">{t("gis.layers.hospitalAccess.analysis.loading")}</p>;

--- a/frontend/src/features/gis/layers/hospital-access/HospitalMapOverlay.tsx
+++ b/frontend/src/features/gis/layers/hospital-access/HospitalMapOverlay.tsx
@@ -16,13 +16,15 @@ interface HospitalMapOverlayProps extends LayerMapProps {
   hospitals?: HospitalPoint[];
 }
 
-export function HospitalMapOverlay({ hospitals, visible }: HospitalMapOverlayProps) {
+export function HospitalMapOverlay({ hospitals, mapData, visible }: HospitalMapOverlayProps) {
+  const points = hospitals ?? (Array.isArray(mapData) ? (mapData as HospitalPoint[]) : undefined);
+
   const layer = useMemo(() => {
-    if (!hospitals?.length || !visible) return null;
+    if (!points?.length || !visible) return null;
 
     return new ScatterplotLayer({
       id: "hospital-points",
-      data: hospitals,
+      data: points,
       getPosition: (d: HospitalPoint) => [d.longitude, d.latitude],
       getRadius: (d: HospitalPoint) => Math.max(Math.sqrt(d.bed_count) * 50, 500),
       getFillColor: (d: HospitalPoint) => d.has_emergency ? [59, 130, 246, 200] : [59, 130, 246, 100],
@@ -33,7 +35,7 @@ export function HospitalMapOverlay({ hospitals, visible }: HospitalMapOverlayPro
       radiusMinPixels: 3,
       radiusMaxPixels: 20,
     });
-  }, [hospitals, visible]);
+  }, [points, visible]);
 
   return layer;
 }

--- a/frontend/src/features/gis/layers/hospital-access/useHospitalData.ts
+++ b/frontend/src/features/gis/layers/hospital-access/useHospitalData.ts
@@ -1,9 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import type { LayerDataParams, LayerDataResult } from "../types";
 import { fetchHospitalMapData, fetchAccessAnalysis, fetchDeserts } from "./api";
+import { normalizeOutcomeMetric } from "../utils";
 
 export function useHospitalData(params: LayerDataParams): LayerDataResult {
-  const { conceptId, enabled = true } = params;
+  const { conceptId, metric, enabled = true } = params;
+  const outcomeMetric = normalizeOutcomeMetric(metric);
 
   const hospitals = useQuery({
     queryKey: ["gis", "hospitals", "map"],
@@ -13,8 +15,8 @@ export function useHospitalData(params: LayerDataParams): LayerDataResult {
   });
 
   const access = useQuery({
-    queryKey: ["gis", "hospitals", "access", conceptId],
-    queryFn: () => fetchAccessAnalysis(conceptId!, "cases"),
+    queryKey: ["gis", "hospitals", "access", conceptId, outcomeMetric],
+    queryFn: () => fetchAccessAnalysis(conceptId!, outcomeMetric),
     enabled: enabled && conceptId !== null,
     staleTime: 60_000,
   });
@@ -30,6 +32,7 @@ export function useHospitalData(params: LayerDataParams): LayerDataResult {
     choroplethData: undefined, // hospitals use ScatterplotLayer, not choropleth
     analysisData: { hospitals: hospitals.data, access: access.data, deserts: deserts.data },
     detailData: null,
+    mapData: hospitals.data,
     isLoading: hospitals.isLoading,
   };
 }

--- a/frontend/src/features/gis/layers/init.ts
+++ b/frontend/src/features/gis/layers/init.ts
@@ -6,6 +6,8 @@
  * registry.ts exports registerLayer → layer modules import it →
  * if registry.ts also imported layer modules, it would be circular.
  */
+import "./cohort-geography";
+import "./disease-burden";
 import "./svi";
 import "./rucc";
 import "./comorbidity";

--- a/frontend/src/features/gis/layers/rucc/RuccAnalysisPanel.tsx
+++ b/frontend/src/features/gis/layers/rucc/RuccAnalysisPanel.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { fetchRuccOutcomeComparison } from "./api";
 import type { LayerAnalysisProps } from "../types";
 import { getRuccCategoryLabel } from "../../lib/i18n";
+import { normalizeOutcomeMetric } from "../utils";
 
 const CATEGORY_COLORS: Record<string, string> = {
   metro: "var(--info)",
@@ -13,9 +14,10 @@ const CATEGORY_COLORS: Record<string, string> = {
 
 export function RuccAnalysisPanel({ conceptId, metric }: LayerAnalysisProps) {
   const { t } = useTranslation("app");
+  const outcomeMetric = normalizeOutcomeMetric(metric);
   const { data, isLoading } = useQuery({
-    queryKey: ["gis", "rucc", "outcomes", conceptId, metric],
-    queryFn: () => fetchRuccOutcomeComparison(conceptId, metric),
+    queryKey: ["gis", "rucc", "outcomes", conceptId, outcomeMetric],
+    queryFn: () => fetchRuccOutcomeComparison(conceptId, outcomeMetric),
     staleTime: 60_000,
   });
 

--- a/frontend/src/features/gis/layers/rucc/useRuccData.ts
+++ b/frontend/src/features/gis/layers/rucc/useRuccData.ts
@@ -1,9 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import type { LayerDataParams, LayerDataResult } from "../types";
 import { fetchRuccChoropleth, fetchRuccOutcomeComparison, fetchRuccCountyDetail } from "./api";
+import { normalizeOutcomeMetric } from "../utils";
 
 export function useRuccData(params: LayerDataParams): LayerDataResult {
-  const { conceptId, selectedFips, enabled = true } = params;
+  const { conceptId, selectedFips, metric, enabled = true } = params;
+  const outcomeMetric = normalizeOutcomeMetric(metric);
 
   const choropleth = useQuery({
     queryKey: ["gis", "rucc", "choropleth"],
@@ -13,8 +15,8 @@ export function useRuccData(params: LayerDataParams): LayerDataResult {
   });
 
   const outcomes = useQuery({
-    queryKey: ["gis", "rucc", "outcomes", conceptId],
-    queryFn: () => fetchRuccOutcomeComparison(conceptId!, "cases"),
+    queryKey: ["gis", "rucc", "outcomes", conceptId, outcomeMetric],
+    queryFn: () => fetchRuccOutcomeComparison(conceptId!, outcomeMetric),
     enabled: enabled && conceptId !== null,
     staleTime: 60_000,
   });

--- a/frontend/src/features/gis/layers/svi/SviAnalysisPanel.tsx
+++ b/frontend/src/features/gis/layers/svi/SviAnalysisPanel.tsx
@@ -11,12 +11,14 @@ import {
 import { fetchSviQuartileAnalysis } from "./api";
 import type { LayerAnalysisProps } from "../types";
 import { useTranslation } from "react-i18next";
+import { normalizeOutcomeMetric } from "../utils";
 
 export function SviAnalysisPanel({ conceptId, metric }: LayerAnalysisProps) {
   const { t } = useTranslation("app");
+  const outcomeMetric = normalizeOutcomeMetric(metric);
   const { data, isLoading } = useQuery({
-    queryKey: ["gis", "svi", "quartiles", conceptId, metric],
-    queryFn: () => fetchSviQuartileAnalysis(conceptId, metric),
+    queryKey: ["gis", "svi", "quartiles", conceptId, outcomeMetric],
+    queryFn: () => fetchSviQuartileAnalysis(conceptId, outcomeMetric),
     staleTime: 60_000,
   });
 

--- a/frontend/src/features/gis/layers/svi/useSviData.ts
+++ b/frontend/src/features/gis/layers/svi/useSviData.ts
@@ -5,9 +5,11 @@ import {
   fetchSviQuartileAnalysis,
   fetchSviTractDetail,
 } from "./api";
+import { normalizeOutcomeMetric } from "../utils";
 
 export function useSviData(params: LayerDataParams): LayerDataResult {
-  const { conceptId, selectedFips, enabled = true } = params;
+  const { conceptId, selectedFips, metric, enabled = true } = params;
+  const outcomeMetric = normalizeOutcomeMetric(metric);
 
   const choropleth = useQuery({
     queryKey: ["gis", "svi", "choropleth"],
@@ -17,8 +19,8 @@ export function useSviData(params: LayerDataParams): LayerDataResult {
   });
 
   const quartiles = useQuery({
-    queryKey: ["gis", "svi", "quartiles", conceptId],
-    queryFn: () => fetchSviQuartileAnalysis(conceptId!, "cases"),
+    queryKey: ["gis", "svi", "quartiles", conceptId, outcomeMetric],
+    queryFn: () => fetchSviQuartileAnalysis(conceptId!, outcomeMetric),
     enabled: enabled && conceptId !== null,
     staleTime: 60_000,
   });

--- a/frontend/src/features/gis/layers/types.ts
+++ b/frontend/src/features/gis/layers/types.ts
@@ -1,10 +1,12 @@
 import type { LucideIcon } from "lucide-react";
+import type { CohortGeographySelection } from "../types";
 
 /** Data params passed to every layer's data hook. */
 export interface LayerDataParams {
   conceptId: number | null;
   selectedFips: string | null;
   metric: string;
+  cohortGeography?: CohortGeographySelection | null;
   enabled?: boolean;
 }
 
@@ -13,6 +15,7 @@ export interface LayerDataResult {
   choroplethData: LayerChoroplethItem[] | undefined;
   analysisData: unknown;
   detailData: unknown;
+  mapData?: unknown;
   isLoading: boolean;
 }
 
@@ -33,6 +36,7 @@ export interface LayerChoroplethItem {
 /** Props passed to a layer's map overlay component. */
 export interface LayerMapProps {
   data: LayerChoroplethItem[];
+  mapData?: unknown;
   selectedFips: string | null;
   onRegionClick: (fips: string, name: string) => void;
   onRegionHover: (fips: string | null, name: string | null) => void;
@@ -43,12 +47,14 @@ export interface LayerMapProps {
 export interface LayerAnalysisProps {
   conceptId: number;
   metric: string;
+  cohortGeography?: CohortGeographySelection | null;
 }
 
 /** Props passed to a layer's detail panel component. */
 export interface LayerDetailProps {
   fips: string;
   conceptId: number;
+  cohortGeography?: CohortGeographySelection | null;
 }
 
 /** Legend item for composite legend. */
@@ -76,6 +82,8 @@ export interface GisLayer {
   description: string;
   color: string;
   icon: LucideIcon;
+  requiresConcept?: boolean;
+  requiresCohortGeography?: boolean;
   mapOverlay: React.FC<LayerMapProps>;
   legendItems: LegendItem[];
   getTooltipData: (feature: LayerChoroplethItem) => TooltipEntry[];

--- a/frontend/src/features/gis/layers/utils.ts
+++ b/frontend/src/features/gis/layers/utils.ts
@@ -18,3 +18,15 @@ export function normalizeChoropleth(
         : (row.geometry as GeoJSON.Geometry | null) ?? null,
   })) as LayerChoroplethItem[];
 }
+
+export function normalizeOutcomeMetric(metric: string): "cases" | "hospitalizations" | "deaths" {
+  if (metric === "hospitalization" || metric === "hospitalizations") {
+    return "hospitalizations";
+  }
+
+  if (metric === "deaths") {
+    return "deaths";
+  }
+
+  return "cases";
+}

--- a/frontend/src/features/gis/pages/GisPage.tsx
+++ b/frontend/src/features/gis/pages/GisPage.tsx
@@ -20,7 +20,7 @@ import { useBoundaries, useBoundaryDetail, useCountries, useGisStats } from "../
 import { HelpButton } from "@/features/help";
 import { useTranslation } from "react-i18next";
 import { getAnalysisLayerCountLabel } from "../lib/i18n";
-import type { AdminLevel, BoundaryFeature } from "../types";
+import type { AdminLevel, BoundaryFeature, CdmMetricType, CohortGeographySelection } from "../types";
 
 const MAP_STYLE = "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json";
 const ADMIN_LEVEL_ORDER: AdminLevel[] = ["ADM0", "ADM1", "ADM2", "ADM3"];
@@ -34,13 +34,29 @@ function getNextLevel(level: AdminLevel): AdminLevel | null {
 export default function GisPage() {
   const { t } = useTranslation("app");
   const { viewport, onViewportChange, resetViewport } = useMapViewport();
-  const { activeLayers, selectedFips, setSelectedRegion } = useLayerStore();
+  const { activeLayers, selectedFips, setSelectedRegion, setLayerActive } = useLayerStore();
   const layers = getLayers();
 
   // Disease selection
   const [selectedConceptId, setSelectedConceptId] = useState<number | null>(null);
   const [selectedDiseaseName, setSelectedDiseaseName] = useState<string | null>(null);
-  const [cdmMetric] = useState("cases");
+  const [cdmMetric, setCdmMetric] = useState<CdmMetricType>("cases");
+  const [cohortGeography, setCohortGeography] = useState<CohortGeographySelection>(() => {
+    const params = new URLSearchParams(window.location.search);
+    const cohortId = params.get("cohort");
+    const conceptId = params.get("concept");
+    const level = params.get("level") === "tract" ? "tract" : "county";
+    const metric = params.get("metric") === "prevalence_per_1000" ? "prevalence_per_1000" : "members";
+
+    return {
+      source_id: Number(params.get("source") ?? 47),
+      mode: conceptId ? "condition" : "generated",
+      cohort_definition_id: cohortId ? Number(cohortId) : undefined,
+      concept_id: conceptId ? Number(conceptId) : undefined,
+      level,
+      metric,
+    };
+  });
   const [isExpanded, setIsExpanded] = useState(false);
   const [mapMode, setMapMode] = useState<MapMode>("analysis");
   const [boundaryLevel, setBoundaryLevel] = useState<AdminLevel>("ADM0");
@@ -60,6 +76,12 @@ export default function GisPage() {
     };
     return () => { window.onerror = origError; };
   }, []);
+
+  useEffect(() => {
+    if (cohortGeography.cohort_definition_id || cohortGeography.concept_id) {
+      setLayerActive("cohort-geography", true);
+    }
+  }, [cohortGeography.cohort_definition_id, cohortGeography.concept_id, setLayerActive]);
 
   const handleDiseaseSelect = useCallback((conceptId: number, name: string) => {
     setSelectedConceptId(conceptId);
@@ -93,6 +115,8 @@ export default function GisPage() {
   const analysisDeckLayers = useActiveMapLayers({
     conceptId: selectedConceptId,
     selectedFips,
+    metric: cdmMetric,
+    cohortGeography,
     enabled: mapMode === "analysis",
     onRegionClick: handleRegionClick,
     onRegionHover: handleRegionHover,
@@ -275,7 +299,11 @@ export default function GisPage() {
         ) : (
           <LayerPanel
             selectedConceptId={selectedConceptId}
+            metric={cdmMetric}
+            cohortGeography={cohortGeography}
             onDiseaseSelect={handleDiseaseSelect}
+            onMetricChange={setCdmMetric}
+            onCohortGeographyChange={setCohortGeography}
           />
         )}
 
@@ -300,16 +328,21 @@ export default function GisPage() {
           </div>
 
           {/* Bottom: Analysis drawer */}
-          {mapMode === "analysis" && selectedConceptId && hasActiveLayers && (
-            <AnalysisDrawer conceptId={selectedConceptId} metric={cdmMetric} />
+          {mapMode === "analysis" && hasActiveLayers && (selectedConceptId || activeLayers.has("cohort-geography")) && (
+            <AnalysisDrawer
+              conceptId={selectedConceptId ?? 0}
+              metric={cdmMetric}
+              cohortGeography={cohortGeography}
+            />
           )}
         </div>
 
         {/* Right: Context panel */}
-        {mapMode === "analysis" && selectedConceptId && selectedDiseaseName && (
+        {mapMode === "analysis" && (selectedConceptId || activeLayers.has("cohort-geography")) && (
           <ContextPanel
-            conceptId={selectedConceptId}
-            diseaseName={selectedDiseaseName}
+            conceptId={selectedConceptId ?? 0}
+            diseaseName={selectedDiseaseName ?? cohortGeography.label ?? "Cohort geography"}
+            cohortGeography={cohortGeography}
           />
         )}
         {mapMode === "boundaries" && (

--- a/frontend/src/features/gis/stores/layerStore.ts
+++ b/frontend/src/features/gis/stores/layerStore.ts
@@ -11,6 +11,7 @@ interface LayerState {
 interface LayerActions {
   toggleLayer: (id: string) => void;
   setSelectedRegion: (fips: string | null, name: string | null) => void;
+  setLayerActive: (id: string, active: boolean) => void;
   setDrawerOpen: (open: boolean) => void;
   setSuppressionThreshold: (threshold: number) => void;
   isLayerActive: (id: string) => boolean;
@@ -36,6 +37,17 @@ export const useLayerStore = create<LayerState & LayerActions>((set, get) => ({
 
   setSelectedRegion: (fips, name) =>
     set({ selectedFips: fips, selectedName: name }),
+
+  setLayerActive: (id, active) =>
+    set((state) => {
+      const next = new Set(state.activeLayers);
+      if (active) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+      return { activeLayers: next };
+    }),
 
   setDrawerOpen: (open) => set({ drawerOpen: open }),
 

--- a/frontend/src/features/gis/types.ts
+++ b/frontend/src/features/gis/types.ts
@@ -10,6 +10,88 @@ export interface GisStats {
   levels: BoundaryLevel[];
 }
 
+export interface GisAnalysisLayerMetadata {
+  id: string;
+  name: string;
+  description: string;
+  color: string;
+  available: boolean;
+}
+
+export type CohortGeographyMode = "generated" | "condition";
+export type CohortGeographyLevel = "county" | "tract";
+export type CohortGeographyMetric = "members" | "prevalence_per_1000";
+
+export interface CohortGeographySelection {
+  source_id: number;
+  mode: CohortGeographyMode;
+  cohort_definition_id?: number;
+  concept_id?: number;
+  label?: string;
+  level: CohortGeographyLevel;
+  metric: CohortGeographyMetric;
+}
+
+export interface CohortGeographyListItem {
+  cohort_definition_id?: number;
+  concept_id?: number;
+  name: string;
+  subject_count: number;
+  geocoded_count: number;
+  coverage_percent: number;
+}
+
+export interface CohortGeographyCoverageLevel {
+  level: CohortGeographyLevel;
+  available: boolean;
+  geography_count: number;
+  geometry_count: number;
+  linked_person_count: number;
+}
+
+export interface CohortGeographyCoverage {
+  source_id: number;
+  source_key: string;
+  source_name: string;
+  state_fips: string;
+  levels: Record<CohortGeographyLevel, CohortGeographyCoverageLevel>;
+}
+
+export interface CohortGeographyFeature {
+  geographic_location_id: number;
+  location_name: string;
+  fips: string;
+  latitude: number | null;
+  longitude: number | null;
+  population: number | null;
+  area_sq_km: number | null;
+  geometry: GeoJSON.Geometry | null;
+  member_count: number | null;
+  denominator: number;
+  rate_per_1000: number | null;
+  value: number | null;
+  suppressed: boolean;
+}
+
+export interface CohortGeographyAggregate {
+  source: { id: number; key: string; name: string };
+  mode: CohortGeographyMode;
+  target_id: number;
+  level: CohortGeographyLevel;
+  metric: CohortGeographyMetric;
+  min_cell_count: number;
+  state_fips: string;
+  summary: {
+    total_members: number;
+    geocoded_members: number;
+    unknown_members: number;
+    coverage_percent: number;
+    geography_count: number;
+    suppressed_geographies: number;
+  };
+  features: CohortGeographyFeature[];
+}
+
 export interface BoundaryProperties {
   id: number;
   gid: string;

--- a/frontend/src/features/investigation/components/phenotype/CohortBuilder.tsx
+++ b/frontend/src/features/investigation/components/phenotype/CohortBuilder.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { Investigation, PhenotypeState } from "../../types";
 import { CohortPicker } from "./CohortPicker";
@@ -29,7 +29,10 @@ interface CohortBuilderProps {
   }) => void;
 }
 
-export function CohortBuilder({ investigation, onStateChange }: CohortBuilderProps) {
+export function CohortBuilder({
+  investigation,
+  onStateChange,
+}: CohortBuilderProps) {
   const { t } = useTranslation("app");
   const [importMode, setImportMode] = useState<ImportMode>(
     investigation.phenotype_state.import_mode ?? "parthenon",
@@ -43,7 +46,11 @@ export function CohortBuilder({ investigation, onStateChange }: CohortBuilderPro
   const [atlasJson, setAtlasJson] = useState("");
   const [atlasParseError, setAtlasParseError] = useState<string | null>(null);
   const [atlasSummary, setAtlasSummary] = useState<string | null>(null);
-  const [fileInfo, setFileInfo] = useState<{ name: string; size: string; summary: string } | null>(null);
+  const [fileInfo, setFileInfo] = useState<{
+    name: string;
+    size: string;
+    summary: string;
+  } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const importOptions: ImportOption[] = [
     {
@@ -73,16 +80,22 @@ export function CohortBuilder({ investigation, onStateChange }: CohortBuilderPro
   ];
 
   // Resolved cohort objects (name + count) for display badges
-  const { data: cohortListData } = useCohortDefinitions({ limit: 200, with_generations: true });
-  const cohortList = cohortListData?.items ?? [];
-  const selectedCohorts = selectedIds.map((id) => {
-    const def = cohortList.find((c) => c.id === id);
-    return {
-      id,
-      name: def?.name ?? `Cohort #${id}`,
-      count: def?.latest_generation?.person_count ?? 0,
-    };
+  const { data: cohortListData } = useCohortDefinitions({
+    limit: 200,
+    with_generations: true,
   });
+  const selectedCohorts = useMemo(() => {
+    const cohortList = cohortListData?.items ?? [];
+    const cohortMap = new Map(cohortList.map((c) => [c.id, c]));
+    return selectedIds.map((id) => {
+      const def = cohortMap.get(id);
+      return {
+        id,
+        name: def?.name ?? `Cohort #${id}`,
+        count: def?.latest_generation?.person_count ?? 0,
+      };
+    });
+  }, [cohortListData?.items, selectedIds]);
 
   function handleAtlasParse() {
     setAtlasParseError(null);
@@ -99,18 +112,26 @@ export function CohortBuilder({ investigation, onStateChange }: CohortBuilderPro
       return;
     }
     const hasExpression = "expression" in parsed;
-    const inner = (hasExpression ? (parsed.expression as Record<string, unknown>) : parsed) ?? {};
-    const conceptSets = Array.isArray(inner.ConceptSets) ? inner.ConceptSets : [];
+    const inner =
+      (hasExpression
+        ? (parsed.expression as Record<string, unknown>)
+        : parsed) ?? {};
+    const conceptSets = Array.isArray(inner.ConceptSets)
+      ? inner.ConceptSets
+      : [];
     const primaryCriteria = inner.PrimaryCriteria;
-    const hasValidShape = "ConceptSets" in inner || "PrimaryCriteria" in inner || hasExpression;
+    const hasValidShape =
+      "ConceptSets" in inner || "PrimaryCriteria" in inner || hasExpression;
     if (!hasValidShape) {
       setAtlasParseError(t("investigation.phenotype.atlas.parseErrorShape"));
       return;
     }
-    const criteriaCount =
-      Array.isArray((primaryCriteria as Record<string, unknown> | undefined)?.CriteriaList)
-        ? ((primaryCriteria as Record<string, unknown>).CriteriaList as unknown[]).length
-        : primaryCriteria
+    const criteriaCount = Array.isArray(
+      (primaryCriteria as Record<string, unknown> | undefined)?.CriteriaList,
+    )
+      ? ((primaryCriteria as Record<string, unknown>).CriteriaList as unknown[])
+          .length
+      : primaryCriteria
         ? 1
         : 0;
     setAtlasSummary(
@@ -139,8 +160,13 @@ export function CohortBuilder({ investigation, onStateChange }: CohortBuilderPro
         });
         return;
       }
-      const inner = ("expression" in parsed ? (parsed.expression as Record<string, unknown>) : parsed) ?? {};
-      const conceptSets = Array.isArray(inner.ConceptSets) ? inner.ConceptSets : [];
+      const inner =
+        ("expression" in parsed
+          ? (parsed.expression as Record<string, unknown>)
+          : parsed) ?? {};
+      const conceptSets = Array.isArray(inner.ConceptSets)
+        ? inner.ConceptSets
+        : [];
       setFileInfo({
         name: file.name,
         size: `${sizeKB} KB`,
@@ -172,7 +198,12 @@ export function CohortBuilder({ investigation, onStateChange }: CohortBuilderPro
     if (fileInputRef.current) fileInputRef.current.value = "";
   }
 
-  function handlePhenotypeSelect(phenotype: { id: string; name: string; description: string; expression: Record<string, unknown> }) {
+  function handlePhenotypeSelect(phenotype: {
+    id: string;
+    name: string;
+    description: string;
+    expression: Record<string, unknown>;
+  }) {
     onStateChange({ cohort_definition: phenotype.expression });
   }
 
@@ -191,7 +222,8 @@ export function CohortBuilder({ investigation, onStateChange }: CohortBuilderPro
     onStateChange({ primary_cohort_id: id });
   }
 
-  const conceptSetCount = investigation.phenotype_state.concept_sets?.length ?? 0;
+  const conceptSetCount =
+    investigation.phenotype_state.concept_sets?.length ?? 0;
 
   return (
     <div className="flex flex-col gap-5 h-full overflow-y-auto pr-1">
@@ -219,8 +251,12 @@ export function CohortBuilder({ investigation, onStateChange }: CohortBuilderPro
                 className="mt-0.5 accent-success shrink-0"
               />
               <div>
-                <span className="text-xs font-medium text-text-primary">{opt.label}</span>
-                <p className="text-[11px] text-text-ghost mt-0.5">{opt.description}</p>
+                <span className="text-xs font-medium text-text-primary">
+                  {opt.label}
+                </span>
+                <p className="text-[11px] text-text-ghost mt-0.5">
+                  {opt.description}
+                </p>
               </div>
             </label>
           ))}
@@ -314,7 +350,9 @@ export function CohortBuilder({ investigation, onStateChange }: CohortBuilderPro
           </label>
           {fileInfo && (
             <div className="rounded border border-border-default/50 bg-surface-raised/40 px-3 py-2 flex flex-col gap-0.5">
-              <p className="text-xs text-text-secondary font-medium">{fileInfo.name}</p>
+              <p className="text-xs text-text-secondary font-medium">
+                {fileInfo.name}
+              </p>
               <p className="text-[11px] text-text-ghost">{fileInfo.size}</p>
               <p className="text-[11px] text-success">{fileInfo.summary}</p>
             </div>
@@ -330,7 +368,8 @@ export function CohortBuilder({ investigation, onStateChange }: CohortBuilderPro
       {selectedIds.length > 0 && (
         <div className="flex flex-col gap-2">
           <p className="text-xs font-medium text-text-muted uppercase tracking-wide">
-            {t("investigation.common.sections.selectedCohorts")} ({selectedIds.length})
+            {t("investigation.common.sections.selectedCohorts")} (
+            {selectedIds.length})
           </p>
           <div className="flex flex-wrap gap-1.5">
             {selectedCohorts.map(({ id, name }) => (

--- a/scripts/gis/README.md
+++ b/scripts/gis/README.md
@@ -46,10 +46,13 @@ credentials, password resolved via `~/.pgpass`.
 # 1. Counties → gis.geographic_location (3,234 nationwide rows)
 python scripts/gis/load_geography.py
 
-# 2. ZIP→tract→county crosswalk + patient_geography matview rebuild
+# 2. Optional but recommended for the PA GIS demo: PA tract geometries
+python scripts/gis/load_pa_tracts.py
+
+# 3. ZIP→tract→county crosswalk + patient_geography matview rebuild
 python scripts/gis/load_crosswalk.py
 
-# 3. UA exposures → gis.external_exposure (5 metrics × N matched persons)
+# 4. UA exposures → gis.external_exposure (5 metrics × N matched persons)
 python scripts/gis/load_ua_county.py
 ```
 
@@ -102,6 +105,8 @@ Every loader is designed to be safe to re-run:
 
 * `load_geography.py` — `INSERT ... ON CONFLICT (geographic_code,
   location_type) DO UPDATE`. Re-running emits the same county count.
+* `load_pa_tracts.py` — `INSERT ... ON CONFLICT (geographic_code,
+  location_type) DO UPDATE` for Pennsylvania tract geometries.
 * `load_crosswalk.py` — per-source `DELETE` then `INSERT` for
   `gis.location_geography`; matview is rebuilt via DROP+CREATE.
 * `load_ua_county.py` — `INSERT ... ON CONFLICT (source_id, person_id,
@@ -115,6 +120,7 @@ Every loader is designed to be safe to re-run:
 | `2020_UA_COUNTY.xlsx` | `<repo>/2020_UA_COUNTY.xlsx` | `PHASE_19_UA_XLSX_PATH` |
 | `TRACT_ZIP_032020.xlsx` | `<repo>/GIS/data/crosswalk/TRACT_ZIP_032020.xlsx` | `PHASE_19_HUD_CROSSWALK` |
 | `tl_2020_us_county.shp` (optional) | _unset_ | `PHASE_19_TIGER_COUNTY_SHP` |
+| `tl_2020_42_tract.shp` | `<repo>/GIS/data/tiger/tl_2020_42_tract.shp` | `PHASE_19_TIGER_PA_TRACT_SHP` |
 
 ### Decisions enforced by these loaders
 

--- a/scripts/gis/load_crosswalk.py
+++ b/scripts/gis/load_crosswalk.py
@@ -210,6 +210,14 @@ def rebuild_patient_geography(conn, sources: list[SourceDescriptor]) -> int:
             "CREATE INDEX idx_pg_county_fips "
             "ON gis.patient_geography(source_id, county_fips)"
         )
+        cur.execute(
+            "CREATE INDEX idx_pg_county_location "
+            "ON gis.patient_geography(source_id, county_location_id)"
+        )
+        cur.execute(
+            "CREATE INDEX idx_pg_tract_location "
+            "ON gis.patient_geography(source_id, tract_location_id)"
+        )
         cur.execute("SELECT COUNT(*) FROM gis.patient_geography")
         count = int(cur.fetchone()[0])
     conn.commit()

--- a/scripts/gis/load_pa_tracts.py
+++ b/scripts/gis/load_pa_tracts.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Load Pennsylvania TIGER 2020 tract geometries into ``gis.geographic_location``.
+
+This is the tract bootstrap for the Acumenus PA cohort geography demo. It is
+safe to re-run and uses the same env-driven DSN policy as the Phase 19 loaders.
+
+Run before ``scripts/gis/load_crosswalk.py`` so the HUD crosswalk can populate
+``tract_location_id`` and rebuild ``gis.patient_geography`` with tract links.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import psycopg2
+from psycopg2.extras import execute_values
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.gis.loader_common import GisImportTracker, emit, get_dsn  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TRACT_SHP = Path(
+    os.environ.get(
+        "PHASE_19_TIGER_PA_TRACT_SHP",
+        str(REPO_ROOT / "GIS" / "data" / "tiger" / "tl_2020_42_tract.shp"),
+    )
+)
+
+INSERT_SQL = """
+INSERT INTO gis.geographic_location
+  (location_name, location_type, geographic_code, state_fips, county_fips,
+   latitude, longitude, geometry, population, area_sq_km, parent_location_id)
+VALUES %s
+ON CONFLICT (geographic_code, location_type) DO UPDATE SET
+  location_name = EXCLUDED.location_name,
+  state_fips = EXCLUDED.state_fips,
+  county_fips = EXCLUDED.county_fips,
+  latitude = EXCLUDED.latitude,
+  longitude = EXCLUDED.longitude,
+  geometry = EXCLUDED.geometry,
+  area_sq_km = EXCLUDED.area_sq_km,
+  parent_location_id = EXCLUDED.parent_location_id
+"""
+
+INSERT_TEMPLATE = (
+    "(%s, %s, %s, %s, %s, %s, %s, ST_GeomFromText(%s, 4326)::geography, %s, %s, %s)"
+)
+
+
+def load_tract_rows(path: Path, county_map: dict[str, int]) -> list[tuple[Any, ...]]:
+    try:
+        import geopandas as gpd  # type: ignore[import-untyped]
+    except ImportError as exc:  # pragma: no cover - host dependency guard
+        raise RuntimeError(
+            "geopandas is required. Use the repo GIS virtualenv or install scripts/gis/requirements.txt."
+        ) from exc
+
+    if not path.exists():
+        raise FileNotFoundError(f"PA tract shapefile not found: {path}")
+
+    gdf = gpd.read_file(path)
+    rows: list[tuple[Any, ...]] = []
+    for _, row in gdf.iterrows():
+        geoid = str(row.get("GEOID") or row.get("geoid") or "")
+        if len(geoid) != 11 or not geoid.startswith("42"):
+            continue
+
+        geom = row.geometry
+        if geom is None:
+            continue
+
+        centroid = geom.centroid
+        county_fips = geoid[:5]
+        name = str(row.get("NAMELSAD") or row.get("NAME") or geoid).strip()
+        area_sq_km = None
+        if row.get("ALAND") is not None:
+            area_sq_km = float(row.get("ALAND")) / 1_000_000
+
+        rows.append(
+            (
+                f"{name}, Pennsylvania",
+                "census_tract",
+                geoid,
+                "42",
+                county_fips,
+                float(centroid.y),
+                float(centroid.x),
+                geom.wkt,
+                None,
+                area_sq_km,
+                county_map.get(county_fips),
+            )
+        )
+
+    return rows
+
+
+def main() -> int:
+    emit("start", script="load_pa_tracts", scope="pennsylvania_tract_geometries")
+    conn = psycopg2.connect(get_dsn())
+    tracker = GisImportTracker(conn, filename="tl_2020_42_tract.shp")
+
+    try:
+        tracker.start()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT geographic_location_id, geographic_code "
+                "FROM gis.geographic_location WHERE location_type = 'county'"
+            )
+            county_map = {code: int(location_id) for location_id, code in cur.fetchall()}
+
+        tracker.update_progress(15, f"loaded {len(county_map)} county parents")
+        rows = load_tract_rows(TRACT_SHP, county_map)
+        tracker.update_progress(60, f"parsed {len(rows)} PA tract geometries")
+
+        with conn.cursor() as cur:
+            execute_values(cur, INSERT_SQL, rows, template=INSERT_TEMPLATE, page_size=500)
+        conn.commit()
+
+        tracker.complete(
+            row_count=len(rows),
+            summary_snapshot={
+                "dataset_slug": "tiger_pa_tract_2020",
+                "scope": "pennsylvania_tract_geometries",
+                "tract_rows": len(rows),
+                "source_path": str(TRACT_SHP),
+            },
+            log_line=f"pa_tracts={len(rows)}",
+        )
+        emit("complete", tract_rows=len(rows))
+    except Exception as exc:
+        tracker.fail(exc)
+        raise
+    finally:
+        conn.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gis/requirements.txt
+++ b/scripts/gis/requirements.txt
@@ -4,3 +4,4 @@ fiona>=1.9.0
 psycopg2-binary>=2.9.0
 requests>=2.31.0
 pandas>=2.0.0
+openpyxl>=3.1.0

--- a/templates/commercial/manifests/registry_to_omop_ncdr/README.md
+++ b/templates/commercial/manifests/registry_to_omop_ncdr/README.md
@@ -1,0 +1,62 @@
+# `registry_to_omop_ncdr`
+
+Phase 3 Plan 4C (T-022C). Commercial-tier template that ingests
+**ACC's National Cardiovascular Data Registry (NCDR) CathPCI v5.0**
+CSV exports and projects to OMOP CDM v5.4 PROCEDURE_OCCURRENCE +
+MEASUREMENT + DEVICE_EXPOSURE + CONDITION_OCCURRENCE + EPISODE.
+
+This is the **first commercial-tier template** to populate the OMOP
+DEVICE_EXPOSURE table — stent UDI codes resolve to standard Device
+concepts via the FDA UDI → SPL → RxNorm-Extension Device path.
+
+## License + access notes
+
+NCDR data is gated behind an **ACC NCDR Participant Agreement**
+between the customer and the American College of Cardiology.
+Parthenon does NOT redistribute NCDR data, fixtures, or column-spec
+excerpts beyond what the manifest test fixtures synthesize.
+
+## Spec version
+
+This template targets **NCDR CathPCI v5.0** column shapes. v4.4 is
+out of v0.1 scope — column-map deltas would be a Phase 4 follow-up.
+
+## Vocabulary prerequisites
+
+- `ICD10CM` (pre-op diagnoses)
+- `CPT4` / `HCPCS` (procedure codes)
+- `SNOMED` (target standard for procedures + conditions)
+- `LOINC` (hemodynamic measurements)
+- `FDA_UDI` (stent UDI source codes — required for DEVICE_EXPOSURE
+  resolution; unmapped UDIs emit `device_concept_id = 0` and preserve
+  the source UDI for downstream review)
+
+## UDI → Device concept lookup
+
+The mapping pipeline joins `fmt_ncdr_pci.stent_udis` against
+`vocab.concept` (`vocabulary_id = 'FDA_UDI'`) and follows
+`concept_relationship 'Maps to'` to a standard Device concept. UDIs
+not present in the vocabulary fall back to `device_concept_id = 0`
+with the source UDI preserved in `device_source_value`.
+
+## Stent UDI / type list invariant
+
+The reader requires `StentUDIs` and `StentTypes` to be parallel
+semicolon-delimited lists of equal length. The DB enforces the same
+via a `CHECK (cardinality(stent_udis) = cardinality(stent_types))`
+constraint on `fmt_ncdr_pci`.
+
+## Acceptance gates (validation E2E)
+
+- 100% of CSV rows produce typed NCDRRecords (or fail-closed on
+  parallel-list mismatch / invalid date / out-of-range field).
+- Every PCI with `stent_count > 0` produces ≥ stent_count
+  DEVICE_EXPOSURE rows.
+- Pre-op + postop conditions both populated.
+- One MEASUREMENT row per (patient, EF) and (patient, cardiac index).
+
+## See also
+
+- ADR 0017 — `registry_to_omop` strategy
+- `column_map.csv` — NCDR field → OMOP destination
+- Plan 4B (STS) — sister sub-template

--- a/templates/commercial/manifests/registry_to_omop_ncdr/column_map.csv
+++ b/templates/commercial/manifests/registry_to_omop_ncdr/column_map.csv
@@ -1,0 +1,22 @@
+ncdr_field,omop_table,omop_column,vocabulary_id,concept_lookup_rule,description
+PCIRecordID,fmt_ncdr_pci,record_id,,passthrough,Unique PCI procedure key
+PatientID,fmt_ncdr_pci,patient_id,,passthrough,De-identified patient identifier
+ProcedureDate,fmt_ncdr_pci,procedure_date,,passthrough,Date of cath/PCI (CCYYMMDD)
+PatientAge,fmt_ncdr_pci,patient_age,,passthrough,Age at procedure
+Gender,fmt_ncdr_pci,gender,,passthrough,M/F
+HospitalID,fmt_ncdr_pci,hospital_id,,passthrough,ACC NCDR-assigned site code
+OperatorNPI,fmt_ncdr_pci,operator_npi,,passthrough,Interventional cardiologist NPI
+PreOpDiagnosis,fmt_ncdr_pci,preop_diagnosis_icd10,ICD10CM,passthrough,Pre-procedure diagnosis (ACS / chronic CAD / etc.)
+HemodynamicEjectionFraction,fmt_ncdr_pci,ejection_fraction,LOINC,measurement_lookup,Pre-PCI EF (%)
+HemodynamicCardiacIndex,fmt_ncdr_pci,cardiac_index,LOINC,measurement_lookup,L/min/m2
+LesionCount,fmt_ncdr_pci,lesion_count,,passthrough,Number of lesions treated
+LesionSegments,fmt_ncdr_pci,lesion_segments,,delimited_list,SCAI lesion segment ids (semicolon-delimited)
+PrimaryProcedureCode,fmt_ncdr_pci,primary_procedure_code,CPT4,passthrough,CPT/HCPCS for the index PCI
+StentCount,fmt_ncdr_pci,stent_count,,passthrough,Total stents implanted
+StentUDIs,fmt_ncdr_pci,stent_udis,,delimited_list,FDA UDI codes (semicolon-delimited)
+StentTypes,fmt_ncdr_pci,stent_types,,delimited_list,DES/BMS per stent (semicolon-delimited)
+PostOpComplication_Bleeding,fmt_ncdr_pci,postop_bleeding,SNOMED,complication_lookup,Major bleeding (yes/no)
+PostOpComplication_AKI,fmt_ncdr_pci,postop_aki,SNOMED,complication_lookup,Contrast-induced AKI (yes/no)
+PostOpComplication_Stroke,fmt_ncdr_pci,postop_stroke,SNOMED,complication_lookup,Periprocedural stroke (yes/no)
+LengthOfStay,fmt_ncdr_pci,length_of_stay,,passthrough,Hospital LOS (days)
+Mortality_InHospital,fmt_ncdr_pci,mortality_in_hospital,,passthrough,In-hospital mortality (yes/no)

--- a/templates/commercial/manifests/registry_to_omop_ncdr/fixtures/synthetic/build_ncdr_corpus.py
+++ b/templates/commercial/manifests/registry_to_omop_ncdr/fixtures/synthetic/build_ncdr_corpus.py
@@ -1,0 +1,187 @@
+"""Synthetic NCDR CathPCI corpus builder — deterministic with seed=42.
+
+Phase 3 Plan 4C Task 6 (T-022C). 50-PCI corpus for the validation E2E.
+Mix:
+
+- 10 diagnostic-only caths (lesion_count=0, stent_count=0, empty UDI/type lists)
+- 30 single-stent PCIs
+- 10 multi-stent PCIs (2-3 stents each)
+- Stent type distribution: 70% DES, 20% BMS, 10% BVS
+- 20% of records carry at least one postop complication; 5% mortality
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import random
+from dataclasses import dataclass
+from typing import Final
+
+_PROCEDURE_CPTS: Final[list[str]] = ["92928", "92933", "92920", "92924"]
+_DIAGNOSES: Final[list[str]] = ["I21.4", "I25.10", "I20.0", "I22.9"]
+# Stent UDI prefix is 0871472... (publicly used for example UDIs);
+# we generate distinct trailing digits per stent.
+
+
+@dataclass(frozen=True)
+class _PCISpec:
+    seed_idx: int
+    record_id: str
+    patient_id: str
+    procedure_date: str
+    patient_age: int
+    gender: str
+    hospital_id: str
+    operator_npi: str
+    preop_diagnosis: str
+    ef: str
+    cardiac_index: str
+    lesion_count: int
+    lesion_segments: str
+    primary_cpt: str
+    stent_count: int
+    stent_udis: str
+    stent_types: str
+    bleeding: str
+    aki: str
+    stroke: str
+    los: int
+    mortality: str
+
+
+def _build_stents(n: int, rng: random.Random, seed_idx: int) -> tuple[str, str]:
+    """Returns (udis_str, types_str) — parallel ; -delimited lists."""
+    if n == 0:
+        return "", ""
+    types = []
+    udis = []
+    for k in range(n):
+        roll = rng.random()
+        if roll < 0.7:
+            stent_type = "DES"
+        elif roll < 0.9:
+            stent_type = "BMS"
+        else:
+            stent_type = "BVS"
+        types.append(stent_type)
+        # UDI: 14-digit numeric per FDA convention
+        udis.append(f"08714729{seed_idx:04d}{k:02d}")
+    return ";".join(udis), ";".join(types)
+
+
+def build_corpus(*, seed: int = 42, n_pcis: int = 50) -> str:
+    """Build a deterministic NCDR CathPCI CSV corpus."""
+    if n_pcis < 1:
+        raise ValueError(f"n_pcis must be >= 1; got {n_pcis}")
+
+    rng = random.Random(seed)
+    specs: list[_PCISpec] = []
+    for i in range(1, n_pcis + 1):
+        # Deterministic PCI-shape mix:
+        # i 1..10  -> diagnostic only
+        # i 11..40 -> single stent
+        # i 41..50 -> multi-stent
+        if i <= 10:
+            lesion_n, stent_n = 0, 0
+        elif i <= 40:
+            lesion_n, stent_n = 1, 1
+        else:
+            lesion_n = rng.randint(2, 3)
+            stent_n = lesion_n  # one stent per lesion in v0.1 fixture
+        udis, types = _build_stents(stent_n, rng, i)
+        lesion_segments = ";".join(str(s) for s in rng.sample(range(1, 17), k=lesion_n))
+        # Complications spread by mod-N + 5% mortality (mod-20)
+        bleeding = "yes" if i % 11 == 0 else "no"
+        aki = "yes" if i % 7 == 0 else "no"
+        stroke = "yes" if i % 13 == 0 else "no"
+        mortality = "yes" if i % 20 == 0 else "no"
+        specs.append(
+            _PCISpec(
+                seed_idx=i,
+                record_id=f"PCI-{i:05d}",
+                patient_id=f"PAT{i:05d}",
+                procedure_date=f"2024{((i - 1) % 12) + 1:02d}{((i - 1) % 28) + 1:02d}",
+                patient_age=50 + rng.randint(0, 35),
+                gender=rng.choice(("M", "F")),
+                hospital_id=f"H{(i % 10) + 1:03d}",
+                operator_npi="1234567893",  # public CMS test NPI; same on every row
+                preop_diagnosis=rng.choice(_DIAGNOSES),
+                ef=f"{30 + rng.randint(0, 40):.1f}",
+                cardiac_index=f"{2.0 + rng.uniform(0, 2):.2f}",
+                lesion_count=lesion_n,
+                lesion_segments=lesion_segments,
+                primary_cpt=rng.choice(_PROCEDURE_CPTS),
+                stent_count=stent_n,
+                stent_udis=udis,
+                stent_types=types,
+                bleeding=bleeding,
+                aki=aki,
+                stroke=stroke,
+                los=1 + rng.randint(0, 6),
+                mortality=mortality,
+            )
+        )
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(
+        [
+            "PCIRecordID",
+            "PatientID",
+            "ProcedureDate",
+            "PatientAge",
+            "Gender",
+            "HospitalID",
+            "OperatorNPI",
+            "PreOpDiagnosis",
+            "HemodynamicEjectionFraction",
+            "HemodynamicCardiacIndex",
+            "LesionCount",
+            "LesionSegments",
+            "PrimaryProcedureCode",
+            "StentCount",
+            "StentUDIs",
+            "StentTypes",
+            "PostOpComplication_Bleeding",
+            "PostOpComplication_AKI",
+            "PostOpComplication_Stroke",
+            "LengthOfStay",
+            "Mortality_InHospital",
+        ]
+    )
+    for s in specs:
+        writer.writerow(
+            [
+                s.record_id,
+                s.patient_id,
+                s.procedure_date,
+                str(s.patient_age),
+                s.gender,
+                s.hospital_id,
+                s.operator_npi,
+                s.preop_diagnosis,
+                s.ef,
+                s.cardiac_index,
+                str(s.lesion_count),
+                s.lesion_segments,
+                s.primary_cpt,
+                str(s.stent_count),
+                s.stent_udis,
+                s.stent_types,
+                s.bleeding,
+                s.aki,
+                s.stroke,
+                str(s.los),
+                s.mortality,
+            ]
+        )
+
+    return buf.getvalue()
+
+
+__all__ = ["build_corpus"]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(build_corpus(seed=42, n_pcis=50))

--- a/templates/commercial/manifests/registry_to_omop_ncdr/manifest.yaml
+++ b/templates/commercial/manifests/registry_to_omop_ncdr/manifest.yaml
@@ -1,0 +1,115 @@
+apiVersion: parthenon.acumenus.net/v1
+kind: Template
+metadata:
+  id: registry_to_omop_ncdr
+  name: NCDR CathPCI v5.0 → OMOP CDM v5.4
+  version: "0.1.0"
+  category: ingestion
+  tier: commercial
+  cdm_versions: ["5.4"]
+  tags: ["registry", "ncdr", "cardiology", "pci", "omop", "etl", "phase-3", "commercial"]
+  author: "Acumenus Data Sciences"
+  description: |
+    Phase 3 Plan 4C (T-022C). Reads NCDR CathPCI v5.0 CSV exports and
+    projects to OMOP PROCEDURE_OCCURRENCE + MEASUREMENT + DEVICE_EXPOSURE
+    + CONDITION_OCCURRENCE + EPISODE. First commercial-tier template to
+    populate DEVICE_EXPOSURE (FDA UDI -> standard Device concept).
+
+    License: NCDR exports require an ACC NCDR Participant Agreement.
+    Parthenon does not redistribute.
+
+    Closes T-022 (registry_to_omop) — third sub-template after Plans 4A
+    (NAACCR) and 4B (STS).
+spec:
+  parameters:
+    type: object
+    properties:
+      ncdr_csv:
+        type: string
+        description: Path to the NCDR CathPCI CSV export.
+      source_schema:
+        type: string
+        default: ncdr_source
+      cdm_schema:
+        type: string
+        default: ncdr_cdm
+      vocab_schema:
+        type: string
+        default: vocab
+      app_schema:
+        type: string
+        default: app
+      run_id:
+        type: string
+        default: "00000000-0000-0000-0000-000000000000"
+    required: ["ncdr_csv"]
+  requires:
+    cdm_initialized: false
+    vocabularies: ["ICD10CM", "CPT4", "HCPCS", "SNOMED", "LOINC", "FDA_UDI"]
+  nodes:
+    - node_id: bootstrap_source
+      type: sql
+      params:
+        statements: ["SELECT 1"]
+        sql_file: file://sql/00_bootstrap_ncdr_source.sql
+
+    - node_id: load_ncdr
+      type: sql
+      depends_on: [bootstrap_source]
+      params:
+        statements: ["SELECT 1"]
+        sql_file: file://sql/01_load_ncdr_csv.sql
+
+    - node_id: map_procedure_occurrence
+      type: sql
+      depends_on: [load_ncdr]
+      params:
+        statements: ["SELECT 1"]
+        sql_file: file://sql/02a_map_procedure_occurrence.sql
+
+    - node_id: map_measurement
+      type: sql
+      depends_on: [load_ncdr]
+      params:
+        statements: ["SELECT 1"]
+        sql_file: file://sql/02b_map_measurement.sql
+
+    - node_id: map_device_exposure
+      type: sql
+      depends_on: [load_ncdr]
+      params:
+        statements: ["SELECT 1"]
+        sql_file: file://sql/02c_map_device_exposure.sql
+
+    - node_id: map_condition_occurrence
+      type: sql
+      depends_on: [load_ncdr]
+      params:
+        statements: ["SELECT 1"]
+        sql_file: file://sql/02d_map_condition_occurrence.sql
+
+    - node_id: map_episode
+      type: sql
+      depends_on: [load_ncdr, map_procedure_occurrence]
+      params:
+        statements: ["SELECT 1"]
+        sql_file: file://sql/02e_map_episode.sql
+
+    - node_id: summarize
+      type: sql
+      depends_on:
+        - map_procedure_occurrence
+        - map_measurement
+        - map_device_exposure
+        - map_condition_occurrence
+        - map_episode
+      params:
+        statements: ["SELECT 1"]
+        fetch_query_file: file://sql/03_summarize.sql
+        result_artifact: registry_to_omop_ncdr_summary
+
+  post_conditions:
+    - kind: artifact_present
+      params:
+        artifact: registry_to_omop_ncdr_summary.json
+        min_rows: 1

--- a/templates/commercial/manifests/registry_to_omop_ncdr/sql/00_bootstrap_ncdr_source.sql
+++ b/templates/commercial/manifests/registry_to_omop_ncdr/sql/00_bootstrap_ncdr_source.sql
@@ -1,0 +1,36 @@
+-- Phase 3 Plan 4C Task 4 (T-022C): bootstrap fmt_ncdr_pci source table.
+
+CREATE SCHEMA IF NOT EXISTS ${parameters.source_schema};
+
+CREATE TABLE IF NOT EXISTS ${parameters.source_schema}.fmt_ncdr_pci (
+    id BIGSERIAL PRIMARY KEY,
+    record_id VARCHAR(40) NOT NULL,
+    patient_id VARCHAR(40) NOT NULL,
+    procedure_date DATE NOT NULL,
+    patient_age INT NOT NULL CHECK (patient_age BETWEEN 0 AND 120),
+    gender CHAR(1) NOT NULL CHECK (gender IN ('M', 'F', 'U')),
+    hospital_id VARCHAR(40) NOT NULL,
+    operator_npi CHAR(10) NOT NULL,
+    preop_diagnosis_icd10 VARCHAR(10) NOT NULL,
+    ejection_fraction NUMERIC(5, 2) NOT NULL CHECK (ejection_fraction BETWEEN 0 AND 100),
+    cardiac_index NUMERIC(5, 2) NOT NULL CHECK (cardiac_index BETWEEN 0 AND 10),
+    lesion_count INT NOT NULL CHECK (lesion_count >= 0),
+    lesion_segments TEXT[],
+    primary_procedure_code VARCHAR(10) NOT NULL,
+    stent_count INT NOT NULL CHECK (stent_count >= 0),
+    stent_udis TEXT[],
+    stent_types TEXT[],
+    postop_bleeding BOOLEAN NOT NULL DEFAULT FALSE,
+    postop_aki BOOLEAN NOT NULL DEFAULT FALSE,
+    postop_stroke BOOLEAN NOT NULL DEFAULT FALSE,
+    length_of_stay INT NOT NULL CHECK (length_of_stay >= 0),
+    mortality_in_hospital BOOLEAN NOT NULL DEFAULT FALSE,
+    source_file VARCHAR(512),
+    loaded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (record_id),
+    -- Reader enforces this; the DB also enforces so a bad direct INSERT fails.
+    CHECK (cardinality(stent_udis) = cardinality(stent_types))
+);
+
+CREATE INDEX IF NOT EXISTS ix_fmt_ncdr_pci_date
+    ON ${parameters.source_schema}.fmt_ncdr_pci (procedure_date);

--- a/templates/commercial/manifests/registry_to_omop_ncdr/sql/01_load_ncdr_csv.sql
+++ b/templates/commercial/manifests/registry_to_omop_ncdr/sql/01_load_ncdr_csv.sql
@@ -1,0 +1,12 @@
+-- Phase 3 Plan 4C Task 4: COPY NCDR CSV into fmt_ncdr_pci.
+
+COPY ${parameters.source_schema}.fmt_ncdr_pci (
+    record_id, patient_id, procedure_date, patient_age, gender,
+    hospital_id, operator_npi, preop_diagnosis_icd10,
+    ejection_fraction, cardiac_index, lesion_count, lesion_segments,
+    primary_procedure_code, stent_count, stent_udis, stent_types,
+    postop_bleeding, postop_aki, postop_stroke,
+    length_of_stay, mortality_in_hospital, source_file
+)
+FROM '${parameters.ncdr_csv}'
+WITH (FORMAT csv, HEADER true, NULL '');

--- a/templates/commercial/manifests/registry_to_omop_ncdr/sql/02a_map_procedure_occurrence.sql
+++ b/templates/commercial/manifests/registry_to_omop_ncdr/sql/02a_map_procedure_occurrence.sql
@@ -1,0 +1,29 @@
+-- Phase 3 Plan 4C Task 4 (T-022C): NCDR -> PROCEDURE_OCCURRENCE.
+-- One row per primary procedure. NCDR doesn't carry secondary CPT codes
+-- separately (lesion-level granularity is captured in lesion_segments
+-- and stent-level granularity in stent_udis); the primary CPT covers
+-- the index PCI.
+
+INSERT INTO ${parameters.cdm_schema}.procedure_occurrence (
+    person_id,
+    procedure_concept_id,
+    procedure_date,
+    procedure_type_concept_id,
+    procedure_source_value,
+    procedure_source_concept_id
+)
+SELECT
+    abs(hashtext(p.patient_id)) AS person_id,
+    COALESCE(snomed.concept_id, 0) AS procedure_concept_id,
+    p.procedure_date AS procedure_date,
+    32861 AS procedure_type_concept_id,  -- 'Registry-derived procedure'
+    p.primary_procedure_code AS procedure_source_value,
+    cpt.concept_id AS procedure_source_concept_id
+FROM ${parameters.source_schema}.fmt_ncdr_pci p
+LEFT JOIN ${parameters.vocab_schema}.concept cpt
+    ON cpt.concept_code = p.primary_procedure_code
+       AND cpt.vocabulary_id IN ('CPT4', 'HCPCS')
+LEFT JOIN ${parameters.vocab_schema}.concept_relationship cr
+    ON cr.concept_id_1 = cpt.concept_id AND cr.relationship_id = 'Maps to'
+LEFT JOIN ${parameters.vocab_schema}.concept snomed
+    ON snomed.concept_id = cr.concept_id_2 AND snomed.standard_concept = 'S';

--- a/templates/commercial/manifests/registry_to_omop_ncdr/sql/02b_map_measurement.sql
+++ b/templates/commercial/manifests/registry_to_omop_ncdr/sql/02b_map_measurement.sql
@@ -1,0 +1,40 @@
+-- Phase 3 Plan 4C Task 4 (T-022C): NCDR hemodynamics -> MEASUREMENT.
+-- EF + cardiac index are pre-procedure measurements; one row per
+-- value per patient. measurement_date = procedure_date - 1 hour
+-- approximation; v0.1 uses procedure_date (no time component on the
+-- export). LOINC concept ids:
+--   3015241 = Cardiac index
+--   3027018 = Heart rate (informational; not in v0.1 column-map)
+--   3038553 = Body weight (not in v0.1)
+-- For EF we use SNOMED Standard 3027496 (Left ventricular ejection
+-- fraction) per OMOP convention.
+
+INSERT INTO ${parameters.cdm_schema}.measurement (
+    person_id,
+    measurement_concept_id,
+    measurement_date,
+    measurement_type_concept_id,
+    value_as_number,
+    measurement_source_value
+)
+-- LVEF
+SELECT
+    abs(hashtext(p.patient_id)),
+    3027496 AS measurement_concept_id,
+    p.procedure_date,
+    32861 AS measurement_type_concept_id,
+    p.ejection_fraction AS value_as_number,
+    'NCDR:HemodynamicEjectionFraction' AS measurement_source_value
+FROM ${parameters.source_schema}.fmt_ncdr_pci p
+
+UNION ALL
+
+-- Cardiac index
+SELECT
+    abs(hashtext(p.patient_id)),
+    3015241 AS measurement_concept_id,
+    p.procedure_date,
+    32861 AS measurement_type_concept_id,
+    p.cardiac_index AS value_as_number,
+    'NCDR:HemodynamicCardiacIndex' AS measurement_source_value
+FROM ${parameters.source_schema}.fmt_ncdr_pci p;

--- a/templates/commercial/manifests/registry_to_omop_ncdr/sql/02c_map_device_exposure.sql
+++ b/templates/commercial/manifests/registry_to_omop_ncdr/sql/02c_map_device_exposure.sql
@@ -1,0 +1,34 @@
+-- Phase 3 Plan 4C Task 4 (T-022C): NCDR stents -> DEVICE_EXPOSURE.
+-- Plan 4C is the first commercial-tier template to populate the OMOP
+-- DEVICE_EXPOSURE table (PROCEDURE_OCCURRENCE + COST were the wedges
+-- for T-021; DEVICE_EXPOSURE is the wedge for cardiology).
+--
+-- One row per stent in stent_udis. The UDI maps to an OMOP Device
+-- concept via the FDA UDI -> SPL -> RxNorm-Extension Device path
+-- (vocabulary_id = 'FDA_UDI'). For UDIs that don't resolve, we emit
+-- device_concept_id=0 and preserve the source UDI in
+-- device_source_value for downstream review.
+
+INSERT INTO ${parameters.cdm_schema}.device_exposure (
+    person_id,
+    device_concept_id,
+    device_exposure_start_date,
+    device_type_concept_id,
+    device_source_value,
+    device_source_concept_id
+)
+SELECT
+    abs(hashtext(p.patient_id)) AS person_id,
+    COALESCE(dev.concept_id, 0) AS device_concept_id,
+    p.procedure_date AS device_exposure_start_date,
+    32861 AS device_type_concept_id,  -- 'Registry-derived'
+    udi AS device_source_value,
+    udi_src.concept_id AS device_source_concept_id
+FROM ${parameters.source_schema}.fmt_ncdr_pci p
+CROSS JOIN LATERAL unnest(COALESCE(p.stent_udis, ARRAY[]::TEXT[])) AS udi
+LEFT JOIN ${parameters.vocab_schema}.concept udi_src
+    ON udi_src.concept_code = udi AND udi_src.vocabulary_id = 'FDA_UDI'
+LEFT JOIN ${parameters.vocab_schema}.concept_relationship cr
+    ON cr.concept_id_1 = udi_src.concept_id AND cr.relationship_id = 'Maps to'
+LEFT JOIN ${parameters.vocab_schema}.concept dev
+    ON dev.concept_id = cr.concept_id_2 AND dev.standard_concept = 'S';

--- a/templates/commercial/manifests/registry_to_omop_ncdr/sql/02d_map_condition_occurrence.sql
+++ b/templates/commercial/manifests/registry_to_omop_ncdr/sql/02d_map_condition_occurrence.sql
@@ -1,0 +1,44 @@
+-- Phase 3 Plan 4C Task 4 (T-022C): NCDR -> CONDITION_OCCURRENCE.
+-- Two passes: pre-op diagnosis (single ICD-10) + postop complications
+-- (booleans -> SNOMED).
+
+-- Pass 1: pre-op
+INSERT INTO ${parameters.cdm_schema}.condition_occurrence (
+    person_id,
+    condition_concept_id,
+    condition_start_date,
+    condition_type_concept_id,
+    condition_source_value,
+    condition_source_concept_id
+)
+SELECT
+    abs(hashtext(p.patient_id)),
+    COALESCE(snomed.concept_id, 0),
+    p.procedure_date,  -- pre-op condition; same-day for index PCI
+    32865,  -- 'Pre-op condition (registry)'
+    p.preop_diagnosis_icd10,
+    icd.concept_id
+FROM ${parameters.source_schema}.fmt_ncdr_pci p
+LEFT JOIN ${parameters.vocab_schema}.concept icd
+    ON icd.concept_code = p.preop_diagnosis_icd10 AND icd.vocabulary_id = 'ICD10CM'
+LEFT JOIN ${parameters.vocab_schema}.concept_relationship cr
+    ON cr.concept_id_1 = icd.concept_id AND cr.relationship_id = 'Maps to'
+LEFT JOIN ${parameters.vocab_schema}.concept snomed
+    ON snomed.concept_id = cr.concept_id_2 AND snomed.standard_concept = 'S';
+
+-- Pass 2: postop complications (one INSERT per TRUE flag)
+INSERT INTO ${parameters.cdm_schema}.condition_occurrence (
+    person_id,
+    condition_concept_id,
+    condition_start_date,
+    condition_type_concept_id,
+    condition_source_value
+)
+SELECT abs(hashtext(p.patient_id)), 432254, p.procedure_date, 32865, 'NCDR:postop_bleeding'
+FROM ${parameters.source_schema}.fmt_ncdr_pci p WHERE p.postop_bleeding = TRUE
+UNION ALL
+SELECT abs(hashtext(p.patient_id)), 4126706, p.procedure_date, 32865, 'NCDR:postop_aki'
+FROM ${parameters.source_schema}.fmt_ncdr_pci p WHERE p.postop_aki = TRUE
+UNION ALL
+SELECT abs(hashtext(p.patient_id)), 4007650, p.procedure_date, 32865, 'NCDR:postop_stroke'
+FROM ${parameters.source_schema}.fmt_ncdr_pci p WHERE p.postop_stroke = TRUE;

--- a/templates/commercial/manifests/registry_to_omop_ncdr/sql/02e_map_episode.sql
+++ b/templates/commercial/manifests/registry_to_omop_ncdr/sql/02e_map_episode.sql
@@ -1,0 +1,20 @@
+-- Phase 3 Plan 4C Task 4 (T-022C): NCDR -> EPISODE.
+-- One Procedure-Anchored Episode per PCI. episode_source_value carries
+-- canonical procedure code only (no PHI per HIGHSEC §7).
+
+INSERT INTO ${parameters.cdm_schema}.episode (
+    person_id,
+    episode_concept_id,
+    episode_start_date,
+    episode_end_date,
+    episode_type_concept_id,
+    episode_source_value
+)
+SELECT
+    abs(hashtext(p.patient_id)) AS person_id,
+    32873 AS episode_concept_id,  -- 'Procedure-Anchored Episode'
+    p.procedure_date AS episode_start_date,
+    p.procedure_date + (p.length_of_stay || ' days')::INTERVAL AS episode_end_date,
+    32861 AS episode_type_concept_id,
+    ('PCI:' || p.primary_procedure_code) AS episode_source_value
+FROM ${parameters.source_schema}.fmt_ncdr_pci p;

--- a/templates/commercial/manifests/registry_to_omop_ncdr/sql/03_summarize.sql
+++ b/templates/commercial/manifests/registry_to_omop_ncdr/sql/03_summarize.sql
@@ -1,0 +1,13 @@
+-- Phase 3 Plan 4C Task 7 (T-022C): summary post-condition artifact.
+
+SELECT
+    (SELECT COUNT(*) FROM ${parameters.source_schema}.fmt_ncdr_pci) AS ncdr_records,
+    (SELECT COUNT(*) FROM ${parameters.cdm_schema}.procedure_occurrence) AS procedure_occurrence_rows,
+    (SELECT COUNT(*) FROM ${parameters.cdm_schema}.measurement) AS measurement_rows,
+    (SELECT COUNT(*) FROM ${parameters.cdm_schema}.device_exposure) AS device_exposure_rows,
+    (SELECT COUNT(*) FROM ${parameters.cdm_schema}.condition_occurrence) AS condition_occurrence_rows,
+    (SELECT COUNT(*) FROM ${parameters.cdm_schema}.episode) AS episode_rows,
+    (SELECT COUNT(*) FROM ${parameters.cdm_schema}.procedure_occurrence WHERE procedure_concept_id = 0)
+        AS unmapped_procedure_rows,
+    (SELECT COUNT(*) FROM ${parameters.cdm_schema}.device_exposure WHERE device_concept_id = 0)
+        AS unmapped_device_rows;

--- a/templates/commercial/runtime/commercial/registry/ncdr/__init__.py
+++ b/templates/commercial/runtime/commercial/registry/ncdr/__init__.py
@@ -1,0 +1,18 @@
+"""NCDR CathPCI v5.0 ETL — Phase 3 Plan 4C (T-022C).
+
+Projects ACC's National Cardiovascular Data Registry CathPCI v5.0
+exports to OMOP CDM v5.4 PROCEDURE_OCCURRENCE + MEASUREMENT (cath
+findings) + CONDITION_OCCURRENCE + DEVICE_EXPOSURE (stent UDIs) +
+EPISODE.
+
+License: NCDR exports require an ACC NCDR Participant Agreement
+between the customer and the American College of Cardiology. Same
+shape as STS — Parthenon does not redistribute.
+
+Distinct from Plan 4B (STS): NCDR carries one-to-many lesion + stent
+records per PCI, projected to multiple DEVICE_EXPOSURE rows. UDI
+codes resolve to OMOP Device concepts via the standard FDA UDI →
+SPL → RxNorm-Extension Device path.
+"""
+
+from __future__ import annotations

--- a/templates/commercial/runtime/commercial/registry/ncdr/reader.py
+++ b/templates/commercial/runtime/commercial/registry/ncdr/reader.py
@@ -1,0 +1,149 @@
+"""NCDR CathPCI CSV reader — materializes ``NCDRRecord`` per PCI procedure.
+
+Phase 3 Plan 4C Task 3 (T-022C). Same general shape as the STS reader
+(Plan 4B) — CSV with header, semicolon-delimited list columns for the
+lesion + stent fans. PHI handling mirrors Plans 1-3 + 4A + 4B.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import re
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from typing import TextIO
+
+from pydantic import ValidationError
+
+from runtime.commercial.registry.ncdr.types import NCDRRecord
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class NCDRReadError(ValueError):
+    """Raised when an NCDR CSV row cannot be parsed.
+
+    Sanitized per HIGHSEC §7 — patient_id, procedure_date, operator_npi
+    MUST never appear in error messages.
+    """
+
+
+class _RedactingFilter(logging.Filter):
+    _ID_TOKEN = re.compile(r"\b[A-Z0-9]{6,15}\b")
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            msg = record.getMessage()
+        except Exception:  # pragma: no cover - defensive
+            return True
+        record.msg = self._ID_TOKEN.sub("***REDACTED***", msg)
+        record.args = ()
+        return True
+
+
+def _parse_date(value: str) -> object:
+    value = (value or "").strip()
+    if len(value) != 8 or not value.isdigit():
+        raise NCDRReadError("invalid NCDR date")
+    try:
+        return datetime.strptime(value, "%Y%m%d").date()
+    except ValueError as exc:
+        raise NCDRReadError("unparseable NCDR date") from exc
+
+
+def _parse_int(value: str, *, name: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise NCDRReadError(f"non-integer NCDR field {name}") from exc
+
+
+def _parse_decimal(value: str, *, name: str) -> Decimal:
+    try:
+        return Decimal(value)
+    except (InvalidOperation, ValueError) as exc:
+        raise NCDRReadError(f"non-numeric NCDR field {name}") from exc
+
+
+def _parse_bool(value: str) -> bool:
+    s = (value or "").strip().lower()
+    if s in {"yes", "y", "1", "true"}:
+        return True
+    if s in {"no", "n", "0", "false", ""}:
+        return False
+    raise NCDRReadError(f"unparseable NCDR boolean: {value!r}")
+
+
+def _parse_delimited(value: str) -> list[str]:
+    if not value:
+        return []
+    return [v.strip() for v in value.split(";") if v.strip()]
+
+
+class NCDRReader:
+    """Read an NCDR CathPCI CSV export."""
+
+    type_name = "ncdr_reader"
+
+    def __init__(self) -> None:
+        self._filter = _RedactingFilter()
+        if not any(isinstance(f, _RedactingFilter) for f in _LOGGER.filters):
+            _LOGGER.addFilter(self._filter)
+
+    def read(self, source: TextIO) -> list[NCDRRecord]:
+        reader = csv.DictReader(source)
+        if reader.fieldnames is None:
+            raise NCDRReadError("NCDR CSV is missing the header row")
+
+        out: list[NCDRRecord] = []
+        for row in reader:
+            try:
+                out.append(self._materialize(row))
+            except NCDRReadError:
+                raise
+            except ValidationError as exc:
+                raise NCDRReadError("NCDR record validation failed") from exc
+        return out
+
+    def _materialize(self, row: dict[str, str]) -> NCDRRecord:
+        # Stent UDIs and stent types must align in length when both
+        # populated — the column-map convention treats them as parallel
+        # lists.
+        udis = _parse_delimited(row.get("StentUDIs", ""))
+        types_raw = _parse_delimited(row.get("StentTypes", ""))
+        if udis and types_raw and len(udis) != len(types_raw):
+            raise NCDRReadError(
+                f"stent UDI / type list length mismatch: {len(udis)} vs {len(types_raw)}"
+            )
+
+        return NCDRRecord(
+            record_id=row["PCIRecordID"].strip(),
+            patient_id=row["PatientID"].strip(),
+            procedure_date=_parse_date(row["ProcedureDate"]),  # type: ignore[arg-type]
+            patient_age=_parse_int(row["PatientAge"], name="PatientAge"),
+            gender=row["Gender"].strip(),  # type: ignore[arg-type]
+            hospital_id=row["HospitalID"].strip(),
+            operator_npi=row["OperatorNPI"].strip(),
+            preop_diagnosis_icd10=row["PreOpDiagnosis"].strip(),
+            ejection_fraction=_parse_decimal(
+                row["HemodynamicEjectionFraction"], name="HemodynamicEjectionFraction"
+            ),
+            cardiac_index=_parse_decimal(
+                row["HemodynamicCardiacIndex"], name="HemodynamicCardiacIndex"
+            ),
+            lesion_count=_parse_int(row["LesionCount"], name="LesionCount"),
+            lesion_segments=_parse_delimited(row.get("LesionSegments", "")),
+            primary_procedure_code=row["PrimaryProcedureCode"].strip(),
+            stent_count=_parse_int(row["StentCount"], name="StentCount"),
+            stent_udis=udis,
+            stent_types=types_raw,  # type: ignore[arg-type]
+            postop_bleeding=_parse_bool(row.get("PostOpComplication_Bleeding", "")),
+            postop_aki=_parse_bool(row.get("PostOpComplication_AKI", "")),
+            postop_stroke=_parse_bool(row.get("PostOpComplication_Stroke", "")),
+            length_of_stay=_parse_int(row["LengthOfStay"], name="LengthOfStay"),
+            mortality_in_hospital=_parse_bool(row.get("Mortality_InHospital", "")),
+        )
+
+
+__all__ = ["NCDRReadError", "NCDRReader"]

--- a/templates/commercial/runtime/commercial/registry/ncdr/types.py
+++ b/templates/commercial/runtime/commercial/registry/ncdr/types.py
@@ -1,0 +1,64 @@
+"""NCDR CathPCI v5.0 typed Pydantic model.
+
+Phase 3 Plan 4C Task 2 (T-022C). One PCI procedure per row, with
+nested lesion + stent lists. The CathPCI v5.0 spec defines ~150 data
+items; we curate the subset that drives PROCEDURE_OCCURRENCE +
+MEASUREMENT + DEVICE_EXPOSURE + CONDITION_OCCURRENCE + EPISODE
+projection.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Stent type per ACC Definitions: DES = drug-eluting, BMS = bare-metal,
+# BVS = bioresorbable vascular scaffold (rare in v5.0 but accepted).
+StentType = Literal["DES", "BMS", "BVS"]
+
+
+class NCDRRecord(BaseModel):
+    """One CathPCI procedure record."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    # Identity
+    record_id: str = Field(min_length=1)
+    patient_id: str = Field(min_length=1)
+    procedure_date: date
+
+    # Demographics + setting
+    patient_age: int = Field(ge=0, le=120)
+    gender: Literal["M", "F", "U"]
+    hospital_id: str
+    operator_npi: str = Field(min_length=10, max_length=10)
+
+    # Pre-op
+    preop_diagnosis_icd10: str
+    ejection_fraction: Decimal = Field(ge=0, le=100)
+    cardiac_index: Decimal = Field(ge=0, le=10)
+
+    # Procedure
+    lesion_count: int = Field(ge=0)
+    lesion_segments: list[str] = Field(default_factory=list)
+    primary_procedure_code: str = Field(min_length=1)
+
+    # Devices
+    stent_count: int = Field(ge=0)
+    stent_udis: list[str] = Field(default_factory=list)
+    stent_types: list[StentType] = Field(default_factory=list)
+
+    # Postop complications
+    postop_bleeding: bool = False
+    postop_aki: bool = False
+    postop_stroke: bool = False
+
+    # Outcome
+    length_of_stay: int = Field(ge=0)
+    mortality_in_hospital: bool = False
+
+
+__all__ = ["NCDRRecord", "StentType"]

--- a/templates/tests/e2e/commercial/test_registry_to_omop_ncdr.py
+++ b/templates/tests/e2e/commercial/test_registry_to_omop_ncdr.py
@@ -1,0 +1,64 @@
+"""Phase 3 Plan 4C Task 7 (T-022C): registry_to_omop_ncdr validation E2E."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+from runtime.commercial.registry.ncdr.reader import NCDRReader
+
+_REPO = Path(__file__).resolve().parents[3]
+_FIXTURE_DIR = (
+    _REPO / "commercial" / "manifests" / "registry_to_omop_ncdr" / "fixtures" / "synthetic"
+)
+
+
+def _load_builder():  # type: ignore[no-untyped-def]
+    spec = importlib.util.spec_from_file_location(
+        "build_ncdr_corpus", _FIXTURE_DIR / "build_ncdr_corpus.py"
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["build_ncdr_corpus"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.slow
+def test_ncdr_e2e_meets_acceptance_gates() -> None:
+    builder = _load_builder()
+    csv_payload: str = builder.build_corpus(seed=42, n_pcis=50)  # type: ignore[attr-defined]
+    records = NCDRReader().read(io.StringIO(csv_payload))
+
+    # Gate 1: 50 in / 50 out
+    assert len(records) == 50
+
+    # Gate 2: every stent_count > 0 record has matching UDI/type lists.
+    for r in records:
+        assert len(r.stent_udis) == r.stent_count
+        assert len(r.stent_types) == r.stent_count
+
+    # Gate 3: total stent count >= 30 (single-stent block) + 20 (multi-
+    # stent at 2-3 each) = expected ~50-60 stents on the fixture.
+    total_stents = sum(r.stent_count for r in records)
+    assert 50 <= total_stents <= 70
+
+    # Gate 4: stent type distribution mostly DES (the realistic clinical
+    # mix). With seed=42, expect >50% DES across all stents.
+    all_types = [t for r in records for t in r.stent_types]
+    if all_types:  # skip for diagnostic-only corpora
+        des_pct = sum(1 for t in all_types if t == "DES") / len(all_types)
+        assert des_pct >= 0.5
+
+
+@pytest.mark.slow
+def test_ncdr_e2e_idempotent_on_replay() -> None:
+    builder = _load_builder()
+    csv_payload: str = builder.build_corpus(seed=42, n_pcis=50)  # type: ignore[attr-defined]
+    a = NCDRReader().read(io.StringIO(csv_payload))
+    b = NCDRReader().read(io.StringIO(csv_payload))
+    assert a == b

--- a/templates/tests/unit/commercial/registry/test_ncdr_column_map.py
+++ b/templates/tests/unit/commercial/registry/test_ncdr_column_map.py
@@ -1,0 +1,57 @@
+"""Phase 3 Plan 4C Task 1 (T-022C): NCDR CathPCI column-mapping table."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+_MAP_FILE = (
+    Path(__file__).resolve().parents[4]
+    / "commercial"
+    / "manifests"
+    / "registry_to_omop_ncdr"
+    / "column_map.csv"
+)
+
+
+def test_column_map_exists() -> None:
+    assert _MAP_FILE.is_file()
+
+
+def test_column_map_has_required_columns() -> None:
+    with _MAP_FILE.open("r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        cols = set(reader.fieldnames or [])
+    expected = {
+        "ncdr_field",
+        "omop_table",
+        "omop_column",
+        "vocabulary_id",
+        "concept_lookup_rule",
+        "description",
+    }
+    assert expected <= cols
+
+
+def test_column_map_covers_required_fields() -> None:
+    with _MAP_FILE.open("r", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    fields = {r["ncdr_field"] for r in rows}
+    for required in (
+        "PCIRecordID",
+        "ProcedureDate",
+        "OperatorNPI",
+        "PrimaryProcedureCode",
+        "StentUDIs",
+        "StentTypes",
+        "Mortality_InHospital",
+    ):
+        assert required in fields, f"missing column-map row for {required}"
+
+
+def test_column_map_uses_known_vocabularies() -> None:
+    with _MAP_FILE.open("r", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    allowed = {"", "SNOMED", "ICD10CM", "CPT4", "HCPCS", "RxNorm", "LOINC"}
+    for r in rows:
+        assert r["vocabulary_id"] in allowed

--- a/templates/tests/unit/commercial/registry/test_ncdr_fixtures.py
+++ b/templates/tests/unit/commercial/registry/test_ncdr_fixtures.py
@@ -1,0 +1,83 @@
+"""Phase 3 Plan 4C Task 6 (T-022C): synthetic NCDR corpus fixture."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+from runtime.commercial.registry.ncdr.reader import NCDRReader
+
+_FIXTURE_DIR = (
+    Path(__file__).resolve().parents[4]
+    / "commercial"
+    / "manifests"
+    / "registry_to_omop_ncdr"
+    / "fixtures"
+    / "synthetic"
+)
+
+
+def _load_builder() -> object:
+    spec = importlib.util.spec_from_file_location(
+        "build_ncdr_corpus", _FIXTURE_DIR / "build_ncdr_corpus.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["build_ncdr_corpus"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fixture_exists() -> None:
+    assert (_FIXTURE_DIR / "build_ncdr_corpus.py").is_file()
+
+
+def test_build_corpus_is_deterministic() -> None:
+    builder = _load_builder()
+    a = builder.build_corpus(seed=42, n_pcis=10)  # type: ignore[attr-defined]
+    b = builder.build_corpus(seed=42, n_pcis=10)  # type: ignore[attr-defined]
+    assert a == b
+
+
+def test_corpus_yields_n_records() -> None:
+    builder = _load_builder()
+    csv_payload: str = builder.build_corpus(seed=42, n_pcis=50)  # type: ignore[attr-defined]
+    records = NCDRReader().read(io.StringIO(csv_payload))
+    assert len(records) == 50
+
+
+def test_corpus_pci_shape_mix() -> None:
+    """Plan-driven mix: 10 diagnostic-only / 30 single-stent / 10 multi-stent."""
+    builder = _load_builder()
+    csv_payload: str = builder.build_corpus(seed=42, n_pcis=50)  # type: ignore[attr-defined]
+    records = NCDRReader().read(io.StringIO(csv_payload))
+
+    diag_only = sum(1 for r in records if r.lesion_count == 0 and r.stent_count == 0)
+    single_stent = sum(1 for r in records if r.lesion_count == 1 and r.stent_count == 1)
+    multi_stent = sum(1 for r in records if r.stent_count >= 2)
+
+    assert diag_only == 10
+    assert single_stent == 30
+    assert multi_stent == 10
+
+
+def test_corpus_stent_udi_type_lists_align() -> None:
+    builder = _load_builder()
+    csv_payload: str = builder.build_corpus(seed=42, n_pcis=50)  # type: ignore[attr-defined]
+    records = NCDRReader().read(io.StringIO(csv_payload))
+    for r in records:
+        assert len(r.stent_udis) == len(r.stent_types) == r.stent_count
+
+
+def test_corpus_includes_complications_and_mortality() -> None:
+    builder = _load_builder()
+    csv_payload: str = builder.build_corpus(seed=42, n_pcis=50)  # type: ignore[attr-defined]
+    records = NCDRReader().read(io.StringIO(csv_payload))
+    aki = sum(1 for r in records if r.postop_aki)
+    mortality = sum(1 for r in records if r.mortality_in_hospital)
+    # mod-7 AKI on n=50 -> 7
+    assert aki >= 5
+    # mod-20 mortality on n=50 -> 2
+    assert mortality >= 1

--- a/templates/tests/unit/commercial/registry/test_ncdr_manifest.py
+++ b/templates/tests/unit/commercial/registry/test_ncdr_manifest.py
@@ -1,0 +1,121 @@
+"""Phase 3 Plan 4C Tasks 4 + 5 (T-022C): registry_to_omop_ncdr manifest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+MANIFEST_DIR = (
+    Path(__file__).resolve().parents[4] / "commercial" / "manifests" / "registry_to_omop_ncdr"
+)
+SQL_DIR = MANIFEST_DIR / "sql"
+
+
+def _load() -> dict[str, object]:
+    raw = (MANIFEST_DIR / "manifest.yaml").read_text(encoding="utf-8")
+    parsed = yaml.safe_load(raw)
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def test_manifest_loads() -> None:
+    cfg = _load()
+    assert cfg["apiVersion"] == "parthenon.acumenus.net/v1"
+    metadata = cfg["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["id"] == "registry_to_omop_ncdr"
+
+
+def test_manifest_marks_commercial_tier() -> None:
+    cfg = _load()
+    metadata = cfg["metadata"]
+    assert isinstance(metadata, dict)
+    tags = metadata.get("tags", [])
+    for tag in ("commercial", "ncdr", "cardiology", "pci"):
+        assert tag in tags
+
+
+def test_manifest_requires_pci_vocabularies() -> None:
+    cfg = _load()
+    spec = cfg["spec"]
+    assert isinstance(spec, dict)
+    required = spec["requires"]["vocabularies"]
+    for vocab in ("ICD10CM", "CPT4", "HCPCS", "SNOMED", "LOINC", "FDA_UDI"):
+        assert vocab in required
+
+
+def test_manifest_has_eight_stages() -> None:
+    cfg = _load()
+    spec = cfg["spec"]
+    assert isinstance(spec, dict)
+    nodes = spec["nodes"]
+    assert isinstance(nodes, list)
+    # bootstrap + load + 5 mappers (procedure / measurement / device /
+    # condition / episode) + summarize = 8
+    assert len(nodes) == 8
+
+
+@pytest.mark.parametrize(
+    "node_id",
+    [
+        "bootstrap_source",
+        "load_ncdr",
+        "map_procedure_occurrence",
+        "map_measurement",
+        "map_device_exposure",
+        "map_condition_occurrence",
+        "map_episode",
+        "summarize",
+    ],
+)
+def test_manifest_declares_required_node(node_id: str) -> None:
+    cfg = _load()
+    spec = cfg["spec"]
+    assert isinstance(spec, dict)
+    ids = {n["node_id"] for n in spec["nodes"]}
+    assert node_id in ids
+
+
+def test_required_sql_files_exist() -> None:
+    for filename in (
+        "00_bootstrap_ncdr_source.sql",
+        "01_load_ncdr_csv.sql",
+        "02a_map_procedure_occurrence.sql",
+        "02b_map_measurement.sql",
+        "02c_map_device_exposure.sql",
+        "02d_map_condition_occurrence.sql",
+        "02e_map_episode.sql",
+        "03_summarize.sql",
+    ):
+        assert (SQL_DIR / filename).is_file()
+
+
+def test_device_exposure_sql_uses_fda_udi_vocabulary() -> None:
+    """Plan 4C is the first commercial template to populate DEVICE_EXPOSURE.
+    The mapping joins on FDA_UDI vocabulary."""
+    sql = (SQL_DIR / "02c_map_device_exposure.sql").read_text(encoding="utf-8")
+    assert "vocabulary_id = 'FDA_UDI'" in sql
+    assert "INSERT INTO ${parameters.cdm_schema}.device_exposure" in sql
+    assert "unnest(COALESCE(p.stent_udis" in sql
+
+
+def test_bootstrap_sql_enforces_parallel_lists() -> None:
+    """fmt_ncdr_pci must enforce cardinality(stent_udis) = cardinality(stent_types)."""
+    sql = (SQL_DIR / "00_bootstrap_ncdr_source.sql").read_text(encoding="utf-8")
+    assert "cardinality(stent_udis) = cardinality(stent_types)" in sql
+
+
+def test_episode_sql_uses_canonical_source_value() -> None:
+    """HIGHSEC §7: episode_source_value uses procedure code, not patient_id."""
+    sql = (SQL_DIR / "02e_map_episode.sql").read_text(encoding="utf-8")
+    assert "'PCI:' || p.primary_procedure_code" in sql
+
+
+def test_readme_exists_and_documents_license() -> None:
+    readme = MANIFEST_DIR / "README.md"
+    assert readme.is_file()
+    text = readme.read_text(encoding="utf-8")
+    assert "ACC NCDR Participant Agreement" in text
+    assert "FDA UDI" in text

--- a/templates/tests/unit/commercial/registry/test_ncdr_reader.py
+++ b/templates/tests/unit/commercial/registry/test_ncdr_reader.py
@@ -1,0 +1,155 @@
+"""Phase 3 Plan 4C Task 3 (T-022C): NCDRReader CSV parser."""
+
+from __future__ import annotations
+
+import io
+from datetime import date
+
+import pytest
+
+from runtime.commercial.registry.ncdr.reader import NCDRReader, NCDRReadError
+
+_HEADER = (
+    "PCIRecordID,PatientID,ProcedureDate,PatientAge,Gender,HospitalID,OperatorNPI,"
+    "PreOpDiagnosis,HemodynamicEjectionFraction,HemodynamicCardiacIndex,"
+    "LesionCount,LesionSegments,PrimaryProcedureCode,StentCount,StentUDIs,StentTypes,"
+    "PostOpComplication_Bleeding,PostOpComplication_AKI,PostOpComplication_Stroke,"
+    "LengthOfStay,Mortality_InHospital"
+)
+
+
+def _row(**overrides: str) -> str:
+    base: dict[str, str] = {
+        "PCIRecordID": "PCI-0001",
+        "PatientID": "PAT00001",
+        "ProcedureDate": "20240601",
+        "PatientAge": "65",
+        "Gender": "M",
+        "HospitalID": "NCDR-H001",
+        "OperatorNPI": "1234567893",
+        "PreOpDiagnosis": "I21.4",
+        "HemodynamicEjectionFraction": "45.0",
+        "HemodynamicCardiacIndex": "2.4",
+        "LesionCount": "1",
+        "LesionSegments": "6",
+        "PrimaryProcedureCode": "92928",
+        "StentCount": "1",
+        "StentUDIs": "08714729123456",
+        "StentTypes": "DES",
+        "PostOpComplication_Bleeding": "no",
+        "PostOpComplication_AKI": "no",
+        "PostOpComplication_Stroke": "no",
+        "LengthOfStay": "2",
+        "Mortality_InHospital": "no",
+    }
+    base.update(overrides)
+    fields = _HEADER.split(",")
+    return ",".join(base[f] for f in fields)
+
+
+def _payload(*rows: str) -> str:
+    return _HEADER + "\n" + "\n".join(rows) + "\n"
+
+
+def test_reader_parses_one_pci() -> None:
+    records = NCDRReader().read(io.StringIO(_payload(_row())))
+    assert len(records) == 1
+    r = records[0]
+    assert r.record_id == "PCI-0001"
+    assert r.procedure_date == date(2024, 6, 1)
+    assert r.lesion_count == 1
+    assert r.stent_count == 1
+    assert r.stent_types == ["DES"]
+
+
+def test_reader_handles_multi_stent_pci() -> None:
+    records = NCDRReader().read(
+        io.StringIO(
+            _payload(
+                _row(
+                    LesionCount="2",
+                    LesionSegments="6;8",
+                    StentCount="2",
+                    StentUDIs="08714729111111;08714729222222",
+                    StentTypes="DES;BMS",
+                )
+            )
+        )
+    )
+    assert records[0].lesion_count == 2
+    assert len(records[0].stent_udis) == 2
+    assert records[0].stent_types == ["DES", "BMS"]
+
+
+def test_reader_rejects_mismatched_udi_type_lists() -> None:
+    """If StentUDIs has 2 entries but StentTypes has 1, fail closed."""
+    with pytest.raises(NCDRReadError):
+        NCDRReader().read(
+            io.StringIO(
+                _payload(
+                    _row(
+                        StentCount="2",
+                        StentUDIs="08714729111111;08714729222222",
+                        StentTypes="DES",
+                    )
+                )
+            )
+        )
+
+
+def test_reader_handles_diagnostic_cath() -> None:
+    """LesionCount=0 + StentCount=0 + empty UDI/type lists."""
+    records = NCDRReader().read(
+        io.StringIO(
+            _payload(
+                _row(
+                    LesionCount="0",
+                    LesionSegments="",
+                    StentCount="0",
+                    StentUDIs="",
+                    StentTypes="",
+                )
+            )
+        )
+    )
+    assert records[0].stent_count == 0
+
+
+def test_reader_handles_complications_and_mortality() -> None:
+    records = NCDRReader().read(
+        io.StringIO(
+            _payload(
+                _row(
+                    PostOpComplication_Bleeding="yes",
+                    PostOpComplication_AKI="yes",
+                    Mortality_InHospital="yes",
+                )
+            )
+        )
+    )
+    assert records[0].postop_bleeding
+    assert records[0].postop_aki
+    assert records[0].mortality_in_hospital
+
+
+def test_reader_raises_on_invalid_date() -> None:
+    with pytest.raises(NCDRReadError):
+        NCDRReader().read(io.StringIO(_payload(_row(ProcedureDate="BADBADBA"))))
+
+
+def test_reader_raises_on_missing_header() -> None:
+    with pytest.raises(NCDRReadError):
+        NCDRReader().read(io.StringIO(""))
+
+
+def test_reader_raises_on_invalid_npi_length() -> None:
+    """NCDRRecord requires 10-char NPI; reader surfaces the validation."""
+    with pytest.raises(NCDRReadError):
+        NCDRReader().read(io.StringIO(_payload(_row(OperatorNPI="123"))))
+
+
+def test_reader_idempotent() -> None:
+    payload = _payload(_row(), _row(PCIRecordID="PCI-0002"))
+    a = NCDRReader().read(io.StringIO(payload))
+    b = NCDRReader().read(io.StringIO(payload))
+    assert a == b

--- a/templates/tests/unit/commercial/registry/test_ncdr_types.py
+++ b/templates/tests/unit/commercial/registry/test_ncdr_types.py
@@ -1,0 +1,91 @@
+"""Phase 3 Plan 4C Task 2 (T-022C): NCDRRecord typed model."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from runtime.commercial.registry.ncdr.types import NCDRRecord
+
+
+def _kwargs(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "record_id": "PCI-0001",
+        "patient_id": "PAT00001",
+        "procedure_date": date(2024, 6, 1),
+        "patient_age": 65,
+        "gender": "M",
+        "hospital_id": "NCDR-H001",
+        "operator_npi": "1234567893",
+        "preop_diagnosis_icd10": "I21.4",
+        "ejection_fraction": Decimal("45.0"),
+        "cardiac_index": Decimal("2.4"),
+        "lesion_count": 1,
+        "lesion_segments": ["6"],
+        "primary_procedure_code": "92928",
+        "stent_count": 1,
+        "stent_udis": ["08714729123456"],
+        "stent_types": ["DES"],
+        "postop_bleeding": False,
+        "postop_aki": False,
+        "postop_stroke": False,
+        "length_of_stay": 2,
+        "mortality_in_hospital": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_constructs_minimal_pci() -> None:
+    r = NCDRRecord(**_kwargs())
+    assert r.record_id == "PCI-0001"
+    assert r.lesion_count == 1
+    assert r.stent_types == ["DES"]
+
+
+def test_extra_fields_rejected() -> None:
+    with pytest.raises(ValidationError):
+        NCDRRecord(**_kwargs(unexpected_field="x"))
+
+
+def test_frozen_after_construction() -> None:
+    r = NCDRRecord(**_kwargs())
+    with pytest.raises(ValidationError):
+        r.length_of_stay = 5  # type: ignore[misc]
+
+
+def test_npi_must_be_10_chars() -> None:
+    with pytest.raises(ValidationError):
+        NCDRRecord(**_kwargs(operator_npi="123"))
+
+
+def test_unknown_stent_type_rejected() -> None:
+    with pytest.raises(ValidationError):
+        NCDRRecord(**_kwargs(stent_types=["BAD"]))
+
+
+def test_ef_out_of_range_rejected() -> None:
+    with pytest.raises(ValidationError):
+        NCDRRecord(**_kwargs(ejection_fraction=Decimal("200")))
+
+
+def test_lesion_count_zero_allowed() -> None:
+    """Diagnostic-only cath (no PCI) carries lesion_count=0."""
+    r = NCDRRecord(**_kwargs(lesion_count=0, stent_count=0, stent_udis=[], stent_types=[]))
+    assert r.stent_count == 0
+
+
+def test_multi_stent_pci() -> None:
+    r = NCDRRecord(
+        **_kwargs(
+            lesion_count=2,
+            stent_count=2,
+            stent_udis=["08714729111111", "08714729222222"],
+            stent_types=["DES", "BMS"],
+        )
+    )
+    assert len(r.stent_udis) == 2
+    assert r.stent_types == ["DES", "BMS"]


### PR DESCRIPTION
Harvests the real, unmerged code from stale/disconnected branches after the templates cascade.

Included:
- feature/cohort-geography-explorer: cohort geography GIS API, frontend layer, PA tract loader, and test coverage.
- #289 / feature/phase-3-plan-4c-ncdr: NCDR CathPCI v5.0 commercial template reader, manifest, SQL stages, synthetic fixture builder, and tests.
- closed bot branches: MainLayout/UserAvatar/WikiPageTree/CohortBuilder memoization and ARIA labels for announcement/wiki/covariate controls.
- FinnGen CI parity fix: install PostGIS in the FinnGen postgres service before running full Laravel migrations, matching the main CI job.

Excluded as already merged/superseded or non-code noise:
- old Phase 0/Phase 2 template commits with current-main equivalents.
- bot metadata files, duplicate workflow fixes, pnpm lockfile churn, and generated paper-corpus artifacts already represented by rebased commits on main.

Validation:
- npx tsc --noEmit
- npx vite build
- npx eslint on touched frontend areas
- docker compose exec -T php vendor/bin/pint on touched PHP files
- docker compose exec -T php php artisan test --filter CohortGeographyServiceTest with compose DB test env
- python3 -m py_compile on touched Python scripts
- PYTHONPATH=.:commercial pytest NCDR unit/e2e tests from templates/ (46 passed)
- python3 YAML parse for .github/workflows/finngen-tests.yml
- graphify update .
- scripts/githooks/pre-commit