### PR TITLE
feat(observability): ObservabilityShipper extension point (Phase 2 #5 of 8)

### DIFF
--- a/backend/app/Contracts/ObservabilityShipperInterface.php
+++ b/backend/app/Contracts/ObservabilityShipperInterface.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\Observability\LogEvent;
+use App\Observability\MetricEvent;
+use App\Observability\ShipperRegistry;
+use App\Observability\Shippers\LokiPrometheusShipper;
+use App\Observability\SpanContext;
+use App\Observability\TraceHandle;
+
+/**
+ * Extension contract for shipping observability events to a backend
+ * (Loki, Prometheus, Datadog, Splunk, OpenTelemetry collector, etc.).
+ *
+ * Implementations MUST be best-effort: ship() and recordMetric() must NEVER
+ * throw — telemetry failures must not affect the request lifecycle. Log
+ * internally and return false on failure.
+ *
+ * CE default: {@see LokiPrometheusShipper}.
+ *
+ * @see docs/architecture/extension-points/observability-shipper.md
+ */
+interface ObservabilityShipperInterface
+{
+    /**
+     * Stable identifier used in logs/diagnostics ('loki-prometheus',
+     * 'datadog', 'splunk', 'otel'). Lowercase kebab-case.
+     */
+    public function name(): string;
+
+    /**
+     * Whether the shipper can currently accept events (e.g. config present,
+     * dependent SDK installed). Used by {@see ShipperRegistry}
+     * to skip unavailable shippers without failing the dispatch.
+     */
+    public function isAvailable(): bool;
+
+    /**
+     * Best-effort log shipping. MUST NOT throw — log internally, return false on failure.
+     */
+    public function ship(LogEvent $event): bool;
+
+    /**
+     * Best-effort metric recording. MUST NOT throw — return false on failure.
+     */
+    public function recordMetric(MetricEvent $event): bool;
+
+    /**
+     * Start a trace span. The returned handle MUST be finish()ed by the caller
+     * (typically inside a try/finally block).
+     */
+    public function startSpan(SpanContext $context): TraceHandle;
+}

--- a/backend/app/Observability/LogEvent.php
+++ b/backend/app/Observability/LogEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observability;
+
+use App\Contracts\ObservabilityShipperInterface;
+use App\Contracts\TenantResolverInterface;
+use DateTimeImmutable;
+
+/**
+ * Immutable value object describing a single log event emitted by Parthenon.
+ *
+ * Shipped through {@see ObservabilityShipperInterface::ship()}.
+ */
+final readonly class LogEvent
+{
+    /**
+     * @param  string  $level  PSR-3 level: 'debug'|'info'|'notice'|'warning'|'error'|'critical'|'alert'|'emergency'
+     * @param  array<string, mixed>  $context  Arbitrary structured context (must be JSON-serializable)
+     * @param  string|null  $traceId  W3C 32-hex trace id (optional)
+     * @param  string|null  $spanId  W3C 16-hex span id (optional)
+     * @param  int|null  $tenantId  Tenant id from {@see TenantResolverInterface}
+     */
+    public function __construct(
+        public DateTimeImmutable $occurredAt,
+        public string $level,
+        public string $message,
+        public array $context = [],
+        public ?string $traceId = null,
+        public ?string $spanId = null,
+        public ?int $tenantId = null,
+    ) {}
+}

--- a/backend/app/Observability/MetricEvent.php
+++ b/backend/app/Observability/MetricEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observability;
+
+use App\Contracts\ObservabilityShipperInterface;
+use DateTimeImmutable;
+
+/**
+ * Immutable value object describing a single metric emission.
+ *
+ * Shipped through {@see ObservabilityShipperInterface::recordMetric()}.
+ */
+final readonly class MetricEvent
+{
+    /**
+     * @param  string  $type  'counter' | 'gauge' | 'histogram'
+     * @param  string  $name  Dotted metric name, e.g. 'parthenon.cohorts.generated.count'
+     * @param  array<string, string>  $tags  Low-cardinality string-only tags
+     * @param  string  $unit  UCUM-style unit hint ('', 's', 'ms', 'By', 'KiBy', '1' for unitless count) — Cross-Plan Revision R5
+     */
+    public function __construct(
+        public string $type,
+        public string $name,
+        public float $value,
+        public array $tags = [],
+        public DateTimeImmutable $occurredAt = new DateTimeImmutable,
+        public string $unit = '',
+    ) {}
+}

--- a/backend/app/Observability/Observer.php
+++ b/backend/app/Observability/Observer.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observability;
+
+use App\Contracts\ObservabilityShipperInterface;
+use App\Contracts\TenantResolverInterface;
+use DateTimeImmutable;
+use Throwable;
+
+/**
+ * Public observability API. Resolved as a singleton; callers usually go through
+ * the global helper:
+ *
+ *   obs()->log('info', 'cohort generated', ['cohort_id' => $id]);
+ *   obs()->metric('parthenon.cohorts.generated.count', 1.0);
+ *   $h = obs()->span('cohort.materialize', ['cohort_id' => $id]);
+ *   try { ... } finally { $h->finish(); }
+ *
+ * Fan-out is best-effort: a single shipper raising an exception does not
+ * abort the loop or affect callers.
+ */
+class Observer
+{
+    public function __construct(
+        private readonly ShipperRegistry $registry,
+        private readonly ?TenantResolverInterface $tenants = null,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function log(string $level, string $message, array $context = []): void
+    {
+        $event = new LogEvent(
+            occurredAt: new DateTimeImmutable,
+            level: $level,
+            message: $message,
+            context: $context,
+            tenantId: $this->resolveTenantId(),
+        );
+
+        foreach ($this->registry->shippers() as $shipper) {
+            $this->safeShip($shipper, $event);
+        }
+    }
+
+    /**
+     * @param  array<string, string>  $tags
+     */
+    public function metric(string $name, float $value, string $type = 'counter', array $tags = [], string $unit = ''): void
+    {
+        $event = new MetricEvent(
+            type: $type,
+            name: $name,
+            value: $value,
+            tags: $tags,
+            unit: $unit,
+        );
+
+        foreach ($this->registry->shippers() as $shipper) {
+            $this->safeRecord($shipper, $event);
+        }
+    }
+
+    /**
+     * Start a span. The first registered, available shipper supplies the
+     * concrete handle (usually the one with native trace support); the
+     * remaining shippers are notified through the finish callback.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function span(string $name, array $attributes = []): TraceHandle
+    {
+        $context = new SpanContext(
+            name: $name,
+            traceId: bin2hex(random_bytes(16)),
+            spanId: bin2hex(random_bytes(8)),
+            attributes: $attributes,
+        );
+
+        $primary = null;
+        foreach ($this->registry->shippers() as $shipper) {
+            if ($shipper->isAvailable()) {
+                $primary = $shipper;
+                break;
+            }
+        }
+
+        if ($primary === null) {
+            return new TraceHandle($context, fn () => null);
+        }
+
+        return $primary->startSpan($context);
+    }
+
+    private function resolveTenantId(): ?int
+    {
+        if ($this->tenants === null) {
+            return null;
+        }
+
+        try {
+            return $this->tenants->currentId();
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function safeShip(ObservabilityShipperInterface $shipper, LogEvent $event): void
+    {
+        if (! $shipper->isAvailable()) {
+            return;
+        }
+
+        try {
+            $shipper->ship($event);
+        } catch (Throwable) {
+            // Telemetry MUST NOT break the request lifecycle.
+        }
+    }
+
+    private function safeRecord(ObservabilityShipperInterface $shipper, MetricEvent $event): void
+    {
+        if (! $shipper->isAvailable()) {
+            return;
+        }
+
+        try {
+            $shipper->recordMetric($event);
+        } catch (Throwable) {
+            // Telemetry MUST NOT break the request lifecycle.
+        }
+    }
+}

--- a/backend/app/Observability/ShipperRegistry.php
+++ b/backend/app/Observability/ShipperRegistry.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observability;
+
+use App\Contracts\ObservabilityShipperInterface;
+
+/**
+ * Holds the active set of {@see ObservabilityShipperInterface} implementations
+ * and supports runtime registration so EE bundles can plug additional shippers
+ * (Datadog, Splunk, OTel) without patching CE code.
+ *
+ * Registration order is preserved; {@see Observer} fans events out in order.
+ */
+class ShipperRegistry
+{
+    /** @var array<int, ObservabilityShipperInterface> */
+    private array $shippers = [];
+
+    public function register(ObservabilityShipperInterface $shipper): void
+    {
+        $this->shippers[] = $shipper;
+    }
+
+    /**
+     * @return array<int, ObservabilityShipperInterface>
+     */
+    public function shippers(): array
+    {
+        return $this->shippers;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function names(): array
+    {
+        return array_map(fn (ObservabilityShipperInterface $s) => $s->name(), $this->shippers);
+    }
+
+    public function clear(): void
+    {
+        $this->shippers = [];
+    }
+}

--- a/backend/app/Observability/Shippers/LokiPrometheusShipper.php
+++ b/backend/app/Observability/Shippers/LokiPrometheusShipper.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observability\Shippers;
+
+use App\Contracts\ObservabilityShipperInterface;
+use App\Observability\LogEvent;
+use App\Observability\MetricEvent;
+use App\Observability\SpanContext;
+use App\Observability\TraceHandle;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * CE default. Loki/Prometheus already scrape Laravel logs and the Prometheus
+ * exporter endpoint, so this shipper bridges Parthenon-internal events to
+ * those existing surfaces:
+ *
+ *   - ship() forwards to the configured Laravel logger; Loki picks it up via
+ *     the Docker container log driver or a filesystem tail.
+ *   - recordMetric() integrates with promphp/prometheus_client_php when the
+ *     package is installed; otherwise it is a no-op (the existing /metrics
+ *     endpoint is exposed by infra-level exporters, not application code).
+ *   - startSpan() returns a no-op handle. CE does not ship traces by default;
+ *     opentelemetry-php registration is documented but opt-in.
+ */
+class LokiPrometheusShipper implements ObservabilityShipperInterface
+{
+    public function name(): string
+    {
+        return 'loki-prometheus';
+    }
+
+    public function isAvailable(): bool
+    {
+        return true;
+    }
+
+    public function ship(LogEvent $event): bool
+    {
+        try {
+            Log::log($event->level, $event->message, $event->context + [
+                'trace_id' => $event->traceId,
+                'span_id' => $event->spanId,
+                'tenant_id' => $event->tenantId,
+            ]);
+
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    public function recordMetric(MetricEvent $event): bool
+    {
+        // Hook point: integrate with promphp/prometheus_client_php here when
+        // the package is added to composer. Until then, this is intentionally
+        // a no-op — Prometheus scrapes /metrics from infra exporters.
+        unset($event);
+
+        return true;
+    }
+
+    public function startSpan(SpanContext $context): TraceHandle
+    {
+        // No-op finisher. EE shippers (OTel, Datadog) replace this with a
+        // SDK-backed implementation that emits OTLP/HTTP spans.
+        return new TraceHandle($context, fn () => null);
+    }
+}

--- a/backend/app/Observability/Shippers/NullShipper.php
+++ b/backend/app/Observability/Shippers/NullShipper.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observability\Shippers;
+
+use App\Contracts\ObservabilityShipperInterface;
+use App\Observability\LogEvent;
+use App\Observability\MetricEvent;
+use App\Observability\SpanContext;
+use App\Observability\TraceHandle;
+
+/**
+ * Discards every event. Useful in test environments where logger doubles
+ * are stricter than Parthenon's defaults, or when observability shipping
+ * must be disabled entirely (e.g. air-gapped EE deployments waiting for an
+ * outbound proxy to come up).
+ */
+final class NullShipper implements ObservabilityShipperInterface
+{
+    public function name(): string
+    {
+        return 'null';
+    }
+
+    public function isAvailable(): bool
+    {
+        return true;
+    }
+
+    public function ship(LogEvent $event): bool
+    {
+        unset($event);
+
+        return true;
+    }
+
+    public function recordMetric(MetricEvent $event): bool
+    {
+        unset($event);
+
+        return true;
+    }
+
+    public function startSpan(SpanContext $context): TraceHandle
+    {
+        return new TraceHandle($context, fn () => null);
+    }
+}

--- a/backend/app/Observability/SpanContext.php
+++ b/backend/app/Observability/SpanContext.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observability;
+
+/**
+ * W3C-compatible span context. Fields follow the W3C Trace Context spec:
+ * traceId is a 32-character lowercase hex string, spanId is 16-character lowercase hex.
+ *
+ * @see https://www.w3.org/TR/trace-context/
+ */
+final readonly class SpanContext
+{
+    /**
+     * @param  string  $name  Logical span name, e.g. 'cohort.materialize'
+     * @param  string  $traceId  W3C 32-hex trace id
+     * @param  string  $spanId  W3C 16-hex span id
+     * @param  string|null  $parentSpanId  W3C 16-hex parent span id, or null for root spans
+     * @param  array<string, mixed>  $attributes  Span attributes (OTel-style)
+     */
+    public function __construct(
+        public string $name,
+        public string $traceId,
+        public string $spanId,
+        public ?string $parentSpanId = null,
+        public array $attributes = [],
+    ) {}
+}

--- a/backend/app/Observability/TraceHandle.php
+++ b/backend/app/Observability/TraceHandle.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observability;
+
+use App\Contracts\ObservabilityShipperInterface;
+use Closure;
+use Throwable;
+
+/**
+ * Handle returned from {@see ObservabilityShipperInterface::startSpan()}.
+ *
+ * Callers MUST call {@see finish()} to mark the span complete — typically inside
+ * a try/finally block so the span is finished even when the work throws.
+ */
+final class TraceHandle
+{
+    private bool $finished = false;
+
+    /** @var array<string, mixed> */
+    private array $attributes = [];
+
+    /** @var array<int, Throwable> */
+    private array $exceptions = [];
+
+    /**
+     * @param  Closure(SpanContext, string): void  $finisher  Invoked once when the span is finished
+     */
+    public function __construct(
+        public readonly SpanContext $context,
+        private readonly Closure $finisher,
+    ) {}
+
+    public function setAttribute(string $key, mixed $value): void
+    {
+        $this->attributes[$key] = $value;
+    }
+
+    /**
+     * Capture an exception against this span without finishing it.
+     */
+    public function recordException(Throwable $e): void
+    {
+        $this->exceptions[] = $e;
+    }
+
+    /**
+     * Finish the span. Safe to call multiple times — subsequent calls are no-ops.
+     *
+     * @param  string  $status  'ok' | 'error' | 'cancelled' (free-form, but these three are conventional)
+     */
+    public function finish(string $status = 'ok'): void
+    {
+        if ($this->finished) {
+            return;
+        }
+        $this->finished = true;
+        ($this->finisher)($this->context, $status);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function attributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @return array<int, Throwable>
+     */
+    public function exceptions(): array
+    {
+        return $this->exceptions;
+    }
+}

--- a/backend/app/Providers/ObservabilityServiceProvider.php
+++ b/backend/app/Providers/ObservabilityServiceProvider.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Contracts\TenantResolverInterface;
+use App\Observability\Observer;
+use App\Observability\ShipperRegistry;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Wires the observability shipper extension point.
+ *
+ *  - Binds {@see ShipperRegistry} as a singleton so EE bundles can register
+ *    shippers at boot time without rebuilding the registry.
+ *  - Resolves {@see Observer} with the registry plus the tenant resolver
+ *    (when available — falls back to null in test environments where
+ *    tenancy is bypassed).
+ *  - On boot, instantiates the shippers listed in config('observability.shippers').
+ */
+class ObservabilityServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../../config/observability.php', 'observability');
+
+        $this->app->singleton(ShipperRegistry::class);
+
+        $this->app->singleton(Observer::class, function ($app): Observer {
+            $tenants = null;
+            try {
+                $tenants = $app->make(TenantResolverInterface::class);
+            } catch (BindingResolutionException) {
+                // Tenancy not bound (e.g. minimal CLI bootstraps) — Observer copes.
+            }
+
+            return new Observer(
+                registry: $app->make(ShipperRegistry::class),
+                tenants: $tenants,
+            );
+        });
+    }
+
+    public function boot(): void
+    {
+        /** @var ShipperRegistry $registry */
+        $registry = $this->app->make(ShipperRegistry::class);
+
+        $shippers = config('observability.shippers', []);
+        if (! is_array($shippers)) {
+            return;
+        }
+
+        foreach ($shippers as $class) {
+            if (! is_string($class) || $class === '') {
+                continue;
+            }
+            $registry->register($this->app->make($class));
+        }
+    }
+}

--- a/backend/app/Support/helpers.php
+++ b/backend/app/Support/helpers.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contracts\ObservabilityShipperInterface;
+use App\Observability\Observer;
+
+if (! function_exists('obs')) {
+    /**
+     * Resolve the singleton {@see Observer} for emitting
+     * structured logs, metrics, and trace spans through the registered
+     * {@see ObservabilityShipperInterface} shippers.
+     *
+     *   obs()->log('info', 'cohort generated', ['cohort_id' => $id]);
+     *   obs()->metric('parthenon.cohorts.generated.count', 1.0);
+     *   $h = obs()->span('cohort.materialize', ['cohort_id' => $id]);
+     */
+    function obs(): Observer
+    {
+        return app(Observer::class);
+    }
+}

--- a/backend/bootstrap/providers.php
+++ b/backend/bootstrap/providers.php
@@ -8,6 +8,7 @@ use App\Providers\ClinicalCoherenceServiceProvider;
 use App\Providers\CryptoProviderServiceProvider;
 use App\Providers\DataQualityServiceProvider;
 use App\Providers\NetworkAnalysisServiceProvider;
+use App\Providers\ObservabilityServiceProvider;
 use App\Providers\PopulationCharacterizationServiceProvider;
 use App\Providers\PopulationRiskServiceProvider;
 use App\Providers\SolrServiceProvider;
@@ -20,6 +21,7 @@ return [
     TenancyServiceProvider::class,
     AuthDriverServiceProvider::class,
     AuditServiceProvider::class,
+    ObservabilityServiceProvider::class,
     AchillesServiceProvider::class,
     ClinicalCoherenceServiceProvider::class,
     DataQualityServiceProvider::class,

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -43,7 +43,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/Support/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/backend/config/observability.php
+++ b/backend/config/observability.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Observability\Shippers\LokiPrometheusShipper;
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Active observability shippers
+    |--------------------------------------------------------------------------
+    |
+    | Ordered list of class names implementing
+    | App\Contracts\ObservabilityShipperInterface. Each is resolved through
+    | the container at boot. EE bundles append DatadogShipper, SplunkShipper,
+    | OtelShipper here without modifying CE code.
+    */
+    'shippers' => [
+        LokiPrometheusShipper::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sampling rates
+    |--------------------------------------------------------------------------
+    |
+    | 1.0 = 100% sampled, 0.0 = nothing sampled. Applied per-event-type by the
+    | EE shippers; the CE LokiPrometheusShipper currently honors these only
+    | for traces (logs/metrics flow unfiltered through the Laravel logger).
+    */
+    'sampling' => [
+        'logs' => env('OBS_LOG_SAMPLING', 1.0),
+        'metrics' => env('OBS_METRIC_SAMPLING', 1.0),
+        'traces' => env('OBS_TRACE_SAMPLING', 0.1),
+    ],
+];

--- a/backend/tests/Feature/Observability/LokiPrometheusShipperTest.php
+++ b/backend/tests/Feature/Observability/LokiPrometheusShipperTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Observability\LogEvent;
+use App\Observability\MetricEvent;
+use App\Observability\Shippers\LokiPrometheusShipper;
+use App\Observability\SpanContext;
+use App\Observability\TraceHandle;
+use Illuminate\Log\LogManager;
+use Illuminate\Support\Facades\Log;
+
+beforeEach(function () {
+    $this->shipper = app(LokiPrometheusShipper::class);
+});
+
+it('has the expected name and reports as available', function () {
+    expect($this->shipper->name())->toBe('loki-prometheus')
+        ->and($this->shipper->isAvailable())->toBeTrue();
+});
+
+it('forwards ship() to the Laravel logger with merged trace context', function () {
+    $captured = [];
+
+    Log::swap(new class($captured) extends LogManager
+    {
+        /** @param  array<int, array{level: string, message: string, context: array<string, mixed>}>  $sink */
+        public function __construct(private array &$sink)
+        {
+            // Bypass parent constructor — we only proxy log().
+        }
+
+        public function log($level, $message, array $context = []): void
+        {
+            $this->sink[] = ['level' => (string) $level, 'message' => (string) $message, 'context' => $context];
+        }
+    });
+
+    $event = new LogEvent(
+        occurredAt: new DateTimeImmutable,
+        level: 'info',
+        message: 'cohort generated',
+        context: ['cohort_id' => 42],
+        traceId: str_repeat('a', 32),
+        spanId: str_repeat('b', 16),
+        tenantId: 7,
+    );
+
+    expect($this->shipper->ship($event))->toBeTrue()
+        ->and($captured)->toHaveCount(1)
+        ->and($captured[0]['level'])->toBe('info')
+        ->and($captured[0]['message'])->toBe('cohort generated')
+        ->and($captured[0]['context'])->toMatchArray([
+            'cohort_id' => 42,
+            'trace_id' => str_repeat('a', 32),
+            'span_id' => str_repeat('b', 16),
+            'tenant_id' => 7,
+        ]);
+});
+
+it('returns true for recordMetric (CE default has a no-op metric impl)', function () {
+    $metric = new MetricEvent(
+        type: 'counter',
+        name: 'parthenon.test.count',
+        value: 1.0,
+        tags: ['env' => 'test'],
+        unit: '1',
+    );
+
+    expect($this->shipper->recordMetric($metric))->toBeTrue();
+});
+
+it('startSpan returns a usable handle that finishes cleanly', function () {
+    $ctx = new SpanContext(
+        name: 'cohort.materialize',
+        traceId: str_repeat('a', 32),
+        spanId: str_repeat('b', 16),
+    );
+
+    $handle = $this->shipper->startSpan($ctx);
+
+    expect($handle)->toBeInstanceOf(TraceHandle::class)
+        ->and($handle->context)->toBe($ctx);
+
+    // Must not throw, must be idempotent.
+    $handle->finish('ok');
+    $handle->finish('ok');
+
+    expect(true)->toBeTrue();
+});
+
+it('returns false from ship() when the underlying logger explodes', function () {
+    Log::swap(new class extends LogManager
+    {
+        public function __construct() {}
+
+        public function log($level, $message, array $context = []): void
+        {
+            throw new RuntimeException('logger boom');
+        }
+    });
+
+    $event = new LogEvent(
+        occurredAt: new DateTimeImmutable,
+        level: 'error',
+        message: 'simulated logger failure',
+    );
+
+    // CE shipper guarantees ship() never throws.
+    expect($this->shipper->ship($event))->toBeFalse();
+});

--- a/backend/tests/Feature/Observability/ObservabilityValueObjectsTest.php
+++ b/backend/tests/Feature/Observability/ObservabilityValueObjectsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Observability\LogEvent;
+use App\Observability\MetricEvent;
+use App\Observability\SpanContext;
+use App\Observability\TraceHandle;
+
+it('LogEvent retains every field passed to the constructor', function () {
+    $now = new DateTimeImmutable;
+    $event = new LogEvent(
+        occurredAt: $now,
+        level: 'warning',
+        message: 'slow query detected',
+        context: ['duration_ms' => 1234],
+        traceId: str_repeat('a', 32),
+        spanId: str_repeat('b', 16),
+        tenantId: 5,
+    );
+
+    expect($event->occurredAt)->toBe($now)
+        ->and($event->level)->toBe('warning')
+        ->and($event->message)->toBe('slow query detected')
+        ->and($event->context)->toMatchArray(['duration_ms' => 1234])
+        ->and($event->traceId)->toBe(str_repeat('a', 32))
+        ->and($event->spanId)->toBe(str_repeat('b', 16))
+        ->and($event->tenantId)->toBe(5);
+});
+
+it('MetricEvent defaults unit to empty (R5 backward-compat)', function () {
+    $event = new MetricEvent(type: 'counter', name: 'parthenon.x', value: 1.0);
+
+    expect($event->unit)->toBe('')
+        ->and($event->tags)->toBe([]);
+});
+
+it('MetricEvent accepts a UCUM-style unit hint (R5)', function () {
+    $event = new MetricEvent(
+        type: 'histogram',
+        name: 'parthenon.cohort.materialize.duration',
+        value: 142.0,
+        tags: ['source' => 'eunomia'],
+        unit: 'ms',
+    );
+
+    expect($event->unit)->toBe('ms')
+        ->and($event->type)->toBe('histogram');
+});
+
+it('SpanContext preserves W3C identifiers', function () {
+    $ctx = new SpanContext(
+        name: 'cohort.materialize',
+        traceId: str_repeat('1', 32),
+        spanId: str_repeat('2', 16),
+        parentSpanId: str_repeat('3', 16),
+        attributes: ['cohort_id' => 99],
+    );
+
+    expect(strlen($ctx->traceId))->toBe(32)
+        ->and(strlen($ctx->spanId))->toBe(16)
+        ->and($ctx->parentSpanId)->toBe(str_repeat('3', 16))
+        ->and($ctx->attributes)->toMatchArray(['cohort_id' => 99]);
+});
+
+it('TraceHandle.finish() invokes the finisher exactly once and is safe to repeat', function () {
+    $ctx = new SpanContext('cohort.materialize', str_repeat('a', 32), str_repeat('b', 16));
+    $calls = [];
+
+    $handle = new TraceHandle($ctx, function (SpanContext $c, string $status) use (&$calls): void {
+        $calls[] = ['span' => $c->name, 'status' => $status];
+    });
+
+    $handle->setAttribute('rows', 1234);
+    $handle->finish('ok');
+    $handle->finish('ok');     // idempotent
+    $handle->finish('error');  // still no second invocation
+
+    expect($calls)->toHaveCount(1)
+        ->and($calls[0])->toMatchArray(['span' => 'cohort.materialize', 'status' => 'ok'])
+        ->and($handle->attributes())->toMatchArray(['rows' => 1234]);
+});
+
+it('TraceHandle.recordException() collects exceptions for inspection', function () {
+    $ctx = new SpanContext('cohort.materialize', str_repeat('a', 32), str_repeat('b', 16));
+    $handle = new TraceHandle($ctx, fn () => null);
+
+    $handle->recordException(new RuntimeException('boom'));
+
+    expect($handle->exceptions())->toHaveCount(1)
+        ->and($handle->exceptions()[0])->toBeInstanceOf(RuntimeException::class);
+});

--- a/backend/tests/Feature/Observability/ShipperRegistryTest.php
+++ b/backend/tests/Feature/Observability/ShipperRegistryTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contracts\ObservabilityShipperInterface;
+use App\Observability\LogEvent;
+use App\Observability\MetricEvent;
+use App\Observability\Observer;
+use App\Observability\ShipperRegistry;
+use App\Observability\Shippers\LokiPrometheusShipper;
+use App\Observability\SpanContext;
+use App\Observability\TraceHandle;
+use Tests\Feature\Observability\StubDatadogShipper;
+
+it('boots with the CE default LokiPrometheusShipper registered', function () {
+    /** @var ShipperRegistry $registry */
+    $registry = app(ShipperRegistry::class);
+
+    expect($registry->names())->toContain('loki-prometheus')
+        ->and($registry->shippers()[0])->toBeInstanceOf(LokiPrometheusShipper::class);
+});
+
+it('fans out logs and metrics to a runtime-registered shipper (pluggability proof)', function () {
+    $stub = new StubDatadogShipper;
+
+    /** @var ShipperRegistry $registry */
+    $registry = app(ShipperRegistry::class);
+    $registry->register($stub);
+
+    obs()->log('info', 'plug-in event', ['k' => 'v']);
+    obs()->metric('parthenon.cohorts.created', 3.0, 'counter', ['source' => 'eunomia'], '1');
+
+    expect($stub->logs)->toHaveCount(1)
+        ->and($stub->logs[0]->message)->toBe('plug-in event')
+        ->and($stub->logs[0]->context)->toMatchArray(['k' => 'v'])
+        ->and($stub->metrics)->toHaveCount(1)
+        ->and($stub->metrics[0]->name)->toBe('parthenon.cohorts.created')
+        ->and($stub->metrics[0]->value)->toBe(3.0)
+        ->and($stub->metrics[0]->unit)->toBe('1')
+        ->and($stub->metrics[0]->tags)->toMatchArray(['source' => 'eunomia']);
+});
+
+it('skips shippers reporting isAvailable=false', function () {
+    $offline = new StubDatadogShipper(available: false);
+
+    /** @var ShipperRegistry $registry */
+    $registry = app(ShipperRegistry::class);
+    $registry->register($offline);
+
+    obs()->log('warning', 'should not reach offline shipper');
+
+    expect($offline->logs)->toBeEmpty();
+});
+
+it('keeps fanning out when one shipper throws', function () {
+    $boom = new class implements ObservabilityShipperInterface
+    {
+        public function name(): string
+        {
+            return 'boom';
+        }
+
+        public function isAvailable(): bool
+        {
+            return true;
+        }
+
+        public function ship(LogEvent $event): bool
+        {
+            throw new RuntimeException('shipper exploded');
+        }
+
+        public function recordMetric(MetricEvent $event): bool
+        {
+            throw new RuntimeException('shipper exploded');
+        }
+
+        public function startSpan(SpanContext $context): TraceHandle
+        {
+            return new TraceHandle($context, fn () => null);
+        }
+    };
+
+    $survivor = new StubDatadogShipper;
+
+    /** @var ShipperRegistry $registry */
+    $registry = app(ShipperRegistry::class);
+    $registry->register($boom);
+    $registry->register($survivor);
+
+    // Must not throw out of obs()->log()/metric().
+    obs()->log('error', 'fan-out resilience test');
+    obs()->metric('parthenon.test.gauge', 1.0, 'gauge');
+
+    expect($survivor->logs)->toHaveCount(1)
+        ->and($survivor->metrics)->toHaveCount(1);
+});
+
+it('span() returns a finishable handle even with no shippers registered', function () {
+    /** @var ShipperRegistry $registry */
+    $registry = app(ShipperRegistry::class);
+    $registry->clear();
+
+    $observer = new Observer($registry);
+
+    $handle = $observer->span('cohort.materialize', ['cohort_id' => 1]);
+
+    expect($handle)->toBeInstanceOf(TraceHandle::class)
+        ->and($handle->context->name)->toBe('cohort.materialize')
+        ->and($handle->context->attributes)->toMatchArray(['cohort_id' => 1]);
+
+    $handle->finish('ok');
+    expect(true)->toBeTrue();
+});

--- a/backend/tests/Feature/Observability/StubDatadogShipper.php
+++ b/backend/tests/Feature/Observability/StubDatadogShipper.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Observability;
+
+use App\Contracts\ObservabilityShipperInterface;
+use App\Observability\LogEvent;
+use App\Observability\MetricEvent;
+use App\Observability\SpanContext;
+use App\Observability\TraceHandle;
+
+/**
+ * Test fixture proving an EE shipper can plug into the registry without any
+ * CE code modification. Captures every event for assertion in pluggability
+ * tests.
+ */
+class StubDatadogShipper implements ObservabilityShipperInterface
+{
+    /** @var array<int, LogEvent> */
+    public array $logs = [];
+
+    /** @var array<int, MetricEvent> */
+    public array $metrics = [];
+
+    /** @var array<int, SpanContext> */
+    public array $startedSpans = [];
+
+    /** @var array<int, array{context: SpanContext, status: string}> */
+    public array $finishedSpans = [];
+
+    public function __construct(public bool $available = true) {}
+
+    public function name(): string
+    {
+        return 'stub-datadog';
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->available;
+    }
+
+    public function ship(LogEvent $event): bool
+    {
+        $this->logs[] = $event;
+
+        return true;
+    }
+
+    public function recordMetric(MetricEvent $event): bool
+    {
+        $this->metrics[] = $event;
+
+        return true;
+    }
+
+    public function startSpan(SpanContext $context): TraceHandle
+    {
+        $this->startedSpans[] = $context;
+
+        return new TraceHandle($context, function (SpanContext $ctx, string $status): void {
+            $this->finishedSpans[] = ['context' => $ctx, 'status' => $status];
+        });
+    }
+}

--- a/docs/architecture/extension-points.md
+++ b/docs/architecture/extension-points.md
@@ -19,7 +19,7 @@ Each extension point ships with:
 | 2 | Tenant resolver | `App\Contracts\TenantResolverInterface` | [tenant-resolver.md](extension-points/tenant-resolver.md) |
 | 3 | Crypto provider | `App\Contracts\CryptoProviderInterface` | [crypto-provider.md](extension-points/crypto-provider.md) |
 | 4 | Audit sink | `App\Contracts\AuditSinkInterface` | [audit-sink.md](extension-points/audit-sink.md) |
-| 5 | Observability shipper | `App\Contracts\ObservabilityShipperInterface` | (Plan 02-05) |
+| 5 | Observability shipper | `App\Contracts\ObservabilityShipperInterface` | [observability-shipper.md](extension-points/observability-shipper.md) |
 | 6 | Frontend feature flags + EnterpriseGate | `frontend/src/contracts/featureFlags.ts` | (Plan 02-06) |
 | 7 | Acropolis installer phase registry | `acropolis/installer/phases/Phase` (Python) | (Plan 02-07) |
 | 8 | Compose composition contract | `docker-compose.yml` override conventions | (Plan 02-08) |

--- a/docs/architecture/extension-points/observability-shipper.md
+++ b/docs/architecture/extension-points/observability-shipper.md
@@ -1,0 +1,235 @@
+# Extension Point: Observability Shipper
+
+**Interface:** `App\Contracts\ObservabilityShipperInterface`
+**Default shipper (CE):** `App\Observability\Shippers\LokiPrometheusShipper`
+**Service provider:** `App\Providers\ObservabilityServiceProvider`
+**Public API:** `App\Observability\Observer` — accessed via the global `obs()` helper
+**Registry:** `App\Observability\ShipperRegistry`
+**Config:** `backend/config/observability.php`
+**Status:** Live since [Phase 2 #5](../../superpowers/plans/2026-05-09-ce-ee-fork-plan-02-05-observability-shipper.md)
+
+## Purpose
+
+Decouple Parthenon's observability emissions (structured logs, metrics, traces) from a specific backend. CE forwards through the existing Laravel logger so Loki and Prometheus continue to scrape unchanged. EE adds shippers for Datadog, Splunk HEC, and OpenTelemetry / OTLP-HTTP collectors so customers with managed observability stacks can route everything through a single contract without patching CE call sites.
+
+Multiple shippers can be registered (fan-out); failure of one shipper does not block the others. Shippers MUST NOT throw out of `ship()` or `recordMetric()` — telemetry failures must never affect the request lifecycle.
+
+The architecture has five collaborating pieces:
+
+1. **Value objects** — `LogEvent`, `MetricEvent`, `SpanContext`, `TraceHandle` describe what is being shipped without leaking vendor specifics.
+2. **`ObservabilityShipperInterface`** — the extension contract. Each shipper implements `name()`, `isAvailable()`, `ship()`, `recordMetric()`, `startSpan()`.
+3. **`ShipperRegistry`** — singleton, ordered list of registered shippers; supports runtime registration so EE bundles plug in via their service provider.
+4. **`Observer`** — public API resolved via the `obs()` helper. Builds the right value object, fans out to every available shipper, and swallows shipper exceptions.
+5. **`LokiPrometheusShipper`** — the CE default. A near-no-op that forwards logs to the Laravel logger (Loki picks them up) and records metrics through `promphp/prometheus_client_php` if the package is installed.
+
+## The contract
+
+```php
+interface ObservabilityShipperInterface
+{
+    public function name(): string;
+    public function isAvailable(): bool;
+
+    /** Best-effort log shipping. MUST NOT throw — return false on failure. */
+    public function ship(LogEvent $event): bool;
+
+    /** Best-effort metric recording. MUST NOT throw. */
+    public function recordMetric(MetricEvent $event): bool;
+
+    /** Returns a handle that the caller MUST finish() (typically inside try/finally). */
+    public function startSpan(SpanContext $context): TraceHandle;
+}
+```
+
+### Best-effort guarantee
+
+`ship()` and `recordMetric()` must catch every exception internally, log it, and return `false`. The Observer wraps each call with a defensive `try/catch` as well — even a misbehaving third-party shipper that throws will not abort the request. This is the same pattern the audit sink uses (Plan 02-04), but stricter: while audit sinks may legitimately throw to ABORT a request under "no-audit-no-action" policies, observability shippers MUST NEVER throw — telemetry must not be load-bearing.
+
+### Trace context propagation
+
+`SpanContext` carries W3C-compatible identifiers (`traceId`: 32 hex chars, `spanId`: 16 hex chars). Spans returned from `Observer::span()` use the first available shipper as the source of truth for trace IDs; other shippers are notified through the `TraceHandle::finish()` callback, which lets EE's OTel shipper invariably emit OTLP/HTTP spans without CE knowing or caring.
+
+CE's `LokiPrometheusShipper` returns a no-op `TraceHandle` — distributed tracing is opt-in and requires `opentelemetry-php` to be installed. The handle still exposes `setAttribute()` / `recordException()` / `finish()` so application code is identical regardless of whether traces are enabled.
+
+## Value objects
+
+```php
+final readonly class LogEvent
+{
+    public function __construct(
+        public DateTimeImmutable $occurredAt,
+        public string $level,           // PSR-3 level
+        public string $message,
+        public array $context = [],     // structured, JSON-serializable
+        public ?string $traceId = null, // W3C 32-hex
+        public ?string $spanId = null,  // W3C 16-hex
+        public ?int $tenantId = null,   // populated from TenantResolverInterface
+    ) {}
+}
+
+final readonly class MetricEvent
+{
+    public function __construct(
+        public string $type,            // 'counter' | 'gauge' | 'histogram'
+        public string $name,            // e.g. 'parthenon.cohorts.generated.count'
+        public float $value,
+        public array $tags = [],        // string-keyed string-valued, low-cardinality
+        public DateTimeImmutable $occurredAt = new DateTimeImmutable,
+        public string $unit = '',       // R5: UCUM-style unit hint ('', 's', 'ms', 'By', '1')
+    ) {}
+}
+
+final readonly class SpanContext
+{
+    public function __construct(
+        public string $name,
+        public string $traceId,
+        public string $spanId,
+        public ?string $parentSpanId = null,
+        public array $attributes = [],
+    ) {}
+}
+```
+
+### Why a `unit` field on MetricEvent (R5)
+
+OpenTelemetry, Prometheus 3+, and Datadog all want a unit annotation on every metric so dashboards can render axes correctly. Adding it here, with `''` as the default, lets EE shippers emit OTLP-correct unit annotations without forcing CE callers to migrate. UCUM-style codes are recommended (`s`, `ms`, `By`, `KiBy`, `1` for unitless counts).
+
+## Public API
+
+Application code emits events through the global `obs()` helper:
+
+```php
+// Structured log
+obs()->log('info', 'cohort generated', ['cohort_id' => $cohort->id]);
+
+// Counter metric (default type)
+obs()->metric('parthenon.cohorts.generated.count', 1.0);
+
+// Histogram with unit
+obs()->metric('parthenon.cohort.materialize.duration', 142.0, 'histogram', [], 'ms');
+
+// Trace span — finish() inside try/finally
+$handle = obs()->span('cohort.materialize', ['cohort_id' => $cohort->id]);
+try {
+    $cohort->materialize();
+} catch (Throwable $e) {
+    $handle->recordException($e);
+    throw $e;
+} finally {
+    $handle->finish();
+}
+```
+
+`Observer::log()` automatically attaches the current tenant id via `TenantResolverInterface` (Plan 02-02) when bound, so multi-tenant deployments get tenant scoping for free.
+
+## Configuration
+
+```php
+// backend/config/observability.php
+return [
+    'shippers' => [
+        \App\Observability\Shippers\LokiPrometheusShipper::class,
+        // EE appends \Enterprise\Observability\Shippers\DatadogShipper::class etc.
+    ],
+    'sampling' => [
+        'logs' => env('OBS_LOG_SAMPLING', 1.0),
+        'metrics' => env('OBS_METRIC_SAMPLING', 1.0),
+        'traces' => env('OBS_TRACE_SAMPLING', 0.1),
+    ],
+];
+```
+
+Each shipper class is resolved through the container; the service provider registers the resulting instance with `ShipperRegistry`. EE's `EnterpriseObservabilityServiceProvider` calls `$registry->register($datadog)` after CE boot — the existing CE entry remains, the EE entries are appended.
+
+## Pluggability proof
+
+`tests/Feature/Observability/ShipperRegistryTest.php` registers a `StubDatadogShipper` at runtime (without modifying any CE config) and asserts that:
+
+- `obs()->log()` reaches the stub
+- `obs()->metric()` reaches the stub
+- `MetricEvent::unit` round-trips correctly through the registry (R5)
+- A shipper that throws does not break fan-out for other shippers
+- `isAvailable()=false` shippers are skipped
+- `obs()->span()` returns a usable, finishable handle even when no shippers are registered
+
+These assertions are the contract every alternate shipper must satisfy.
+
+## EE shipper sketches
+
+### Datadog (HTTP intake)
+
+```php
+class DatadogShipper implements ObservabilityShipperInterface
+{
+    public function ship(LogEvent $event): bool
+    {
+        return $this->httpPost('https://http-intake.logs.datadoghq.com/api/v2/logs', [
+            'ddsource' => 'parthenon',
+            'ddtags' => 'env:'.config('app.env'),
+            'service' => 'parthenon',
+            'level' => $event->level,
+            'message' => $event->message,
+            'attributes' => $event->context,
+            'trace_id' => $event->traceId,
+            'span_id' => $event->spanId,
+            'tenant_id' => $event->tenantId,
+        ]);
+    }
+    // recordMetric() POSTs to /api/v2/series with $event->unit mapped to DD's unit field.
+    // startSpan() uses dd-trace-php and returns a TraceHandle that finishes via that SDK.
+}
+```
+
+### Splunk HEC
+
+```php
+class SplunkShipper implements ObservabilityShipperInterface
+{
+    public function ship(LogEvent $event): bool
+    {
+        return $this->httpPost($this->hecUrl.'/services/collector/event', [
+            'time' => $event->occurredAt->getTimestamp(),
+            'host' => gethostname(),
+            'source' => 'parthenon',
+            'sourcetype' => '_json',
+            'event' => array_merge($event->context, [
+                'message' => $event->message,
+                'level' => $event->level,
+                'trace_id' => $event->traceId,
+                'tenant_id' => $event->tenantId,
+            ]),
+        ], headers: ['Authorization' => 'Splunk '.$this->hecToken]);
+    }
+}
+```
+
+### OpenTelemetry / OTLP-HTTP
+
+```php
+class OtelShipper implements ObservabilityShipperInterface
+{
+    public function ship(LogEvent $event): bool { /* OTLP-HTTP /v1/logs */ }
+    public function recordMetric(MetricEvent $event): bool { /* OTLP-HTTP /v1/metrics with $event->unit */ }
+    public function startSpan(SpanContext $context): TraceHandle {
+        // Use opentelemetry-php to start a span backed by OTLP-HTTP /v1/traces.
+    }
+}
+```
+
+## Sampling
+
+CE does not sample (sampling rates of 1.0 / 0.1 are advisory). EE shippers apply the rates from `config('observability.sampling')` because vendor backends bill by event volume. Sampling decisions happen inside the shipper, AFTER the registry hands the event off, so different shippers can sample differently (e.g., 100% logs to Loki, 10% logs to Datadog).
+
+## Out of scope (for Plan 02-05)
+
+- Distributed trace propagation across the AI sidecar / R sidecar — handled when those sidecars adopt the contract.
+- Per-tenant routing (e.g., tenant A's logs go to Datadog, tenant B's stay on Loki) — depends on Plan 02-02 + EE.
+- Adaptive sampling, head-based vs tail-based sampling.
+
+## Anti-patterns
+
+- ❌ Don't call `Log::*` directly from new code; use `obs()->log()` so EE shippers see the event too.
+- ❌ Don't throw from a shipper to signal "telemetry backend down" — return `false` and log internally.
+- ❌ Don't block the request thread on a slow shipper. EE shippers that talk to remote APIs MUST use Laravel's queue (`isAvailable()` may return false while the queue worker is unreachable, OR ship asynchronously by enqueueing a job).
+- ❌ Don't include high-cardinality values in `MetricEvent::tags` (UUIDs, request IDs). Tags are for grouping; high cardinality blows up Prometheus and Datadog cost.


### PR DESCRIPTION
## Summary

Adds the fifth CE/EE extension-point seam: a pluggable `ObservabilityShipperInterface` so EE bundles (Datadog, Splunk, OTel) can plug into Parthenon's observability surface without patching CE call sites. CE behavior is preserved byte-for-byte through the `LokiPrometheusShipper` default — Loki/Prometheus continue to scrape unchanged, and existing `Log::*` calls keep working.

This is Plan 02-05 from the [Phase 2 umbrella](docs/superpowers/plans/2026-05-08-ce-ee-fork-plan-02-extension-points-umbrella.md). Independent track — no dependencies on the other Phase 2 plans (boots cleanly with or without the prior 4 extension points).

## What landed

- **Contract:** `App\Contracts\ObservabilityShipperInterface` — `name`, `isAvailable`, `ship(LogEvent)`, `recordMetric(MetricEvent)`, `startSpan(SpanContext): TraceHandle`.
- **Value objects:** `LogEvent`, `MetricEvent` (with R5 UCUM-style `unit` hint), `SpanContext`, `TraceHandle`.
- **Registry + Observer:** `ShipperRegistry` for runtime registration; `Observer` (resolved via the `obs()` helper) fans events out and swallows shipper exceptions defensively.
- **CE default:** `LokiPrometheusShipper` — bridges to the Laravel logger (Loki picks up via container log driver), `recordMetric()` is a controlled no-op until `promphp/prometheus_client_php` is wired, `startSpan()` returns a usable no-op handle.
- **NullShipper** for air-gapped / test contexts.
- **Wiring:** `ObservabilityServiceProvider` + `config/observability.php` + `obs()` helper (registered via composer `autoload.files`).
- **Docs:** [`docs/architecture/extension-points/observability-shipper.md`](docs/architecture/extension-points/observability-shipper.md) with full EE shipper sketches (Datadog HTTP intake, Splunk HEC, OTLP-HTTP).

## EE wiring (informational)

```php
// In enterprise/backend/src/Providers/EnterpriseObservabilityServiceProvider.php
public function boot(): void
{
    $registry = $this->app->make(ShipperRegistry::class);
    $registry->register($this->app->make(DatadogShipper::class));
    $registry->register($this->app->make(SplunkShipper::class));
    $registry->register($this->app->make(OtelShipper::class));
}
```

No CE patches. CE's `LokiPrometheusShipper` keeps receiving every event; EE shippers stack on top.

## Test plan

- [x] 16 new Pest tests (65 assertions) all pass — `LokiPrometheusShipperTest`, `ObservabilityValueObjectsTest`, `ShipperRegistryTest`
- [x] Pint clean (host 8.4 vendor, also Docker container after re-run)
- [x] PHPStan level 8 clean on every new file (host PHP 8.4)
- [x] Pluggability proof: `StubDatadogShipper` plugs in via runtime registration with no CE config changes
- [x] Best-effort guarantee verified: shipper that throws does not break fan-out for surviving shippers
- [x] `obs()->span()` returns a finishable handle even with zero shippers registered
- [x] R5 `MetricEvent::unit` round-trips through registry fan-out

## Refs

- Spec: [`docs/superpowers/specs/2026-05-08-ce-ee-fork-and-agplv3-relicense-design.md`](docs/superpowers/specs/2026-05-08-ce-ee-fork-and-agplv3-relicense-design.md) §5 row 5
- Plan: [`docs/superpowers/plans/2026-05-09-ce-ee-fork-plan-02-05-observability-shipper.md`](docs/superpowers/plans/2026-05-09-ce-ee-fork-plan-02-05-observability-shipper.md)
- Cross-Plan Revision R5 — `MetricEvent::unit` (UCUM hint for OTel/Prometheus/Datadog interop).