### PR TITLE
feat(feature-flags): featureFlags store + EnterpriseGate (Phase 2 #6 of 8)

### DIFF
--- a/backend/app/FeatureFlags/FeatureFlag.php
+++ b/backend/app/FeatureFlags/FeatureFlag.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\FeatureFlags;
+
+use App\Http\Controllers\Api\V1\System\FeatureFlagsController;
+
+/**
+ * Immutable description of a single deployment-level feature flag.
+ *
+ * The {@see FeatureFlagResolver} composes a list of these from the
+ * configured drivers + license + EE registrations. The
+ * {@see FeatureFlagsController}
+ * serializes the list and the frontend hydrates it into Zustand.
+ */
+final readonly class FeatureFlag
+{
+    /**
+     * @param  string  $name  Dotted name, e.g. 'auth.saml', 'tenancy.multi'
+     * @param  bool  $enabled  Whether the deployment exposes the capability
+     * @param  string  $source  'ce' | 'ee' | 'config' | 'license' — diagnostic only
+     * @param  string|null  $description  Human-readable hint for admin UIs
+     */
+    public function __construct(
+        public string $name,
+        public bool $enabled,
+        public string $source,
+        public ?string $description = null,
+    ) {}
+
+    /**
+     * @return array{name: string, enabled: bool, source: string, description: string|null}
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'enabled' => $this->enabled,
+            'source' => $this->source,
+            'description' => $this->description,
+        ];
+    }
+}

--- a/backend/app/FeatureFlags/FeatureFlagResolver.php
+++ b/backend/app/FeatureFlags/FeatureFlagResolver.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\FeatureFlags;
+
+use App\Auth\AuthDriverRegistry;
+use App\Contracts\TenantResolverInterface;
+use App\Tenancy\SingleTenantResolver;
+
+/**
+ * Composes the active feature-flag set for the current deployment.
+ *
+ * Sources, in order:
+ *  1. `config('feature-flags.flags')` — explicit per-deployment overrides.
+ *  2. {@see AuthDriverRegistry} — every non-default auth driver registered
+ *     (Keycloak, SAML, SCIM) becomes an `auth.<driver>` flag.
+ *  3. Tenancy configuration — emits `tenancy.multi` reflecting whether
+ *     a non-CE TenantResolver is bound.
+ *
+ * Both registry-driven flags are EE-coupled: CE's defaults emit nothing for
+ * (2) and `tenancy.multi=false` for (3). EE bundles append more flags by
+ * registering EE drivers + binding their own `MultiTenantResolver`.
+ */
+class FeatureFlagResolver
+{
+    /**
+     * The auth driver names that ship with CE. They are NOT projected to
+     * feature flags (no `auth.local` flag, no `auth.authentik-oidc` flag) —
+     * those capabilities are part of the CE baseline. Only EE-additive
+     * drivers (saml, keycloak, scim, ...) become flags.
+     */
+    private const CE_AUTH_DRIVERS = ['local', 'authentik-oidc'];
+
+    public function __construct(
+        private readonly ?AuthDriverRegistry $authDrivers = null,
+        private readonly ?TenantResolverInterface $tenants = null,
+    ) {}
+
+    /**
+     * @return array<int, FeatureFlag>
+     */
+    public function resolve(): array
+    {
+        $flags = [];
+
+        $configured = config('feature-flags.flags', []);
+        if (is_array($configured)) {
+            foreach ($configured as $name => $spec) {
+                if (! is_string($name) || ! is_array($spec)) {
+                    continue;
+                }
+                $flags[] = new FeatureFlag(
+                    name: $name,
+                    enabled: (bool) ($spec['enabled'] ?? false),
+                    source: is_string($spec['source'] ?? null) ? $spec['source'] : 'config',
+                    description: is_string($spec['description'] ?? null) ? $spec['description'] : null,
+                );
+            }
+        }
+
+        if ($this->authDrivers !== null) {
+            foreach ($this->authDrivers->availableNames() as $driverName) {
+                if (in_array($driverName, self::CE_AUTH_DRIVERS, true)) {
+                    continue;
+                }
+                $flags[] = new FeatureFlag(
+                    name: "auth.{$driverName}",
+                    enabled: true,
+                    source: 'ee',
+                    description: "Auth driver '{$driverName}' is registered.",
+                );
+            }
+        }
+
+        $resolverClass = config('tenancy.resolver');
+        $isMulti = is_string($resolverClass) && $resolverClass !== SingleTenantResolver::class;
+        $flags[] = new FeatureFlag(
+            name: 'tenancy.multi',
+            enabled: $isMulti,
+            source: $isMulti ? 'ee' : 'ce',
+            description: 'Multi-tenant request routing.',
+        );
+
+        return $flags;
+    }
+}

--- a/backend/app/Http/Controllers/Api/V1/System/FeatureFlagsController.php
+++ b/backend/app/Http/Controllers/Api/V1/System/FeatureFlagsController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\System;
+
+use App\FeatureFlags\FeatureFlagResolver;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * @group System
+ *
+ * Returns the active deployment-level feature flags.
+ *
+ * Flags reflect installed drivers / license / EE registrations — they do
+ * NOT carry per-user RBAC. The endpoint is intentionally unauthenticated
+ * (per Plan 02-06) because every CE deployment ships an effectively-empty
+ * flag set and the response only describes capability presence, not data.
+ */
+class FeatureFlagsController extends Controller
+{
+    /**
+     * GET /api/v1/system/feature-flags
+     *
+     * Response shape:
+     *  {
+     *    "data": [
+     *      { "name": "tenancy.multi", "enabled": false, "source": "ce", "description": "..." }
+     *    ]
+     *  }
+     */
+    public function index(FeatureFlagResolver $resolver): JsonResponse
+    {
+        $flags = array_map(
+            static fn ($f) => $f->toArray(),
+            $resolver->resolve(),
+        );
+
+        return response()->json(['data' => $flags]);
+    }
+}

--- a/backend/app/Providers/FeatureFlagsServiceProvider.php
+++ b/backend/app/Providers/FeatureFlagsServiceProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Auth\AuthDriverRegistry;
+use App\Contracts\TenantResolverInterface;
+use App\FeatureFlags\FeatureFlagResolver;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Wires the deployment-level feature-flag extension point.
+ *
+ *  - Merges `config/feature-flags.php` so EE's published config can override.
+ *  - Singleton-binds {@see FeatureFlagResolver} so the controller and any
+ *    in-process consumers (e.g., Blade conditionals, console commands) see
+ *    the same resolver.
+ *  - Resolves AuthDriverRegistry + TenantResolverInterface lazily so this
+ *    provider boots even in minimal CLI contexts (e.g., `artisan tinker`)
+ *    where tenancy/auth aren't yet bound.
+ */
+class FeatureFlagsServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../../config/feature-flags.php', 'feature-flags');
+
+        $this->app->singleton(FeatureFlagResolver::class, function ($app): FeatureFlagResolver {
+            $auth = null;
+            $tenants = null;
+
+            try {
+                $auth = $app->make(AuthDriverRegistry::class);
+            } catch (BindingResolutionException) {
+                // AuthDriverRegistry not bound — feature flags fall back to config-only.
+            }
+
+            try {
+                $tenants = $app->make(TenantResolverInterface::class);
+            } catch (BindingResolutionException) {
+                // TenantResolver not bound — tenancy flag still emits via config('tenancy.resolver').
+            }
+
+            return new FeatureFlagResolver(
+                authDrivers: $auth,
+                tenants: $tenants,
+            );
+        });
+    }
+}

