### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix plaintext password leak in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** A query validation function (`checkSqlSafety`) intended to block destructive queries (like `DROP`, `INSERT`) could be completely bypassed if the attacker added a comment containing a whitelisted schema name (e.g., `DROP TABLE users; -- temp_abby`).
 **Learning:** Checking for substrings or using simple regexes on raw, un-parsed SQL strings is extremely brittle because SQL comments and string literals can hide tokens or introduce false flags.
 **Prevention:** Always strip SQL comments and string literals (replacing them with spaces to preserve token boundaries) before attempting to identify keywords via regex.
+
+## 2026-05-07 - [Secrets] Passwords Leak in Error Logs
+**Vulnerability:** The temporary password created for the user when an email send failed was being logged to the backend logger in plaintext, leaking secrets into application logs.
+**Learning:** Even well-intentioned error handling and logging (e.g., providing a fallback so an admin can give a user their password if an email fails) can introduce critical security risks by leaving plaintext secrets in persistent logs.
+**Prevention:** Never log plaintext passwords or sensitive credentials. Fallback mechanisms should rely on standard password reset flows rather than exposing temporary credentials in logs.

--- a/backend/app/Http/Controllers/Api/V1/Admin/UserController.php
+++ b/backend/app/Http/Controllers/Api/V1/Admin/UserController.php
@@ -88,7 +88,6 @@ class UserController extends Controller
             } catch (\Throwable $e) {
                 logger()->warning('Failed to send temp password email', [
                     'user_id' => $user->id,
-                    'temp_password' => $plainPassword,
                     'error' => $e->getMessage(),
                 ]);
             }

--- a/backend/app/Http/Controllers/Api/V1/AuthController.php
+++ b/backend/app/Http/Controllers/Api/V1/AuthController.php
@@ -51,11 +51,10 @@ class AuthController extends Controller
         try {
             Mail::to($user->email)->send(new TempPasswordMail($user->name, $tempPassword));
         } catch (\Throwable $e) {
-            // Non-fatal: log the temp password so admins can retrieve it if email fails
+            // Non-fatal: log the error. Admins or users can reset password later if email fails
             logger()->warning('Failed to send temp password email', [
                 'user_id' => $user->id,
                 'email' => $user->email,
-                'temp_password' => $tempPassword,
                 'error' => $e->getMessage(),
             ]);
         }
@@ -167,7 +166,6 @@ class AuthController extends Controller
                 logger()->warning('Failed to send password reset email', [
                     'user_id' => $user->id,
                     'email' => $user->email,
-                    'temp_password' => $tempPassword,
                     'error' => $e->getMessage(),
                 ]);
             }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The temporary plaintext password generated for new users or password resets was being logged in plaintext if the email dispatch failed, exposing sensitive credentials in application logs.
🎯 Impact: Anyone with access to the application logs could view and misuse plaintext passwords for active user accounts.
🔧 Fix: Removed the `temp_password` field from the error log arrays in `AuthController.php` and `UserController.php`. Updated inline comments to recommend standard password reset flows instead of log retrieval.
✅ Verification: Verified the code using PHPStan. Tested that the plaintext `temp_password` array key was completely removed from `logger()->warning()` calls.

---
*PR created automatically by Jules for task [7729769964767009109](https://jules.google.com/task/7729769964767009109) started by @sudoshi*