### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection bypass in DataInterrogationService

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,13 @@
 **Vulnerability:** The temporary password created for the user when an email send failed was being logged to the backend logger in plaintext, leaking secrets into application logs.
 **Learning:** Even well-intentioned error handling and logging (e.g., providing a fallback so an admin can give a user their password if an email fails) can introduce critical security risks by leaving plaintext secrets in persistent logs.
 **Prevention:** Never log plaintext passwords or sensitive credentials. Fallback mechanisms should rely on standard password reset flows rather than exposing temporary credentials in logs.
+
+## 2024-05-08 - [Data Interrogation Service SQL Bypass Vulnerabilities]
+**Vulnerability:** The AI DataInterrogationService contained two severe SQL check bypasses:
+1. The check `substr_count($stripped, ';') > 1` permitted queries with exactly 1 semicolon, effectively allowing *two* SQL statements (e.g. `SELECT 1; DROP TABLE users`).
+2. The check simply looked for the presence of `temp_abby.` and, if found, bypassed all forbidden keyword checks. This allowed arbitrary forbidden SQL anywhere in the query if the string `temp_abby.` was appended.
+**Learning:** Poorly crafted regular expressions and simplistic substring counts can completely negate the intended purpose of input validation, specifically around SQL execution safeguards.
+**Prevention:**
+- Explicitly validate statements based on strict bounds rather than blind string existence.
+- When validating multiple statements, check if a semicolon exists `str_contains(rtrim($string, " \t\n\r\0\x0B;"), ';')` rather than assuming `< 2` means one statement.
+- First extract and remove intentionally whitelisted/safe patterns, then check the remainder for forbidden logic.

--- a/backend/app/Services/AI/DataInterrogationService.php
+++ b/backend/app/Services/AI/DataInterrogationService.php
@@ -189,16 +189,34 @@ class DataInterrogationService
         // Replace with space to preserve token boundaries like "DROP/**/TABLE"
         $stripped = preg_replace('/--.*$|\/\*[\s\S]*?\*\//m', ' ', $stripped) ?? $stripped;
 
+        // Strip trailing semicolons and whitespace so a single query ending in ';' is not falsely rejected
+        $noTrailingSemicolon = rtrim($stripped, " \t\n\r\0\x0B;");
+
         // Check for multi-statement
-        if (substr_count($stripped, ';') > 1) {
+        if (str_contains($noTrailingSemicolon, ';')) {
             return 'Multiple statements are not allowed. Send one query at a time.';
         }
 
         // Check for forbidden patterns (excluding temp_abby operations)
         foreach (self::FORBIDDEN_PATTERNS as $pattern) {
             if (preg_match($pattern, $stripped)) {
-                // Allow CREATE/INSERT/DROP on temp_abby schema
-                if (preg_match('/temp_abby\./i', $stripped)) {
+                // Strip out explicitly allowed operations on temp_abby
+                $strippedWithoutAllowed = preg_replace(
+                    '/\b(INSERT\s+INTO|DROP\s+(?:TABLE|INDEX)(?:\s+IF\s+EXISTS)?|CREATE\s+(?:TABLE|INDEX)(?:\s+IF\s+NOT\s+EXISTS)?)\s+temp_abby\.[a-z0-9_]+/i',
+                    ' ',
+                    $stripped
+                );
+
+                // Re-check for any remaining forbidden patterns
+                $stillForbidden = false;
+                foreach (self::FORBIDDEN_PATTERNS as $p) {
+                    if (preg_match($p, $strippedWithoutAllowed ?? '')) {
+                        $stillForbidden = true;
+                        break;
+                    }
+                }
+
+                if (! $stillForbidden) {
                     continue;
                 }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The DataInterrogationService SQL safeguard contained two massive bypasses. First, the multi-statement check permitted one semicolon, allowing a second malicious statement. Second, the forbidden pattern check exited entirely if the string 'temp_abby.' existed anywhere in the query, allowing data destruction on protected schemas.
🎯 Impact: Attackers or a hallucinating AI could bypass safeguards to execute arbitrary SQL, resulting in the ability to drop tables, delete records, or insert unauthorized data into the omop and results schemas.
🔧 Fix: Updated the check to strip explicitly allowed temp_abby operations first, re-evaluating the remaining string for forbidden operations. Also replaced the semicolon check with a strict check for ANY remaining semicolons after trimming trailing chars.
✅ Verification: Ran unit tests and verified pest passed. Simulated various injections verifying blocks against multi-statement queries and unauthorized table mutations.

---
*PR created automatically by Jules for task [9220307200108581191](https://jules.google.com/task/9220307200108581191) started by @sudoshi*