--- a/backend/bootstrap/providers.php
+++ b/backend/bootstrap/providers.php
@@ -7,6 +7,7 @@ use App\Providers\AuthDriverServiceProvider;
 use App\Providers\ClinicalCoherenceServiceProvider;
 use App\Providers\CryptoProviderServiceProvider;
 use App\Providers\DataQualityServiceProvider;
+use App\Providers\FeatureFlagsServiceProvider;
 use App\Providers\NetworkAnalysisServiceProvider;
 use App\Providers\ObservabilityServiceProvider;
 use App\Providers\PopulationCharacterizationServiceProvider;
@@ -22,6 +23,7 @@ return [
     AuthDriverServiceProvider::class,
     AuditServiceProvider::class,
     ObservabilityServiceProvider::class,
+    FeatureFlagsServiceProvider::class,
     AchillesServiceProvider::class,
     ClinicalCoherenceServiceProvider::class,
     DataQualityServiceProvider::class,

--- a/backend/config/feature-flags.php
+++ b/backend/config/feature-flags.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Per-deployment explicit flags
+    |--------------------------------------------------------------------------
+    |
+    | Keyed by flag name. Each entry can set { enabled, source, description }.
+    | EE bundles append entries via their own published config or via a
+    | container override on App\FeatureFlags\FeatureFlagResolver.
+    |
+    | CE ships ZERO entries here — every deployment-level flag is implied by
+    | what drivers/resolvers are bound. EE's EnterpriseFeatureFlagsProvider
+    | populates this list (or returns its own resolver) when the EE overlay
+    | is installed.
+    */
+    'flags' => [
+        // Example (commented):
+        // 'audit.signed' => [
+        //     'enabled' => false,
+        //     'source'  => 'ce',
+        //     'description' => 'Signed (HMAC) audit chain shipped to WORM storage.',
+        // ],
+    ],
+];

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -145,6 +145,7 @@ use App\Http\Controllers\Api\V1\SurveyConductController;
 use App\Http\Controllers\Api\V1\SurveyHonestBrokerController;
 use App\Http\Controllers\Api\V1\SurveyInstrumentController;
 use App\Http\Controllers\Api\V1\SyntheaController;
+use App\Http\Controllers\Api\V1\System\FeatureFlagsController;
 use App\Http\Controllers\Api\V1\TemplatesController;
 use App\Http\Controllers\Api\V1\TextToSqlController;
 use App\Http\Controllers\Api\V1\UserProfileController;
