### PR TITLE
ci(license-guard): add license-text, license-metadata, notice/trademarks jobs (stacked on #311)

### DIFF
--- a/.github/workflows/license-guard.yml
+++ b/.github/workflows/license-guard.yml
@@ -41,3 +41,96 @@ jobs:
             exit 1
           fi
           echo "OK: no stale sudoshi/Parthenon references in active source."
+
+  license-text:
+    name: Verify LICENSE is AGPL-3.0
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check LICENSE first lines
+        run: |
+          set -e
+          if ! head -3 LICENSE | grep -q 'GNU AFFERO GENERAL PUBLIC LICENSE'; then
+            echo "LICENSE does not appear to be AGPL-3.0:"
+            head -3 LICENSE
+            exit 1
+          fi
+          if ! head -3 LICENSE | grep -q 'Version 3'; then
+            echo "LICENSE does not say Version 3:"
+            head -3 LICENSE
+            exit 1
+          fi
+          echo "OK: LICENSE is AGPL-3.0."
+
+  license-metadata:
+    name: Verify package manifests declare AGPL-3.0-only
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - name: composer.json declares AGPL-3.0-only
+        run: |
+          set -e
+          LICENSE=$(node -e 'console.log(require("./backend/composer.json").license)')
+          if [ "$LICENSE" != "AGPL-3.0-only" ]; then
+            echo "backend/composer.json license is '$LICENSE', expected 'AGPL-3.0-only'"
+            exit 1
+          fi
+          echo "OK: backend/composer.json license = AGPL-3.0-only"
+      - name: frontend/package.json declares AGPL-3.0-only
+        run: |
+          set -e
+          LICENSE=$(node -e 'console.log(require("./frontend/package.json").license)')
+          if [ "$LICENSE" != "AGPL-3.0-only" ]; then
+            echo "frontend/package.json license is '$LICENSE', expected 'AGPL-3.0-only'"
+            exit 1
+          fi
+          echo "OK: frontend/package.json license = AGPL-3.0-only"
+      - name: ai/pyproject.toml declares AGPL-3.0-only
+        run: |
+          set -e
+          python3 - <<'PY'
+          import tomllib
+          with open('ai/pyproject.toml', 'rb') as f:
+              data = tomllib.load(f)
+          lic = data.get('project', {}).get('license', {}).get('text', '')
+          if lic != 'AGPL-3.0-only':
+              print(f"ai/pyproject.toml license is '{lic}', expected 'AGPL-3.0-only'")
+              raise SystemExit(1)
+          print('OK: ai/pyproject.toml license = AGPL-3.0-only')
+          PY
+      - name: templates/pyproject.toml declares AGPL-3.0-only
+        run: |
+          set -e
+          python3 - <<'PY'
+          import tomllib
+          with open('templates/pyproject.toml', 'rb') as f:
+              data = tomllib.load(f)
+          lic = data.get('project', {}).get('license', {}).get('text', '')
+          if lic != 'AGPL-3.0-only':
+              print(f"templates/pyproject.toml license is '{lic}', expected 'AGPL-3.0-only'")
+              raise SystemExit(1)
+          print('OK: templates/pyproject.toml license = AGPL-3.0-only')
+          PY
+
+  notice-and-trademarks:
+    name: Verify NOTICE, LICENSING.md, TRADEMARKS.md exist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          set -e
+          for f in NOTICE LICENSING.md TRADEMARKS.md; do
+            if [ ! -s "$f" ]; then
+              echo "Missing or empty: $f"
+              exit 1
+            fi
+          done
+          grep -q 'OHDSI Atlas' NOTICE || { echo "NOTICE missing OHDSI Atlas attribution"; exit 1; }
+          grep -q 'GNU Affero' LICENSING.md || { echo "LICENSING.md missing AGPL reference"; exit 1; }
+          grep -q 'nominative' TRADEMARKS.md || { echo "TRADEMARKS.md missing nominative use"; exit 1; }
+          grep -q 'licensing@acumenus.net' LICENSING.md || { echo "LICENSING.md missing commercial contact"; exit 1; }
+          echo "OK: NOTICE, LICENSING.md, TRADEMARKS.md present and contain expected sections"


### PR DESCRIPTION
## Summary

Stacked on #311. Extends \`.github/workflows/license-guard.yml\` with three new jobs that serve as **TDD for the AGPLv3 relicense PR** (next, stacked on this).

- \`license-text\`: LICENSE first lines must say AGPL-3.0
- \`license-metadata\`: 4 package manifests must declare \`AGPL-3.0-only\`
- \`notice-and-trademarks\`: NOTICE, LICENSING.md, TRADEMARKS.md must exist with key sections

## Expected CI state on this PR

These three new jobs WILL FAIL on this PR. That is the intended TDD signal — the guard is the contract; the relicense PR (next) satisfies it. The \`org-references\` job from #311 should still pass.

## DO NOT merge before:

1. #311 merges first (this PR is stacked on it)
2. The AGPLv3 relicense PR (next, stacked on this) is open and reviewed

## DO NOT add these jobs to required status checks until:

The AGPLv3 relicense PR has merged. Otherwise main becomes unmergeable.

## Test plan

- [x] org-references job passes (carried from #311)
- [x] license-text fails (TDD)
- [x] license-metadata fails (TDD)
- [x] notice-and-trademarks fails (TDD)
- [ ] After AGPLv3 PR merges, all 4 jobs pass on main