@@ -189,6 +190,9 @@ Route::prefix('v1')->group(function () {
 
     // §9.2 — Public shared cohort link (no auth required)
     Route::get('/cohort-definitions/shared/{token}', [CohortDefinitionController::class, 'showShared']);
+
+    // Plan 02-06 — Deployment-level feature flags (public; describes capability presence only).
+    Route::get('/system/feature-flags', [FeatureFlagsController::class, 'index']);
 
     // Poseidon webhook (Dagster → Laravel, secret-authenticated, no Sanctum)
     Route::post('/poseidon/webhooks/run-status', [PoseidonController::class, 'webhook'])

--- a/backend/tests/Feature/Api/V1/System/FeatureFlagsControllerTest.php
+++ b/backend/tests/Feature/Api/V1/System/FeatureFlagsControllerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Tenancy\SingleTenantResolver;
+
+it('returns 200 + a tenancy.multi flag without authentication on a fresh CE install', function () {
+    config(['tenancy.resolver' => SingleTenantResolver::class]);
+    config(['feature-flags.flags' => []]);
+
+    $res = $this->getJson('/api/v1/system/feature-flags');
+
+    $res->assertOk();
+    $body = $res->json();
+    expect($body)->toHaveKey('data')
+        ->and($body['data'])->toBeArray();
+
+    $names = collect($body['data'])->pluck('name')->all();
+    expect($names)
+        ->toContain('tenancy.multi')
+        ->and($names)->not->toContain('auth.saml')
+        ->and($names)->not->toContain('auth.keycloak');
+});
+
+it('reports tenancy.multi=false / source=ce on the CE single-tenant default', function () {
+    config(['tenancy.resolver' => SingleTenantResolver::class]);
+
+    $res = $this->getJson('/api/v1/system/feature-flags');
+
+    $tenancy = collect($res->json('data'))->firstWhere('name', 'tenancy.multi');
+    expect($tenancy)
+        ->not->toBeNull()
+        ->and($tenancy['enabled'])->toBeFalse()
+        ->and($tenancy['source'])->toBe('ce');
+});
+
+it('flips tenancy.multi=true / source=ee when MultiTenantResolver class name is configured', function () {
+    config(['tenancy.resolver' => 'Acumenus\\Parthenon\\Enterprise\\Tenant\\MultiTenantResolver']);
+
+    $res = $this->getJson('/api/v1/system/feature-flags');
+
+    $tenancy = collect($res->json('data'))->firstWhere('name', 'tenancy.multi');
+    expect($tenancy['enabled'])->toBeTrue()
+        ->and($tenancy['source'])->toBe('ee');
+});
+
+it('does not require authentication (deployment posture is public by design)', function () {
+    $this->getJson('/api/v1/system/feature-flags')->assertOk();
+});
+
+it('every entry has the documented shape', function () {
+    $res = $this->getJson('/api/v1/system/feature-flags');
+
+    foreach ($res->json('data') as $row) {
+        expect($row)->toHaveKeys(['name', 'enabled', 'source', 'description'])
+            ->and($row['name'])->toBeString()
+            ->and($row['enabled'])->toBeBool()
+            ->and(in_array($row['source'], ['ce', 'ee', 'config', 'license'], true))->toBeTrue();
+    }
+});
+
+it('surfaces config-driven flags in the response', function () {
+    config(['feature-flags.flags' => [
+        'audit.signed' => [
+            'enabled' => true,
+            'source' => 'ee',
+            'description' => 'Signed audit chain.',
+        ],
+    ]]);
+
+    $res = $this->getJson('/api/v1/system/feature-flags');
+
+    $signed = collect($res->json('data'))->firstWhere('name', 'audit.signed');
+    expect($signed)
+        ->not->toBeNull()
+        ->and($signed['enabled'])->toBeTrue()
+        ->and($signed['source'])->toBe('ee')
+        ->and($signed['description'])->toBe('Signed audit chain.');
+});

--- a/backend/tests/Feature/FeatureFlags/FeatureFlagResolverTest.php
+++ b/backend/tests/Feature/FeatureFlags/FeatureFlagResolverTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Auth\AuthDriverRegistry;
+use App\Auth\Drivers\AuthDriverResult;
+use App\Contracts\AuthDriverInterface;
+use App\Contracts\TenantResolverInterface;
+use App\FeatureFlags\FeatureFlag;
+use App\FeatureFlags\FeatureFlagResolver;
+use App\Tenancy\SingleTenantResolver;
+
+beforeEach(function () {
+    config(['feature-flags.flags' => []]);
+});
+
+it('returns only the tenancy.multi flag on a fresh CE single-tenant install', function () {
+    config(['tenancy.resolver' => SingleTenantResolver::class]);
+
+    $resolver = new FeatureFlagResolver(
+        authDrivers: app(AuthDriverRegistry::class),
+        tenants: app(TenantResolverInterface::class),
+    );
+
+    $flags = $resolver->resolve();
+
+    $names = array_map(fn (FeatureFlag $f) => $f->name, $flags);
+    expect($names)
+        ->toContain('tenancy.multi')
+        ->and($names)->not->toContain('auth.saml')
+        ->and($names)->not->toContain('auth.keycloak');
+
+    $tenancy = collect($flags)->firstWhere('name', 'tenancy.multi');
+    expect($tenancy)
+        ->not->toBeNull()
+        ->and($tenancy->enabled)->toBeFalse()
+        ->and($tenancy->source)->toBe('ce');
+});
+
+it('flips tenancy.multi=true when a non-CE resolver is configured', function () {
+    config(['tenancy.resolver' => 'Acumenus\\Parthenon\\Enterprise\\Tenant\\MultiTenantResolver']);
+
+    $resolver = new FeatureFlagResolver(authDrivers: null, tenants: null);
+    $flags = $resolver->resolve();
+
+    $tenancy = collect($flags)->firstWhere('name', 'tenancy.multi');
+    expect($tenancy->enabled)->toBeTrue()
+        ->and($tenancy->source)->toBe('ee');
+});
+
+it('emits an EE-sourced flag for every non-CE auth driver registered', function () {
+    $registry = new AuthDriverRegistry;
+
+    // Register a CE-baseline driver and an EE-style driver.
+    $registry->register(new class implements AuthDriverInterface
+    {
+        public function name(): string
+        {
+            return 'local';
+        }
+
+        public function isAvailable(): bool
+        {
+            return true;
+        }
+
+        public function authenticate(array $credentials): AuthDriverResult
+        {
+            throw new LogicException('not used in this test');
+        }
+    });
+    $registry->register(new class implements AuthDriverInterface
+    {
+        public function name(): string
+        {
+            return 'saml';
+        }
+
+        public function isAvailable(): bool
+        {
+            return true;
+        }
+
+        public function authenticate(array $credentials): AuthDriverResult
+        {
+            throw new LogicException('not used in this test');
+        }
+    });
+
+    $resolver = new FeatureFlagResolver(authDrivers: $registry, tenants: null);
+    $flags = $resolver->resolve();
+
+    $authFlags = collect($flags)->filter(fn (FeatureFlag $f) => str_starts_with($f->name, 'auth.'));
+    $names = $authFlags->pluck('name')->all();
+
+    expect($names)
+        ->toContain('auth.saml')
+        ->and($names)->not->toContain('auth.local'); // CE baseline is not projected as a flag
+
+    $saml = $authFlags->firstWhere('name', 'auth.saml');
+    expect($saml->enabled)->toBeTrue()
+        ->and($saml->source)->toBe('ee');
+});
+
+it('honors per-deployment config('.var_export('feature-flags.flags', true).')', function () {
+    config(['feature-flags.flags' => [
+        'audit.signed' => [
+            'enabled' => true,
+            'source' => 'ee',
+            'description' => 'Signed audit chain.',
+        ],
+    ]]);
+
+    $resolver = new FeatureFlagResolver(authDrivers: null, tenants: null);
+    $flags = $resolver->resolve();
+
+    $signed = collect($flags)->firstWhere('name', 'audit.signed');
+    expect($signed)->not->toBeNull()
+        ->and($signed->enabled)->toBeTrue()
+        ->and($signed->source)->toBe('ee')
+        ->and($signed->description)->toBe('Signed audit chain.');
+});
+
+it('skips malformed entries in config()', function () {
+    config(['feature-flags.flags' => [
+        'good.flag' => ['enabled' => true],
+        42 => ['enabled' => true],          // non-string key
+        'bad.flag' => 'not-an-array',       // non-array spec
+    ]]);
+
+    $resolver = new FeatureFlagResolver(authDrivers: null, tenants: null);
+    $names = array_map(fn (FeatureFlag $f) => $f->name, $resolver->resolve());
+
+    expect($names)
+        ->toContain('good.flag')
+        ->and($names)->not->toContain('bad.flag')
+        ->and($names)->not->toContain('42');
+});
+
+it('every flag toArray() round-trips with stable shape', function () {
+    config(['tenancy.resolver' => SingleTenantResolver::class]);
+
+    $resolver = new FeatureFlagResolver(authDrivers: null, tenants: null);
+    $flags = $resolver->resolve();
+
+    foreach ($flags as $flag) {
+        $row = $flag->toArray();
+        expect($row)->toHaveKeys(['name', 'enabled', 'source', 'description'])
+            ->and($row['name'])->toBeString()
+            ->and($row['enabled'])->toBeBool()
+            ->and(in_array($row['source'], ['ce', 'ee', 'config', 'license'], true))->toBeTrue();
+    }
+});

--- a/docs/architecture/extension-points.md
+++ b/docs/architecture/extension-points.md
@@ -20,7 +20,7 @@ Each extension point ships with:
 | 3 | Crypto provider | `App\Contracts\CryptoProviderInterface` | [crypto-provider.md](extension-points/crypto-provider.md) |
 | 4 | Audit sink | `App\Contracts\AuditSinkInterface` | [audit-sink.md](extension-points/audit-sink.md) |
 | 5 | Observability shipper | `App\Contracts\ObservabilityShipperInterface` | [observability-shipper.md](extension-points/observability-shipper.md) |
-| 6 | Frontend feature flags + EnterpriseGate | `frontend/src/contracts/featureFlags.ts` | (Plan 02-06) |
+| 6 | Frontend feature flags + EnterpriseGate | `frontend/src/contracts/featureFlags.ts` | [feature-flags.md](extension-points/feature-flags.md) |
 | 7 | Acropolis installer phase registry | `acropolis/installer/phases/Phase` (Python) | (Plan 02-07) |
 | 8 | Compose composition contract | `docker-compose.yml` override conventions | (Plan 02-08) |
 

--- a/docs/architecture/extension-points/feature-flags.md
+++ b/docs/architecture/extension-points/feature-flags.md
@@ -1,0 +1,185 @@
+# Extension Point: Feature Flags + EnterpriseGate
+
+**Backend resolver:** `App\FeatureFlags\FeatureFlagResolver`
+**Backend value object:** `App\FeatureFlags\FeatureFlag`
+**Backend controller:** `App\Http\Controllers\Api\V1\System\FeatureFlagsController` (GET `/api/v1/system/feature-flags`)
+**Backend service provider:** `App\Providers\FeatureFlagsServiceProvider`
+**Backend config:** `backend/config/feature-flags.php`
+**Frontend store:** `frontend/src/stores/featureFlagsStore.ts` (Zustand)
+**Frontend hook:** `useFlag(name)` — typed boolean
+**Frontend gate component:** `frontend/src/components/EnterpriseGate.tsx`
+**Frontend extension contract:** `frontend/src/contracts/featureFlags.ts`
+**Status:** Live since [Phase 2 #6](../../superpowers/plans/2026-05-09-ce-ee-fork-plan-02-06-feature-flags-enterprise-gate.md)
+
+## Purpose
+
+Decouple deployment-level capability discovery (what features exist on this install) from per-user RBAC (what this user can do). Server-driven flags let CE ship a closed UI that EE bundles can light up by:
+
+1. Registering an EE driver (auth, audit, observability, etc.) — its presence flips a flag automatically.
+2. Publishing additional entries through `config/feature-flags.php`.
+3. Augmenting the `FlagNameRegistry` TypeScript interface in `enterprise/frontend/` to extend the union — typed `useFlag('foo')` calls then accept the new EE flag names without CE compile errors.
+
+CE deployments get an effectively-empty flag set — every `<EnterpriseGate>` either renders nothing or shows a "see what you're missing" locked card with the Enterprise badge.
+
+## Architecture
+
+```
+┌──────── Backend ────────┐         ┌──────── Frontend ────────┐
+│ FeatureFlagResolver     │  GET    │  useFeatureFlagsQuery    │
+│  ├── config/...flags    │ ──────▶ │  ↓ hydrates              │
+│  ├── AuthDriverRegistry │         │  useFeatureFlagsStore    │
+│  └── tenancy.resolver   │         │  ├── useFlag(name)       │
+└─────────────────────────┘         │  └── <EnterpriseGate>    │
+                                    └──────────────────────────┘
+```
+
+Flags reflect **deployment posture**, not per-user permissions. The endpoint is intentionally unauthenticated — every CE deployment ships an effectively-empty flag set and the response only describes capability presence (no PHI, no user data).
+
+## Backend contract
+
+### `FeatureFlag` value object
+
+```php
+final readonly class FeatureFlag
+{
+    public function __construct(
+        public string $name,                // e.g. 'auth.saml', 'tenancy.multi'
+        public bool $enabled,               // is this capability live on this deployment?
+        public string $source,              // 'ce' | 'ee' | 'config' | 'license'
+        public ?string $description = null, // human hint for admin UIs
+    ) {}
+}
+```
+
+### `FeatureFlagResolver`
+
+The resolver composes flags from three sources, in this order:
+
+1. **`config('feature-flags.flags')`** — explicit per-deployment overrides. CE ships an empty array; EE-published config or runtime overrides populate it.
+2. **`AuthDriverRegistry`** — every driver whose name is *not* in `['local', 'authentik-oidc']` (CE baseline) becomes an `auth.<driver>` flag with `enabled=true, source='ee'`.
+3. **`tenancy.resolver`** — emits `tenancy.multi` reflecting whether the configured TenantResolver is `SingleTenantResolver` (`enabled=false, source='ce'`) or anything else (`enabled=true, source='ee'`).
+
+### How EE adds flags without patching CE
+
+```php
+// enterprise/backend/src/Providers/EnterpriseFeatureFlagsProvider.php
+class EnterpriseFeatureFlagsProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        // Option A: append to config (best for static EE flags).
+        $this->mergeConfigFrom(__DIR__.'/../../config/feature-flags.ee.php', 'feature-flags');
+    }
+
+    public function boot(): void
+    {
+        // Option B: re-bind the resolver to layer on dynamic EE logic.
+        $this->app->extend(FeatureFlagResolver::class, function ($base, $app) {
+            return new EnterpriseFeatureFlagResolver($base, $app->make(LicenseService::class));
+        });
+    }
+}
+```
+
+CE's `FeatureFlagResolver` keeps emitting its own flags; EE's resolver wraps it.
+
+### Endpoint
+
+```
+GET /api/v1/system/feature-flags
+
+200 OK
+{
+  "data": [
+    { "name": "tenancy.multi", "enabled": false, "source": "ce", "description": "Multi-tenant request routing." }
+  ]
+}
+```
+
+No auth required (deployment posture is public). The response is small (typically <2 KB) and deployment-stable — TanStack Query caches it for 5 minutes.
+
+## Frontend contract
+
+### Typed `FlagName` union (R6)
+
+`frontend/src/types/featureFlags.ts` exposes a **closed** `FlagNameRegistry` interface. `useFlag('typo')` is a compile error and IDE autocomplete works:
+
+```ts
+export interface FlagNameRegistry {
+  "auth.saml": true;
+  "auth.scim": true;
+  // ...
+}
+export type FlagName = keyof FlagNameRegistry;
+```
+
+EE extends the registry through TypeScript module augmentation:
+
+```ts
+// enterprise/frontend/src/types/featureFlags.d.ts
+declare module "@/types/featureFlags" {
+  interface FlagNameRegistry {
+    "auth.keycloak-step-up": true;
+    "auth.saml-step-up": true;
+  }
+}
+```
+
+After `tsc` merges the augmentation, EE consumers see the extended union. CE callers see only the closed CE union.
+
+### Zustand store + hooks
+
+```ts
+import { useFlag, useFeatureFlag } from "@/stores/featureFlagsStore";
+
+const samlEnabled = useFlag("auth.saml");           // boolean
+const samlFlag = useFeatureFlag("auth.saml");       // FeatureFlag | undefined (when admin UI needs description/source)
+```
+
+The store hydrates on app mount via `<FlagsLoader />` (rendered inside `QueryClientProvider`, before `<RouterProvider>`). Subsequent renders are reactive — flipping a flag at runtime causes every gated subtree to re-render.
+
+### `<EnterpriseGate>` modes
+
+```tsx
+// hide entirely (default)
+<EnterpriseGate flag="auth.saml">
+  <SamlConfigForm />
+</EnterpriseGate>
+
+// fall back to a marketing CTA
+<EnterpriseGate flag="auth.saml" fallback={<UpgradeBanner />}>
+  <SamlConfigForm />
+</EnterpriseGate>
+
+// "see what you're missing" — render dimmed + badged, non-interactive
+<EnterpriseGate flag="auth.saml" showAsLocked>
+  <SamlConfigForm />
+</EnterpriseGate>
+```
+
+Locked mode is the recommended pattern for surfaces that exist conceptually in CE marketing material but only function in EE — admin pages for SAML/Keycloak/multi-tenant.
+
+## Pluggability proof
+
+The Plan 02-06 test suite exercises four pluggability behaviors:
+
+1. **Config-driven flags surface** in the resolver and the endpoint.
+2. **EE auth drivers** registered in `AuthDriverRegistry` become flags automatically (`auth.saml` → `enabled=true, source='ee'`).
+3. **MultiTenantResolver** swap (via `config('tenancy.resolver')`) flips `tenancy.multi` to `enabled=true, source='ee'`.
+4. **EnterpriseGate live re-render** when the store mutates — proves runtime EE registration paths take effect without a page reload.
+
+CE callers never have to change. EE plugs in via service provider + module augmentation.
+
+## Out of scope
+
+- **Per-user feature flag overrides** (admin tooling that whitelists a single account into a flag) — separate plan.
+- **Real-time flag updates over WebSocket / Reverb** — separate plan.
+- **A/B testing rollouts** — Parthenon isn't a SaaS-style product; flags are deployment-scoped, not user-scoped.
+- **Marketing pages explaining each flag** — handled in `docs/site/`.
+
+## Anti-patterns
+
+- ❌ Don't gate role-based actions on feature flags. RBAC stays in Spatie permissions; flags describe capability presence only.
+- ❌ Don't fetch the flags endpoint inside hot paths. It's hydrated once on mount and cached for 5 minutes.
+- ❌ Don't fall back to `| string` on `FlagName` (R6) — that defeats compile-time discovery of typos.
+- ❌ Don't ship secret/PII data in `description` — the endpoint is unauthenticated by design.

--- a/frontend/src/__tests__/EnterpriseGate.test.tsx
+++ b/frontend/src/__tests__/EnterpriseGate.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { EnterpriseGate } from "@/components/EnterpriseGate";
+import { useFeatureFlagsStore } from "@/stores/featureFlagsStore";
+
+describe("EnterpriseGate", () => {
+  beforeEach(() => {
+    useFeatureFlagsStore.getState().reset();
+  });
+
+  it("hides children when the flag is off (CE default)", () => {
+    render(
+      <EnterpriseGate flag="auth.saml">
+        <div>SAML config</div>
+      </EnterpriseGate>,
+    );
+    expect(screen.queryByText("SAML config")).toBeNull();
+  });
+
+  it("renders children when the flag is on (EE)", () => {
+    useFeatureFlagsStore.getState().setFlags([
+      { name: "auth.saml", enabled: true, source: "ee", description: null },
+    ]);
+
+    render(
+      <EnterpriseGate flag="auth.saml">
+        <div>SAML config</div>
+      </EnterpriseGate>,
+    );
+    expect(screen.getByText("SAML config")).toBeInTheDocument();
+  });
+
+  it("renders fallback when the flag is off and a fallback is provided", () => {
+    render(
+      <EnterpriseGate flag="auth.saml" fallback={<div>Upgrade to EE</div>}>
+        <div>SAML config</div>
+      </EnterpriseGate>,
+    );
+    expect(screen.queryByText("SAML config")).toBeNull();
+    expect(screen.getByText("Upgrade to EE")).toBeInTheDocument();
+  });
+
+  it("renders locked-mode (children dimmed + Enterprise badge) when showAsLocked=true", () => {
+    render(
+      <EnterpriseGate flag="auth.saml" showAsLocked>
+        <div data-testid="kid">SAML config</div>
+      </EnterpriseGate>,
+    );
+
+    expect(screen.getByTestId("gate-locked-auth.saml")).toBeInTheDocument();
+    expect(screen.getByTestId("kid")).toBeInTheDocument();
+    expect(screen.getByTestId("enterprise-badge")).toBeInTheDocument();
+    expect(screen.getByText("Enterprise")).toBeInTheDocument();
+  });
+
+  it("does NOT render locked-mode wrapper when the flag is on", () => {
+    useFeatureFlagsStore.getState().setFlags([
+      { name: "auth.saml", enabled: true, source: "ee", description: null },
+    ]);
+
+    render(
+      <EnterpriseGate flag="auth.saml" showAsLocked>
+        <div>SAML config</div>
+      </EnterpriseGate>,
+    );
+
+    expect(screen.queryByTestId("gate-locked-auth.saml")).toBeNull();
+    expect(screen.queryByTestId("enterprise-badge")).toBeNull();
+    expect(screen.getByText("SAML config")).toBeInTheDocument();
+  });
+
+  it("flips visibility live when the underlying store mutates", () => {
+    const { rerender } = render(
+      <EnterpriseGate flag="audit.signed">
+        <div>signed audit</div>
+      </EnterpriseGate>,
+    );
+    expect(screen.queryByText("signed audit")).toBeNull();
+
+    useFeatureFlagsStore.getState().setFlags([
+      { name: "audit.signed", enabled: true, source: "ee", description: null },
+    ]);
+    rerender(
+      <EnterpriseGate flag="audit.signed">
+        <div>signed audit</div>
+      </EnterpriseGate>,
+    );
+    expect(screen.getByText("signed audit")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -2,6 +2,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "react-router-dom";
 import { queryClient } from "@/lib/query-client";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { FlagsLoader } from "@/features/system/FlagsLoader";
 import { LocaleSync } from "@/i18n/LocaleSync";
 import { router } from "./router";
 
@@ -10,6 +11,7 @@ export function App() {
     <ErrorBoundary>
       <LocaleSync />
       <QueryClientProvider client={queryClient}>
+        <FlagsLoader />
         <RouterProvider router={router} />
       </QueryClientProvider>
     </ErrorBoundary>

--- a/frontend/src/components/EnterpriseBadge.tsx
+++ b/frontend/src/components/EnterpriseBadge.tsx
@@ -1,0 +1,28 @@
+interface EnterpriseBadgeProps {
+  className?: string;
+}
+
+/**
+ * "Enterprise Edition" pill. Shown inside locked-mode `<EnterpriseGate>` so
+ * users see what features exist in the EE overlay without the surface being
+ * interactive. Visual treatment uses the gold/amber accent from the
+ * Parthenon clinical theme.
+ */
+export function EnterpriseBadge({ className = "" }: EnterpriseBadgeProps) {
+  return (
+    <span
+      data-testid="enterprise-badge"
+      className={`inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-300 ring-1 ring-amber-500/30 ${className}`.trim()}
+    >
+      <svg
+        className="h-3 w-3"
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path d="M8 1L2 4v4c0 4 3 6 6 7 3-1 6-3 6-7V4l-6-3z" />
+      </svg>
+      Enterprise
+    </span>
+  );
+}

--- a/frontend/src/components/EnterpriseGate.tsx
+++ b/frontend/src/components/EnterpriseGate.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+
+import { useFlag } from "@/stores/featureFlagsStore";
+import type { FlagName } from "@/types/featureFlags";
+
+import { EnterpriseBadge } from "./EnterpriseBadge";
+
+interface EnterpriseGateProps {
+  /** The feature flag this gate is keyed on. */
+  flag: FlagName;
+  /** Rendered when the flag is `enabled === true`. */
+  children: ReactNode;
+  /** Rendered when the flag is off. Defaults to `null` (renders nothing). */
+  fallback?: ReactNode;
+  /**
+   * "See what you're missing" mode for marketing surfaces. Children render
+   * dimmed and non-interactive, with an Enterprise badge overlay. Default
+   * `false` (hide entirely).
+   */
+  showAsLocked?: boolean;
+}
+
+/**
+ * Conditionally renders children based on a server-resolved feature flag.
+ *
+ * CE deployments — every EE flag is off, so `<EnterpriseGate>` renders the
+ * fallback (or nothing) for EE-only surfaces. EE deployments — flags are
+ * flipped server-side; the gate reveals the children.
+ *
+ * Usage:
+ *   <EnterpriseGate flag="auth.saml">
+ *     <SamlConfigForm />
+ *   </EnterpriseGate>
+ *
+ *   <EnterpriseGate flag="auth.saml" showAsLocked>
+ *     <SamlConfigForm />   // dimmed, non-interactive, badged
+ *   </EnterpriseGate>
+ */
+export function EnterpriseGate({
+  flag,
+  children,
+  fallback = null,
+  showAsLocked = false,
+}: EnterpriseGateProps) {
+  const enabled = useFlag(flag);
+  if (enabled) {
+    return <>{children}</>;
+  }
+  if (showAsLocked) {
+    return (
+      <div
+        data-testid={`gate-locked-${flag}`}
+        className="relative pointer-events-none opacity-50"
+        aria-disabled
+      >
+        <div className="absolute right-2 top-2 z-10 pointer-events-auto">
+          <EnterpriseBadge />
+        </div>
+        {children}
+      </div>
+    );
+  }
+  return <>{fallback}</>;
+}

--- a/frontend/src/contracts/featureFlags.ts
+++ b/frontend/src/contracts/featureFlags.ts
@@ -1,0 +1,38 @@
+// Plan 02-06 — Public extension contract for the feature-flags surface.
+//
+// EE consumers (and any community fork that ships its own gating) implement
+// this contract to plug in additional flag sources without patching CE
+// code. CE itself never imports from this file outside of test fixtures —
+// the contract exists purely as documentation + a type anchor for EE.
+//
+// EE wires its provider in `enterprise/frontend/src/providers/EnterpriseFeatureFlagsProvider.tsx`
+// which calls `useFeatureFlagsStore.getState().setFlags([...])` on mount with
+// the merged CE+EE flag list.
+
+import type { FeatureFlag, FlagName } from "@/types/featureFlags";
+
+/**
+ * Implemented by consumers that contribute additional flags at runtime
+ * (typically only EE bundles). The host application calls `flags()` after
+ * the CE backend response has been hydrated and merges the results.
+ */
+export interface FeatureFlagContributor {
+  /** Stable identifier — 'ce-builtin', 'ee-overlay', 'community-foo'. */
+  name(): string;
+
+  /**
+   * Returns the additional flags this contributor wants applied. Implementers
+   * MUST return a stable shape; the host may call this synchronously on
+   * every store hydration.
+   */
+  flags(): readonly FeatureFlag[];
+}
+
+/**
+ * Hook contract surfaced by the CE feature-flags store. EE depends only on
+ * the type here, never on the concrete Zustand store implementation.
+ */
+export interface FeatureFlagAccessor {
+  isEnabled(name: FlagName): boolean;
+  flag(name: FlagName): FeatureFlag | undefined;
+}

--- a/frontend/src/features/administration/pages/AuthProvidersPage.tsx
+++ b/frontend/src/features/administration/pages/AuthProvidersPage.tsx
@@ -262,7 +262,7 @@ export default function AuthProvidersPage() {
                 Configure SAML 2.0 IdP integration for your organization.
               </p>
             </div>
-            <Button variant="default" disabled>Configure</Button>
+            <Button variant="primary" disabled>Configure</Button>
           </div>
         </Panel>
       </EnterpriseGate>

--- a/frontend/src/features/administration/pages/AuthProvidersPage.tsx
+++ b/frontend/src/features/administration/pages/AuthProvidersPage.tsx
@@ -6,6 +6,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { EnterpriseGate } from "@/components/EnterpriseGate";
 import { HelpButton } from "@/features/help";
 import { Panel, Badge, Button } from "@/components/ui";
 import { useAuthProviders, useToggleAuthProvider, useUpdateAuthProvider, useTestAuthProvider } from "../hooks/useAuthProviders";
@@ -246,6 +247,25 @@ export default function AuthProvidersPage() {
           {ordered.map((p) => <ProviderCard key={p.provider_type} provider={p} />)}
         </div>
       )}
+
+      {/* Plan 02-06 — EE smoke gate. CE renders this card dimmed with an
+          Enterprise badge so users know SAML SSO is part of the EE overlay. */}
+      <EnterpriseGate flag="auth.saml" showAsLocked>
+        <Panel>
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-muted text-amber-500">
+              <FileKey className="h-5 w-5" />
+            </div>
+            <div className="flex-1">
+              <p className="font-medium text-foreground">SAML 2.0 Single Sign-On</p>
+              <p className="text-xs text-muted-foreground">
+                Configure SAML 2.0 IdP integration for your organization.
+              </p>
+            </div>
+            <Button variant="default" disabled>Configure</Button>
+          </div>
+        </Panel>
+      </EnterpriseGate>
     </div>
   );
 }

--- a/frontend/src/features/system/FlagsLoader.tsx
+++ b/frontend/src/features/system/FlagsLoader.tsx
@@ -1,0 +1,14 @@
+import { useFeatureFlagsQuery } from "./api";
+
+/**
+ * Side-effect-only component that triggers `/system/feature-flags` fetch on
+ * mount and hydrates {@link useFeatureFlagsStore}. Renders nothing.
+ *
+ * Mounted once near the root of the app tree (inside `QueryClientProvider`)
+ * so every gated surface in the app sees a populated store before its first
+ * paint.
+ */
+export function FlagsLoader() {
+  useFeatureFlagsQuery();
+  return null;
+}

--- a/frontend/src/features/system/api.ts
+++ b/frontend/src/features/system/api.ts
@@ -1,0 +1,40 @@
+import { useQuery } from "@tanstack/react-query";
+
+import apiClient from "@/lib/api-client";
+import { useFeatureFlagsStore } from "@/stores/featureFlagsStore";
+import type { FeatureFlag } from "@/types/featureFlags";
+
+interface FeatureFlagsResponse {
+  data: FeatureFlag[];
+}
+
+/**
+ * Fetches deployment-level feature flags from `/api/v1/system/feature-flags`
+ * and hydrates the {@link useFeatureFlagsStore}.
+ *
+ * Stale time: 5 minutes — feature flags are deployment-level and rarely
+ * change inside a session. Auth/login flows that flip server-side state
+ * should call `useFeatureFlagsStore.getState().reset()` and refetch.
+ */
+export function useFeatureFlagsQuery() {
+  const setFlags = useFeatureFlagsStore((s) => s.setFlags);
+  const setError = useFeatureFlagsStore((s) => s.setError);
+
+  return useQuery({
+    queryKey: ["system", "feature-flags"],
+    queryFn: async (): Promise<FeatureFlag[]> => {
+      try {
+        const response = await apiClient.get<FeatureFlagsResponse>("/system/feature-flags");
+        const flags = response.data.data;
+        setFlags(flags);
+        return flags;
+      } catch (e) {
+        const message = e instanceof Error ? e.message : "Failed to load feature flags";
+        setError(message);
+        throw e;
+      }
+    },
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+}

--- a/frontend/src/stores/__tests__/featureFlagsStore.test.ts
+++ b/frontend/src/stores/__tests__/featureFlagsStore.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { useFeatureFlagsStore, useFlag } from "../featureFlagsStore";
+import type { FeatureFlag } from "@/types/featureFlags";
+
+describe("featureFlagsStore", () => {
+  beforeEach(() => {
+    useFeatureFlagsStore.getState().reset();
+  });
+
+  it("starts empty + unloaded with no error", () => {
+    const s = useFeatureFlagsStore.getState();
+    expect(s.loaded).toBe(false);
+    expect(s.error).toBeNull();
+    expect(Object.keys(s.flags)).toHaveLength(0);
+  });
+
+  it("isEnabled returns false for an unset flag", () => {
+    expect(useFeatureFlagsStore.getState().isEnabled("auth.saml")).toBe(false);
+  });
+
+  it("setFlags hydrates the map and marks loaded=true", () => {
+    const flags: FeatureFlag[] = [
+      { name: "auth.saml", enabled: true, source: "ee", description: null },
+      { name: "tenancy.multi", enabled: false, source: "ce", description: "single-tenant" },
+    ];
+    useFeatureFlagsStore.getState().setFlags(flags);
+
+    const s = useFeatureFlagsStore.getState();
+    expect(s.loaded).toBe(true);
+    expect(s.error).toBeNull();
+    expect(s.isEnabled("auth.saml")).toBe(true);
+    expect(s.isEnabled("tenancy.multi")).toBe(false);
+    expect(s.flag("auth.saml")?.source).toBe("ee");
+  });
+
+  it("setError clears loaded and stores the message", () => {
+    useFeatureFlagsStore.getState().setError("network down");
+    const s = useFeatureFlagsStore.getState();
+    expect(s.loaded).toBe(false);
+    expect(s.error).toBe("network down");
+  });
+
+  it("reset() clears flags + error + loaded", () => {
+    useFeatureFlagsStore.getState().setFlags([
+      { name: "auth.saml", enabled: true, source: "ee", description: null },
+    ]);
+    useFeatureFlagsStore.getState().reset();
+
+    const s = useFeatureFlagsStore.getState();
+    expect(s.loaded).toBe(false);
+    expect(s.error).toBeNull();
+    expect(s.isEnabled("auth.saml")).toBe(false);
+  });
+
+  it("flag() returns undefined for an unset flag, the descriptor for a set flag", () => {
+    expect(useFeatureFlagsStore.getState().flag("auth.saml")).toBeUndefined();
+
+    useFeatureFlagsStore.getState().setFlags([
+      { name: "auth.saml", enabled: true, source: "ee", description: "SAML 2.0 SSO" },
+    ]);
+
+    const flag = useFeatureFlagsStore.getState().flag("auth.saml");
+    expect(flag).toBeDefined();
+    expect(flag?.description).toBe("SAML 2.0 SSO");
+  });
+
+  it("useFlag selector reads from the same backing store", () => {
+    useFeatureFlagsStore.getState().setFlags([
+      { name: "audit.signed", enabled: true, source: "ee", description: null },
+    ]);
+
+    // useFlag is a hook — invoke it through the store's getState path used in tests.
+    // Directly verify the selector logic the hook is built on:
+    const state = useFeatureFlagsStore.getState();
+    expect(Boolean(state.flags["audit.signed"]?.enabled)).toBe(true);
+    // Sanity: the hook itself is a thin wrapper over this same logic.
+    expect(typeof useFlag).toBe("function");
+  });
+});

--- a/frontend/src/stores/featureFlagsStore.ts
+++ b/frontend/src/stores/featureFlagsStore.ts
@@ -1,0 +1,57 @@
+import { create } from "zustand";
+
+import type { FeatureFlag, FeatureFlagMap, FlagName } from "@/types/featureFlags";
+
+interface FeatureFlagsState {
+  flags: FeatureFlagMap;
+  loaded: boolean;
+  error: string | null;
+  setFlags: (flags: readonly FeatureFlag[]) => void;
+  setError: (msg: string) => void;
+  isEnabled: (name: FlagName) => boolean;
+  flag: (name: FlagName) => FeatureFlag | undefined;
+  reset: () => void;
+}
+
+/**
+ * Zustand store for deployment-level feature flags. Hydrated once on app
+ * mount via {@link useFeatureFlagsQuery}. EE bundles can also call
+ * `setFlags(...)` directly to merge additional flag sources without
+ * modifying CE code.
+ */
+export const useFeatureFlagsStore = create<FeatureFlagsState>((set, get) => ({
+  flags: {},
+  loaded: false,
+  error: null,
+
+  setFlags: (flags) =>
+    set({
+      flags: Object.fromEntries(flags.map((f) => [f.name, f])) as FeatureFlagMap,
+      loaded: true,
+      error: null,
+    }),
+
+  setError: (msg) => set({ error: msg, loaded: false }),
+
+  isEnabled: (name) => Boolean(get().flags[name]?.enabled),
+  flag: (name) => get().flags[name],
+
+  reset: () => set({ flags: {}, loaded: false, error: null }),
+}));
+
+/**
+ * Subscribed boolean for a single flag. Recommended call site for components
+ * that gate sub-trees on flag state.
+ */
+export function useFlag(name: FlagName): boolean {
+  return useFeatureFlagsStore((s) => Boolean(s.flags[name]?.enabled));
+}
+
+/**
+ * Subscribed accessor returning the raw flag descriptor, or undefined when
+ * the flag is absent from the deployment. Use when callers need
+ * `description` or `source` (e.g. admin UIs).
+ */
+export function useFeatureFlag(name: FlagName): FeatureFlag | undefined {
+  return useFeatureFlagsStore((s) => s.flags[name]);
+}

--- a/frontend/src/types/featureFlags.ts
+++ b/frontend/src/types/featureFlags.ts
@@ -1,0 +1,49 @@
+// Plan 02-06 — typed registry of deployment-level feature flags.
+//
+// R6 (Cross-Plan Revision): the FlagName union must be CLOSED so that
+// `useFlag('typo')` is a compile error and IDE autocomplete works. EE
+// extends the registry via TypeScript module augmentation in:
+//
+//   enterprise/frontend/src/types/featureFlags.d.ts
+//
+//   declare module "@/types/featureFlags" {
+//     interface FlagNameRegistry {
+//       "auth.keycloak-step-up": true;
+//       "auth.saml-step-up": true;
+//     }
+//   }
+//
+// CE consumers see the closed union below; EE consumers see the augmented
+// union after `tsc` merges the declaration.
+
+export interface FlagNameRegistry {
+  "auth.saml": true;
+  "auth.scim": true;
+  "auth.keycloak": true;
+  "tenancy.multi": true;
+  "audit.signed": true;
+  "observability.datadog": true;
+  "observability.splunk": true;
+  "observability.opentelemetry": true;
+  "crypto.fips": true;
+  "operator.k8s": true;
+}
+
+export type FlagName = keyof FlagNameRegistry;
+
+/**
+ * Deployment-level feature flag, as returned by
+ * `GET /api/v1/system/feature-flags`.
+ */
+export interface FeatureFlag {
+  name: FlagName;
+  enabled: boolean;
+  source: "ce" | "ee" | "config" | "license";
+  description: string | null;
+}
+
+/**
+ * Map of flag-name -> the flag descriptor. Partial because most flags are
+ * absent on a CE deployment.
+ */
+export type FeatureFlagMap = Partial<Record<FlagName, FeatureFlag>>;


### PR DESCRIPTION
## Summary

Adds the sixth CE/EE extension-point seam — and the **first dual-stack** one. Server-driven feature flags let CE ship a closed UI that EE bundles light up by:

1. Registering an EE auth driver (Keycloak, SAML, SCIM) — its presence flips `auth.<driver>=true` automatically.
2. Binding a non-CE TenantResolver — `tenancy.multi` flips to `enabled=true, source='ee'`.
3. Publishing additional entries through `config/feature-flags.php`.
4. Augmenting the typed `FlagNameRegistry` interface in `enterprise/frontend/` (R6 — closed CE union, augmented EE union).

CE deployments get an effectively-empty flag set — every `<EnterpriseGate>` either renders nothing or shows a "see what you're missing" locked card with the Enterprise badge. The smoke gate landed in `AuthProvidersPage` previews this for SAML 2.0 SSO.

This is Plan 02-06 from the [Phase 2 umbrella](docs/superpowers/plans/2026-05-08-ce-ee-fork-plan-02-extension-points-umbrella.md).

## What landed

**Backend**
- `App\FeatureFlags\FeatureFlag` value object + `FeatureFlagResolver` composing flags from config + `AuthDriverRegistry` + `tenancy.resolver`.
- `App\Http\Controllers\Api\V1\System\FeatureFlagsController` exposing `GET /api/v1/system/feature-flags` (public, deployment-posture only).
- `FeatureFlagsServiceProvider` + `config/feature-flags.php` (empty CE list — EE appends).

**Frontend**
- Closed `FlagName` union (R6) via `FlagNameRegistry` interface — typed `useFlag('typo')` is a compile error, EE extends via TS module augmentation.
- Zustand store with `useFlag(name)` and `useFeatureFlag(name)` selectors.
- TanStack Query hook + `<FlagsLoader />` side-effect component mounted inside `QueryClientProvider`.
- `<EnterpriseGate>` with three modes — hide / fallback / `showAsLocked`.
- `<EnterpriseBadge>` gold-amber pill (Parthenon clinical theme accent).
- Smoke gate in `AuthProvidersPage` previewing SAML 2.0 SSO surface.

**Docs**
- [`docs/architecture/extension-points/feature-flags.md`](docs/architecture/extension-points/feature-flags.md) — full doc with EE wiring sketches, FlagNameRegistry augmentation, EnterpriseGate modes, anti-patterns.

## EE wiring sketch

```php
// enterprise/backend/src/Providers/EnterpriseFeatureFlagsProvider.php
public function boot(): void {
    $this->app->extend(FeatureFlagResolver::class, function ($base, $app) {
        return new EnterpriseFeatureFlagResolver($base, $app->make(LicenseService::class));
    });
}
```

```ts
// enterprise/frontend/src/types/featureFlags.d.ts
declare module "@/types/featureFlags" {
  interface FlagNameRegistry {
    "auth.keycloak-step-up": true;
  }
}
```

CE's resolver keeps emitting; EE wraps. CE's union stays closed; EE augments.

## Test plan

- [x] **Backend (12 tests, 49 assertions)** — `FeatureFlagResolverTest`, `FeatureFlagsControllerTest` — all green via host Pest 8.4
- [x] **Frontend (13 tests)** — `featureFlagsStore.test`, `EnterpriseGate.test` — all green via Vitest
- [x] **Pint** clean (host + Docker)
- [x] **PHPStan level 8** clean on every new file
- [x] **TypeScript strict** — `tsc --noEmit` clean
- [x] **Vite build** succeeds (stricter than tsc)
- [x] **ESLint** clean on every new file (host node_modules)
- [x] Pluggability proof: tests register an EE-style auth driver and verify `auth.saml` flag emerges; tests swap `config('tenancy.resolver')` and verify `tenancy.multi` flips source from 'ce' to 'ee' — no CE code modified.
- [x] Live re-render proof: store mutation triggers `<EnterpriseGate>` to switch modes without a remount.

## Refs

- Spec: [`docs/superpowers/specs/2026-05-08-ce-ee-fork-and-agplv3-relicense-design.md`](docs/superpowers/specs/2026-05-08-ce-ee-fork-and-agplv3-relicense-design.md) §5 row 6
- Plan: [`docs/superpowers/plans/2026-05-09-ce-ee-fork-plan-02-06-feature-flags-enterprise-gate.md`](docs/superpowers/plans/2026-05-09-ce-ee-fork-plan-02-06-feature-flags-enterprise-gate.md)
- Cross-Plan Revision R6 — closed `FlagName` union with EE module augmentation.