### PR TITLE
feat(installer): Acropolis phase registry (Phase 2 #7 of 8)

### DIFF
--- a/acropolis/installer/cli.py
+++ b/acropolis/installer/cli.py
@@ -1,50 +1,43 @@
-"""Infrastructure installer orchestrator — runs all phases with state persistence.
+"""Infrastructure installer orchestrator — runs all phases through the registry.
 
-This is the Acropolis infrastructure installer, now integrated into the
+This is the Acropolis infrastructure installer, integrated into the
 Parthenon monorepo. It adds Traefik, Portainer, pgAdmin, and optionally
-enterprise services (n8n, Superset, DataHub, Authentik, Wazuh) on top of Parthenon.
+enterprise services (n8n, Superset, DataHub, Authentik, Wazuh) on top of
+Parthenon.
 
-Flow:
-  Phase 1: Preflight checks (Docker, ports, disk)
-  Phase 2: Detect local Parthenon installation
-  Phase 3: Edition selection (Community / Enterprise)
-  Phase 4: Service discovery (enumerate Parthenon containers)
-  Phase 5: Configuration (domain, TLS, credentials)
-  Phase 5.5: Run Parthenon installer if not already installed
-  Phase 6: Network setup (acumenus + parthenon bridges)
-  Phase 7: Deploy infrastructure services
-  Phase 8: Traefik routing configuration
-  Phase 9: Verification + generate day-2 CLI
+Plan 02-07 lifted the legacy 9-step inline flow into a phase registry.
+The CE phases live under ``acropolis/installer/phases/community/`` and
+preserve the ``InstallState`` resume contract (each CE phase keeps its
+legacy numeric ``state_id`` so an old ``.install-state.json`` still
+resumes correctly). EE bundles add their phases by registering through
+setuptools entry-point group ``parthenon.acropolis.phases``.
+
+Flow (canonical CE order):
+  Phase 1: Preflight checks (Docker, ports, disk)               community.preflight
+  Phase 2: Topology (compose vs k8s, networks)                  community.topology
+  Phase 3: Edition selection (Community / Enterprise)           community.edition
+  Phase 4: Service discovery                                    community.discovery
+  Phase 5: Configuration (domain, TLS, credentials)             community.configuration
+  Phase 5.5: Run Parthenon installer if not already installed   community.parthenon_install
+  Phase 6: Network setup (acumenus + parthenon bridges)         community.network
+  Phase 7: Deploy infrastructure services                       community.deploy
+  Phase 8: Traefik routing configuration                        community.traefik
+  Phase 9: Verification + day-2 generator                       community.verify
 """
 from __future__ import annotations
-
-import sys
-from dataclasses import asdict
-from pathlib import Path
 
 import questionary
 from rich.console import Console
 from rich.panel import Panel
 
-from acropolis.installer.config import (
-    InstallConfig,
-    collect_config,
-    write_env_file,
-    write_credentials_file,
-    write_pgadmin_servers,
-    write_wazuh_configs,
+from acropolis.installer.phases import (
+    InstallerContext,
+    PhaseError,
+    PhaseRegistry,
 )
-from acropolis.installer.deploy import deploy, teardown
-from acropolis.installer.discovery import DiscoveredService, discover_services
-from acropolis.installer.editions import EditionConfig, collect_edition
-from acropolis.installer.generator import write_acropolis_sh
-from acropolis.installer.network import rollback_network, setup_network
-from acropolis.installer.preflight import display_results, has_failures, has_warnings, run_preflight
-from acropolis.installer.routing import write_route_configs
+from acropolis.installer.phases.community import register_into as register_community_phases
 from acropolis.installer.state import InstallState
-from acropolis.installer.topology import TopologyConfig, collect_topology
-from acropolis.installer.verify import display_summary, run_smoke_tests
-from acropolis.installer.utils import ACROPOLIS_ROOT, PARTHENON_ROOT
+from acropolis.installer.utils import ACROPOLIS_ROOT
 
 
 def _banner(console: Console) -> None:
@@ -58,50 +51,66 @@ def _banner(console: Console) -> None:
     )
 
 
-def _run_parthenon_installer(config: InstallConfig, console: Console) -> bool:
-    """Run Parthenon's own installer with pre-seeded credentials.
+def _show_upgrade_banner(console: Console) -> bool:
+    """Returns True if the operator confirms the upgrade (or no upgrade is pending)."""
+    from acropolis.installer.version import (
+        CURRENT_VERSION,
+        UPGRADE_NOTES,
+        detect_installed_version,
+    )
 
-    Instead of a subprocess call (as in the old two-repo model), we import
-    Parthenon's installer directly since we're in the same repo.
-    """
-    console.print("\n[bold cyan]Installing Parthenon Application[/]\n")
-
-    pre_seed = {
-        "admin_email": config.parthenon_admin_email,
-        "admin_name": config.parthenon_admin_name,
-        "admin_password": config.parthenon_admin_password,
-        "app_url": f"https://parthenon.{config.domain}",
-        "timezone": config.timezone,
-        "experience": "Experienced",
-    }
-
-    # Remove empty values so they don't override real defaults
-    pre_seed = {k: v for k, v in pre_seed.items() if v}
-
-    try:
-        # Import Parthenon's installer — it's at the repo root level
-        import importlib
-        import sys as _sys
-
-        # Ensure Parthenon root is on sys.path so `installer` package resolves
-        parthenon_str = str(PARTHENON_ROOT)
-        if parthenon_str not in _sys.path:
-            _sys.path.insert(0, parthenon_str)
-
-        installer_cli = importlib.import_module("installer.cli")
-        installer_cli.run(pre_seed=pre_seed)
-        console.print("[green]Parthenon installation complete.[/]\n")
+    installed = detect_installed_version()
+    if not installed or installed == CURRENT_VERSION:
         return True
-    except SystemExit as e:
-        if e.code == 0:
-            console.print("[green]Parthenon installation complete.[/]\n")
-            return True
-        console.print("[yellow]Parthenon installer did not complete.[/]")
-        console.print("Fix Parthenon manually, then re-run this installer.")
+
+    notes = UPGRADE_NOTES.get(CURRENT_VERSION, {})
+    lines = [f"[bold]Upgrading: v{installed} → v{CURRENT_VERSION}[/bold]\n"]
+    if notes.get("new"):
+        lines.append("[cyan]New Features:[/cyan]")
+        for item in notes["new"]:
+            lines.append(f"  ✦ {item}")
+    if notes.get("upgraded"):
+        lines.append("\n[cyan]Upgraded:[/cyan]")
+        for item in notes["upgraded"]:
+            lines.append(f"  ↑ {item}")
+
+    console.print(Panel("\n".join(lines), border_style="cyan", padding=(1, 2)))
+
+    if not questionary.confirm("Proceed with upgrade?", default=True).ask():
+        console.print("[dim]Upgrade cancelled.[/dim]")
         return False
-    except Exception as e:
-        console.print(f"[red]Parthenon installer error: {e}[/]")
-        return False
+    return True
+
+
+def _resolve_resume(state: InstallState, console: Console) -> None:
+    """Show the resume/fresh prompt when an existing state file is found."""
+    if not state.exists():
+        return
+    console.print(
+        f"\n[yellow]Previous installation found "
+        f"(completed phases: {state.completed_phases}).[/]"
+    )
+    action = questionary.select(
+        "How would you like to proceed?",
+        choices=[
+            questionary.Choice("Resume from where I left off", value="resume"),
+            questionary.Choice("Start fresh", value="fresh"),
+        ],
+    ).ask()
+    if action == "fresh":
+        state.clear()
+
+
+def build_registry(console: Console | None = None) -> PhaseRegistry:
+    """Build a registry pre-loaded with CE phases + EE entry-point phases.
+
+    Exposed as a public helper so EE wrappers and tests can construct
+    a fully populated registry without recreating the wiring.
+    """
+    registry = PhaseRegistry(console=console)
+    register_community_phases(registry)
+    registry.discover_entry_points()
+    return registry
 
 
 def run(upgrade: bool = False) -> None:
@@ -109,263 +118,28 @@ def run(upgrade: bool = False) -> None:
     console = Console()
     _banner(console)
 
-    # ── Upgrade banner ────────────────────────────────────────────────────
-    if upgrade:
-        from acropolis.installer.version import (
-            detect_installed_version, CURRENT_VERSION, UPGRADE_NOTES,
-        )
-
-        installed = detect_installed_version()
-        if installed and installed != CURRENT_VERSION:
-            notes = UPGRADE_NOTES.get(CURRENT_VERSION, {})
-            lines = [f"[bold]Upgrading: v{installed} → v{CURRENT_VERSION}[/bold]\n"]
-            if notes.get("new"):
-                lines.append("[cyan]New Features:[/cyan]")
-                for item in notes["new"]:
-                    lines.append(f"  ✦ {item}")
-            if notes.get("upgraded"):
-                lines.append("\n[cyan]Upgraded:[/cyan]")
-                for item in notes["upgraded"]:
-                    lines.append(f"  ↑ {item}")
-
-            console.print(Panel("\n".join(lines), border_style="cyan", padding=(1, 2)))
-
-            if not questionary.confirm("Proceed with upgrade?", default=True).ask():
-                console.print("[dim]Upgrade cancelled.[/dim]")
-                return
+    if upgrade and not _show_upgrade_banner(console):
+        return
 
     state_path = ACROPOLIS_ROOT / ".install-state.json"
     state = InstallState(state_path)
+    _resolve_resume(state, console)
 
-    # Resume check
-    if state.exists():
-        completed = state.completed_phases
-        console.print(
-            f"\n[yellow]Previous installation found "
-            f"(completed phases: {completed}).[/]"
-        )
-        action = questionary.select(
-            "How would you like to proceed?",
-            choices=[
-                questionary.Choice("Resume from where I left off", value="resume"),
-                questionary.Choice("Start fresh", value="fresh"),
-            ],
-        ).ask()
-        if action == "fresh":
-            state.clear()
+    ctx = InstallerContext(state=state, console=console, upgrade=upgrade)
+    registry = build_registry(console=console)
 
-    # ── Phase 1: Preflight ──────────────────────────────────────────────────
-    if not state.is_completed(1):
-        console.print("\n[bold cyan]Phase 1: Preflight Checks[/]\n")
-        state.start_phase(1)
-        state.save()
+    # Edition isn't known until EditionSelectionPhase runs, but the
+    # registry's filter applies before any phase runs. We therefore
+    # plan with the maximal "enterprise" view so EE phases declared via
+    # entry points are scheduled; CE-tier phases that gate on edition
+    # at runtime can short-circuit themselves with a skipped result.
+    # Since CE has zero requires_enterprise=True phases, the practical
+    # behavior on a community-only install is identical to the old
+    # inline flow.
+    target_edition = "enterprise"
 
-        results = run_preflight()
-        display_results(results, console)
-
-        if has_failures(results):
-            console.print("[red]Fix the issues above before continuing.[/]")
-            sys.exit(1)
-
-        if has_warnings(results):
-            if not questionary.confirm(
-                "Warnings detected. Continue?", default=True
-            ).ask():
-                sys.exit(0)
-
-        state.complete_phase(1)
-        state.save()
-
-    # ── Phase 2: Topology ───────────────────────────────────────────────────
-    if not state.is_completed(2):
-        state.start_phase(2)
-        state.save()
-
-        topology = collect_topology(console)
-        state.data["topology"] = asdict(topology)
-        state.complete_phase(2)
-        state.save()
-    else:
-        topo_data = state.data.get("topology", {})
-        topology = TopologyConfig(**topo_data)
-
-    # ── Phase 3: Edition Selection ──────────────────────────────────────────
-    if not state.is_completed(3):
-        state.start_phase(3)
-        state.save()
-
-        edition = collect_edition(console)
-        state.data["edition"] = {
-            "tier": edition.tier,
-            "license_key": edition.license_key,
-        }
-        state.complete_phase(3)
-        state.save()
-    else:
-        ed_data = state.data.get("edition", {})
-        edition = EditionConfig(
-            tier=ed_data.get("tier", "community"),
-            license_key=ed_data.get("license_key"),
-        )
-
-    # ── Phase 4: Service Discovery ──────────────────────────────────────────
-    if not state.is_completed(4):
-        state.start_phase(4)
-        state.save()
-
-        services = discover_services(topology, console)
-        state.data["services"] = [
-            {
-                "name": s.name,
-                "host": s.host,
-                "port": s.port,
-                "subdomain": s.subdomain,
-                "expose": s.expose,
-            }
-            for s in services
-        ]
-        state.complete_phase(4)
-        state.save()
-    else:
-        services = [
-            DiscoveredService(**s)
-            for s in state.data.get("services", [])
-        ]
-
-    # ── Phase 5: Configuration ──────────────────────────────────────────────
-    if not state.is_completed(5):
-        state.start_phase(5)
-        state.save()
-
-        config = collect_config(topology, edition, console)
-        write_env_file(config, topology, edition)
-        write_credentials_file(config, edition, topology)
-        if edition.tier in ("community", "enterprise"):
-            write_pgadmin_servers(config)
-        if edition.tier == "enterprise":
-            write_wazuh_configs(config)
-        console.print("[green]Configuration files written.[/]")
-
-        state.data["config"] = {
-            "domain": config.domain,
-            "timezone": config.timezone,
-            "tls_mode": config.tls_mode,
-            "acme_email": config.acme_email,
-            "parthenon_admin_email": config.parthenon_admin_email,
-            "parthenon_admin_name": config.parthenon_admin_name,
-            "parthenon_admin_password": config.parthenon_admin_password,
-        }
-        state.complete_phase(5)
-        state.save()
-    else:
-        cfg = state.data.get("config", {})
-        config = InstallConfig(
-            domain=cfg.get("domain", "acumenus.net"),
-            timezone=cfg.get("timezone", "UTC"),
-            tls_mode=cfg.get("tls_mode", "letsencrypt"),
-            acme_email=cfg.get("acme_email", ""),
-            parthenon_admin_email=cfg.get("parthenon_admin_email", ""),
-            parthenon_admin_name=cfg.get("parthenon_admin_name", ""),
-            parthenon_admin_password=cfg.get("parthenon_admin_password", ""),
-        )
-
-    # ── Parthenon Install (if not already running) ──────────────────────────
-    if not topology.parthenon_install_completed:
-        completed = _run_parthenon_installer(config, console)
-        topology.parthenon_install_completed = completed
-        state.data["topology"]["parthenon_install_completed"] = completed
-        state.save()
-
-        if not completed:
-            console.print("[red]Cannot continue without Parthenon. Exiting.[/]")
-            sys.exit(1)
-
-        # Re-discover services now that Parthenon is running
-        services = discover_services(topology, console)
-        state.data["services"] = [
-            {
-                "name": s.name,
-                "host": s.host,
-                "port": s.port,
-                "subdomain": s.subdomain,
-                "expose": s.expose,
-            }
-            for s in services
-        ]
-        state.save()
-
-    # ── Phase 6: Network Setup ──────────────────────────────────────────────
-    if not state.is_completed(6):
-        state.start_phase(6)
-        state.save()
-
-        try:
-            connections = setup_network(topology, services, console)
-            state.data["network_connections"] = connections
-            state.complete_phase(6)
-            state.save()
-        except RuntimeError as e:
-            console.print(f"[red]Network setup failed: {e}[/]")
-            sys.exit(1)
-    else:
-        connections = state.data.get("network_connections", [])
-
-    # ── Phase 7: Docker Deploy ──────────────────────────────────────────────
-    if not state.is_completed(7):
-        state.start_phase(7)
-        state.save()
-
-        success = deploy(edition, console, domain=config.domain)
-        if not success:
-            console.print("[red]Deployment aborted.[/]")
-            teardown(edition, console)
-            rollback_network(connections, console)
-            sys.exit(1)
-
-        state.complete_phase(7)
-        state.save()
-
-    # ── Phase 8: Traefik Routing ────────────────────────────────────────────
-    if not state.is_completed(8):
-        state.start_phase(8)
-        state.save()
-
-        write_route_configs(
-            services=services,
-            domain=config.domain,
-            topology_mode=topology.mode,
-            tier=edition.tier,
-            tls_mode=config.tls_mode,
-            acme_email=config.acme_email,
-            console=console,
-        )
-        state.complete_phase(8)
-        state.save()
-
-    # ── Phase 9: Verification + Generator ───────────────────────────────────
-    state.start_phase(9)
-    state.save()
-
-    passed, failed, skipped = run_smoke_tests(config, edition, services, console)
-
-    # Generate customized acropolis.sh
-    service_names = [s.name for s in services if s.expose]
-    write_acropolis_sh(
-        tier=edition.tier,
-        domain=config.domain,
-        topology_mode=topology.mode,
-        services=service_names,
-        parthenon_path=topology.parthenon_path,
-        parthenon_url=topology.parthenon_url,
-        parthenon_network=topology.parthenon_network,
-        console=console,
-    )
-
-    display_summary(config, topology, edition, services, passed, failed, skipped, console)
-
-    # Write version file
-    from acropolis.installer.version import write_version
-    write_version(edition=edition.tier)
-
-    # Clear state on success
-    state.clear()
+    try:
+        registry.run_all(ctx, edition=target_edition)
+    except PhaseError as err:
+        console.print(f"[red]Installer halted at phase {err.phase_id}: {err}[/]")
+        raise

--- a/acropolis/installer/phases/__init__.py
+++ b/acropolis/installer/phases/__init__.py
@@ -1,0 +1,31 @@
+"""Phase registry — extension point #7 of the CE/EE fork.
+
+The Acropolis installer used to encode its 9-step flow inline in
+``acropolis/installer/cli.py``. Plan 02-07 lifts each step into a
+:class:`~acropolis.installer.phases.base.Phase` subclass and registers
+them through :class:`~acropolis.installer.phases.registry.PhaseRegistry`.
+
+EE bundles add their phases by:
+
+  - Implementing :class:`Phase` and registering through setuptools
+    entry-point group ``parthenon.acropolis.phases``, OR
+  - Calling ``registry.register(MyPhase())`` from EE's own ``cli.py``
+    wrapper before invoking ``run_all``.
+
+CE never patches EE phases; EE never patches CE phases.
+"""
+from acropolis.installer.phases.base import (
+    InstallerContext,
+    Phase,
+    PhaseError,
+    PhaseResult,
+)
+from acropolis.installer.phases.registry import PhaseRegistry
+
+__all__ = [
+    "InstallerContext",
+    "Phase",
+    "PhaseError",
+    "PhaseRegistry",
+    "PhaseResult",
+]

--- a/acropolis/installer/phases/base.py
+++ b/acropolis/installer/phases/base.py
@@ -1,0 +1,142 @@
+"""Phase ABC + the structural types every Phase implementation depends on.
+
+A phase is a single step in the Acropolis installer flow. Phases hold no
+state of their own — every mutation goes through the shared
+:class:`InstallerContext` so resume-from-checkpoint works the same way it
+did when the flow was inlined in ``cli.py``.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+    from acropolis.installer.config import InstallConfig
+    from acropolis.installer.discovery import DiscoveredService
+    from acropolis.installer.editions import EditionConfig
+    from acropolis.installer.state import InstallState
+    from acropolis.installer.topology import TopologyConfig
+
+
+@dataclass
+class PhaseResult:
+    """Outcome of running a single phase.
+
+    ``skipped=True`` means the phase decided to no-op (e.g. resume after
+    crash detected the phase had already completed). The registry treats
+    skipped phases as successes for ordering purposes but does not call
+    ``state.complete_phase`` again.
+
+    R7 (Cross-Plan Revision): ``warnings`` is the canonical place for
+    non-fatal advisories. EE phases like ``signed_audit_setup`` or
+    ``observability_shipper_init`` use this for "primary action OK,
+    optional verification (test ship) failed; please check after install."
+    """
+
+    phase_id: str
+    success: bool
+    skipped: bool = False
+    duration_s: float = 0.0
+    message: str = ""
+    diagnostics: dict[str, Any] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+
+class PhaseError(RuntimeError):
+    """Raised when a phase fails fatally and the installer cannot continue."""
+
+    def __init__(
+        self,
+        phase_id: str,
+        message: str,
+        diagnostics: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(f"[{phase_id}] {message}")
+        self.phase_id = phase_id
+        self.diagnostics = diagnostics or {}
+
+
+@dataclass
+class InstallerContext:
+    """Mutable bag of state shared across phases.
+
+    Phases read & write this object. The registry creates one instance
+    per ``run_all`` invocation and threads it through every phase.
+    Replaces the implicit local-variable bag the inlined ``cli.run()``
+    flow used to keep state in (config, topology, edition, services,
+    connections were all locals); now they live here so EE phases can
+    read them without the cli.py re-wiring them.
+    """
+
+    state: InstallState
+    console: Console
+    upgrade: bool = False
+
+    # Filled in as phases run; ``None`` means "phase that produces this
+    # has not run yet (or is being resumed and we re-hydrated it from
+    # state)". Resume hydration happens in ``cli.run()`` before phases
+    # execute.
+    topology: TopologyConfig | None = None
+    edition: EditionConfig | None = None
+    services: list[DiscoveredService] = field(default_factory=list)
+    config: InstallConfig | None = None
+    connections: list[str] = field(default_factory=list)
+
+    # Smoke-test outcome from VerifyPhase, used by the day-2 generator.
+    smoke_passed: int = 0
+    smoke_failed: int = 0
+    smoke_skipped: int = 0
+
+
+class Phase(ABC):
+    """Base class for every Acropolis installer step.
+
+    Subclasses set the four class-level metadata fields and implement
+    :meth:`run`. The registry consults metadata for ordering, edition
+    filtering, and dependency resolution.
+    """
+
+    #: Stable string identifier — ``community.preflight``, ``community.deploy``,
+    #: ``enterprise.fips_bootstrap``. Used by :attr:`depends_on` references and
+    #: by the registry log output.
+    id: str = ""
+
+    #: Sort order within the same edition. Lower runs first. CE phases use
+    #: 100..1000; EE phases pick a slot that respects ``depends_on``.
+    order: int = 0
+
+    #: Editions this phase applies to. Empty list = all editions.
+    editions: list[str] = []
+
+    #: Phase IDs this phase depends on. Registry topologically sorts.
+    depends_on: list[str] = []
+
+    #: Whether running this phase requires the user to have selected the
+    #: enterprise tier. CE phases set this False; EE phases set it True.
+    requires_enterprise: bool = False
+
+    #: Numeric ID matching the legacy ``InstallState.is_completed(N)``
+    #: contract. None means "this phase is new and not represented in
+    #: the legacy state machine" — the registry then assumes it must run.
+    #: Existing CE phases keep their numbers (preflight=1 .. verify=9)
+    #: so an old ``.install-state.json`` from before this refactor still
+    #: resumes correctly.
+    legacy_state_id: int | None = None
+
+    @abstractmethod
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        """Execute the phase, mutating ``ctx`` as needed."""
+
+    def is_applicable(self, edition: str) -> bool:
+        """Whether the registry should consider this phase for ``edition``."""
+        if self.requires_enterprise and edition != "enterprise":
+            return False
+        if not self.editions:
+            return True
+        return edition in self.editions
+
+    def __repr__(self) -> str:  # pragma: no cover - cosmetic
+        return f"<Phase {self.id} order={self.order}>"

--- a/acropolis/installer/phases/community/__init__.py
+++ b/acropolis/installer/phases/community/__init__.py
@@ -1,0 +1,56 @@
+"""Community-edition installer phases.
+
+Importing this package triggers definition of every CE phase class. The
+:func:`register_into` helper attaches them to a :class:`PhaseRegistry`
+in canonical order — the same flow ``cli.run()`` used to encode inline.
+"""
+from __future__ import annotations
+
+from acropolis.installer.phases.community.configuration import ConfigurationPhase
+from acropolis.installer.phases.community.deploy import DeployPhase
+from acropolis.installer.phases.community.discovery import DiscoveryPhase
+from acropolis.installer.phases.community.edition import EditionSelectionPhase
+from acropolis.installer.phases.community.network import NetworkSetupPhase
+from acropolis.installer.phases.community.parthenon_install import ParthenonInstallPhase
+from acropolis.installer.phases.community.preflight import PreflightPhase
+from acropolis.installer.phases.community.topology import TopologyPhase
+from acropolis.installer.phases.community.traefik import TraefikPhase
+from acropolis.installer.phases.community.verify import VerifyPhase
+
+# Canonical CE phase order. Numeric prefixes preserve the legacy state
+# machine's phase ids (1..9) plus the unnumbered Parthenon-install
+# sub-phase that runs between 5 and 6.
+__all_phases__ = [
+    PreflightPhase,
+    TopologyPhase,
+    EditionSelectionPhase,
+    DiscoveryPhase,
+    ConfigurationPhase,
+    ParthenonInstallPhase,
+    NetworkSetupPhase,
+    DeployPhase,
+    TraefikPhase,
+    VerifyPhase,
+]
+
+
+def register_into(registry) -> None:
+    """Attach every CE phase to ``registry`` in canonical order."""
+    for cls in __all_phases__:
+        registry.register(cls())
+
+
+__all__ = [
+    "ConfigurationPhase",
+    "DeployPhase",
+    "DiscoveryPhase",
+    "EditionSelectionPhase",
+    "NetworkSetupPhase",
+    "ParthenonInstallPhase",
+    "PreflightPhase",
+    "TopologyPhase",
+    "TraefikPhase",
+    "VerifyPhase",
+    "__all_phases__",
+    "register_into",
+]

--- a/acropolis/installer/phases/community/configuration.py
+++ b/acropolis/installer/phases/community/configuration.py
@@ -1,0 +1,64 @@
+"""CE Phase 5 — Domain / TLS / credentials and config-file generation."""
+from __future__ import annotations
+
+from acropolis.installer.config import (
+    InstallConfig,
+    collect_config,
+    write_credentials_file,
+    write_env_file,
+    write_pgadmin_servers,
+    write_wazuh_configs,
+)
+from acropolis.installer.phases.base import InstallerContext, Phase, PhaseResult
+
+
+class ConfigurationPhase(Phase):
+    """Collect operator answers and write env/credentials files."""
+
+    id = "community.configuration"
+    order = 500
+    depends_on = ["community.edition", "community.discovery"]
+    legacy_state_id = 5
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        if ctx.state.is_completed(self.legacy_state_id or -1):
+            cfg = ctx.state.data.get("config", {})
+            ctx.config = InstallConfig(
+                domain=cfg.get("domain", "acumenus.net"),
+                timezone=cfg.get("timezone", "UTC"),
+                tls_mode=cfg.get("tls_mode", "letsencrypt"),
+                acme_email=cfg.get("acme_email", ""),
+                parthenon_admin_email=cfg.get("parthenon_admin_email", ""),
+                parthenon_admin_name=cfg.get("parthenon_admin_name", ""),
+                parthenon_admin_password=cfg.get("parthenon_admin_password", ""),
+            )
+            return PhaseResult(self.id, success=True, skipped=True, message="resumed from state")
+
+        if ctx.topology is None or ctx.edition is None:
+            return PhaseResult(self.id, success=False, message="topology + edition must run before configuration")
+
+        ctx.state.start_phase(self.legacy_state_id or 5)
+        ctx.state.save()
+
+        config = collect_config(ctx.topology, ctx.edition, ctx.console)
+        write_env_file(config, ctx.topology, ctx.edition)
+        write_credentials_file(config, ctx.edition, ctx.topology)
+        if ctx.edition.tier in ("community", "enterprise"):
+            write_pgadmin_servers(config)
+        if ctx.edition.tier == "enterprise":
+            write_wazuh_configs(config)
+        ctx.console.print("[green]Configuration files written.[/]")
+
+        ctx.config = config
+        ctx.state.data["config"] = {
+            "domain": config.domain,
+            "timezone": config.timezone,
+            "tls_mode": config.tls_mode,
+            "acme_email": config.acme_email,
+            "parthenon_admin_email": config.parthenon_admin_email,
+            "parthenon_admin_name": config.parthenon_admin_name,
+            "parthenon_admin_password": config.parthenon_admin_password,
+        }
+        ctx.state.complete_phase(self.legacy_state_id or 5)
+        ctx.state.save()
+        return PhaseResult(self.id, success=True)

--- a/acropolis/installer/phases/community/deploy.py
+++ b/acropolis/installer/phases/community/deploy.py
@@ -1,0 +1,38 @@
+"""CE Phase 7 — Docker compose up of the infrastructure stack."""
+from __future__ import annotations
+
+import sys
+
+from acropolis.installer.deploy import deploy, teardown
+from acropolis.installer.network import rollback_network
+from acropolis.installer.phases.base import InstallerContext, Phase, PhaseResult
+
+
+class DeployPhase(Phase):
+    """Bring up Traefik, Portainer, pgAdmin, optional EE services."""
+
+    id = "community.deploy"
+    order = 700
+    depends_on = ["community.network"]
+    legacy_state_id = 7
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        if ctx.state.is_completed(self.legacy_state_id or -1):
+            return PhaseResult(self.id, success=True, skipped=True, message="resumed from state")
+
+        if ctx.edition is None or ctx.config is None:
+            return PhaseResult(self.id, success=False, message="edition + config must run first")
+
+        ctx.state.start_phase(self.legacy_state_id or 7)
+        ctx.state.save()
+
+        success = deploy(ctx.edition, ctx.console, domain=ctx.config.domain)
+        if not success:
+            ctx.console.print("[red]Deployment aborted.[/]")
+            teardown(ctx.edition, ctx.console)
+            rollback_network(ctx.connections, ctx.console)
+            sys.exit(1)
+
+        ctx.state.complete_phase(self.legacy_state_id or 7)
+        ctx.state.save()
+        return PhaseResult(self.id, success=True)

--- a/acropolis/installer/phases/community/discovery.py
+++ b/acropolis/installer/phases/community/discovery.py
@@ -1,0 +1,45 @@
+"""CE Phase 4 — Service discovery (enumerate Parthenon containers)."""
+from __future__ import annotations
+
+from acropolis.installer.discovery import DiscoveredService, discover_services
+from acropolis.installer.phases.base import InstallerContext, Phase, PhaseResult
+
+
+def _service_to_dict(s: DiscoveredService) -> dict:
+    return {
+        "name": s.name,
+        "host": s.host,
+        "port": s.port,
+        "subdomain": s.subdomain,
+        "expose": s.expose,
+    }
+
+
+class DiscoveryPhase(Phase):
+    """Enumerate Parthenon services + record them in installer state."""
+
+    id = "community.discovery"
+    order = 400
+    depends_on = ["community.topology"]
+    legacy_state_id = 4
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        if ctx.state.is_completed(self.legacy_state_id or -1):
+            ctx.services = [
+                DiscoveredService(**s)
+                for s in ctx.state.data.get("services", [])
+            ]
+            return PhaseResult(self.id, success=True, skipped=True, message="resumed from state")
+
+        if ctx.topology is None:
+            return PhaseResult(self.id, success=False, message="topology must run before discovery")
+
+        ctx.state.start_phase(self.legacy_state_id or 4)
+        ctx.state.save()
+
+        services = discover_services(ctx.topology, ctx.console)
+        ctx.services = services
+        ctx.state.data["services"] = [_service_to_dict(s) for s in services]
+        ctx.state.complete_phase(self.legacy_state_id or 4)
+        ctx.state.save()
+        return PhaseResult(self.id, success=True)

--- a/acropolis/installer/phases/community/edition.py
+++ b/acropolis/installer/phases/community/edition.py
@@ -1,0 +1,36 @@
+"""CE Phase 3 — Edition selection (community vs enterprise)."""
+from __future__ import annotations
+
+from acropolis.installer.editions import EditionConfig, collect_edition
+from acropolis.installer.phases.base import InstallerContext, Phase, PhaseResult
+
+
+class EditionSelectionPhase(Phase):
+    """Ask the operator which tier to install."""
+
+    id = "community.edition"
+    order = 300
+    depends_on = ["community.topology"]
+    legacy_state_id = 3
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        if ctx.state.is_completed(self.legacy_state_id or -1):
+            ed_data = ctx.state.data.get("edition", {})
+            ctx.edition = EditionConfig(
+                tier=ed_data.get("tier", "community"),
+                license_key=ed_data.get("license_key"),
+            )
+            return PhaseResult(self.id, success=True, skipped=True, message="resumed from state")
+
+        ctx.state.start_phase(self.legacy_state_id or 3)
+        ctx.state.save()
+
+        edition = collect_edition(ctx.console)
+        ctx.edition = edition
+        ctx.state.data["edition"] = {
+            "tier": edition.tier,
+            "license_key": edition.license_key,
+        }
+        ctx.state.complete_phase(self.legacy_state_id or 3)
+        ctx.state.save()
+        return PhaseResult(self.id, success=True)

--- a/acropolis/installer/phases/community/network.py
+++ b/acropolis/installer/phases/community/network.py
@@ -1,0 +1,39 @@
+"""CE Phase 6 — Docker network setup (acumenus + parthenon bridges)."""
+from __future__ import annotations
+
+import sys
+
+from acropolis.installer.network import setup_network
+from acropolis.installer.phases.base import InstallerContext, Phase, PhaseResult
+
+
+class NetworkSetupPhase(Phase):
+    """Bring up Docker networks the rest of the stack lives on."""
+
+    id = "community.network"
+    order = 600
+    depends_on = ["community.parthenon_install"]
+    legacy_state_id = 6
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        if ctx.state.is_completed(self.legacy_state_id or -1):
+            ctx.connections = ctx.state.data.get("network_connections", [])
+            return PhaseResult(self.id, success=True, skipped=True, message="resumed from state")
+
+        if ctx.topology is None:
+            return PhaseResult(self.id, success=False, message="topology must run first")
+
+        ctx.state.start_phase(self.legacy_state_id or 6)
+        ctx.state.save()
+
+        try:
+            connections = setup_network(ctx.topology, ctx.services, ctx.console)
+        except RuntimeError as exc:
+            ctx.console.print(f"[red]Network setup failed: {exc}[/]")
+            sys.exit(1)
+
+        ctx.connections = connections
+        ctx.state.data["network_connections"] = connections
+        ctx.state.complete_phase(self.legacy_state_id or 6)
+        ctx.state.save()
+        return PhaseResult(self.id, success=True)

--- a/acropolis/installer/phases/community/parthenon_install.py
+++ b/acropolis/installer/phases/community/parthenon_install.py
@@ -1,0 +1,88 @@
+"""Sub-Phase between 5 and 6 — install Parthenon itself if not already running.
+
+This phase is unique in the legacy state machine: it has no numeric ID
+because it isn't tracked through ``InstallState.completed_phases``;
+instead it consults the topology's ``parthenon_install_completed`` flag
+and re-runs service discovery afterwards. The registry preserves that
+behavior — ``legacy_state_id`` stays ``None``.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+
+from acropolis.installer.discovery import discover_services
+from acropolis.installer.phases.base import InstallerContext, Phase, PhaseResult
+from acropolis.installer.phases.community.discovery import _service_to_dict
+from acropolis.installer.utils import PARTHENON_ROOT
+
+
+def _run_parthenon_installer(ctx: InstallerContext) -> bool:
+    if ctx.config is None:
+        return False
+    config = ctx.config
+    console = ctx.console
+
+    console.print("\n[bold cyan]Installing Parthenon Application[/]\n")
+
+    pre_seed = {
+        "admin_email": config.parthenon_admin_email,
+        "admin_name": config.parthenon_admin_name,
+        "admin_password": config.parthenon_admin_password,
+        "app_url": f"https://parthenon.{config.domain}",
+        "timezone": config.timezone,
+        "experience": "Experienced",
+    }
+    pre_seed = {k: v for k, v in pre_seed.items() if v}
+
+    try:
+        parthenon_str = str(PARTHENON_ROOT)
+        if parthenon_str not in sys.path:
+            sys.path.insert(0, parthenon_str)
+
+        installer_cli = importlib.import_module("installer.cli")
+        installer_cli.run(pre_seed=pre_seed)
+        console.print("[green]Parthenon installation complete.[/]\n")
+        return True
+    except SystemExit as exc:
+        if exc.code == 0:
+            console.print("[green]Parthenon installation complete.[/]\n")
+            return True
+        console.print("[yellow]Parthenon installer did not complete.[/]")
+        console.print("Fix Parthenon manually, then re-run this installer.")
+        return False
+    except Exception as exc:  # noqa: BLE001 — boundary
+        console.print(f"[red]Parthenon installer error: {exc}[/]")
+        return False
+
+
+class ParthenonInstallPhase(Phase):
+    """Install Parthenon if its containers aren't already running."""
+
+    id = "community.parthenon_install"
+    order = 550  # Between configuration (500) and network (600).
+    depends_on = ["community.configuration"]
+    legacy_state_id = None  # Not in InstallState.completed_phases.
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        if ctx.topology is None or ctx.config is None:
+            return PhaseResult(self.id, success=False, message="topology + config must run first")
+
+        if ctx.topology.parthenon_install_completed:
+            return PhaseResult(self.id, success=True, skipped=True, message="parthenon already installed")
+
+        completed = _run_parthenon_installer(ctx)
+        ctx.topology.parthenon_install_completed = completed
+        ctx.state.data.setdefault("topology", {})["parthenon_install_completed"] = completed
+        ctx.state.save()
+
+        if not completed:
+            ctx.console.print("[red]Cannot continue without Parthenon. Exiting.[/]")
+            sys.exit(1)
+
+        # Re-discover services now that Parthenon is up.
+        services = discover_services(ctx.topology, ctx.console)
+        ctx.services = services
+        ctx.state.data["services"] = [_service_to_dict(s) for s in services]
+        ctx.state.save()
+        return PhaseResult(self.id, success=True)

--- a/acropolis/installer/phases/community/preflight.py
+++ b/acropolis/installer/phases/community/preflight.py
@@ -1,0 +1,47 @@
+"""CE Phase 1 — Preflight checks (Docker, ports, disk)."""
+from __future__ import annotations
+
+import sys
+
+import questionary
+
+from acropolis.installer.phases.base import InstallerContext, Phase, PhaseResult
+from acropolis.installer.preflight import (
+    display_results,
+    has_failures,
+    has_warnings,
+    run_preflight,
+)
+
+
+class PreflightPhase(Phase):
+    """Validate the host before touching anything."""
+
+    id = "community.preflight"
+    order = 100
+    legacy_state_id = 1
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        if ctx.state.is_completed(self.legacy_state_id or -1):
+            return PhaseResult(self.id, success=True, skipped=True, message="already completed (resumed)")
+
+        ctx.console.print("\n[bold cyan]Phase 1: Preflight Checks[/]\n")
+        ctx.state.start_phase(self.legacy_state_id or 1)
+        ctx.state.save()
+
+        results = run_preflight()
+        display_results(results, ctx.console)
+
+        if has_failures(results):
+            ctx.console.print("[red]Fix the issues above before continuing.[/]")
+            sys.exit(1)
+
+        if has_warnings(results):
+            if not questionary.confirm(
+                "Warnings detected. Continue?", default=True
+            ).ask():
+                sys.exit(0)
+
+        ctx.state.complete_phase(self.legacy_state_id or 1)
+        ctx.state.save()
+        return PhaseResult(self.id, success=True)

--- a/acropolis/installer/phases/community/topology.py
+++ b/acropolis/installer/phases/community/topology.py
@@ -1,0 +1,32 @@
+"""CE Phase 2 — Detect / collect local Parthenon topology."""
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from acropolis.installer.phases.base import InstallerContext, Phase, PhaseResult
+from acropolis.installer.topology import TopologyConfig, collect_topology
+
+
+class TopologyPhase(Phase):
+    """Resolve where Parthenon is running (compose vs k8s, network, etc.)."""
+
+    id = "community.topology"
+    order = 200
+    depends_on = ["community.preflight"]
+    legacy_state_id = 2
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        if ctx.state.is_completed(self.legacy_state_id or -1):
+            topo_data = ctx.state.data.get("topology", {})
+            ctx.topology = TopologyConfig(**topo_data)
+            return PhaseResult(self.id, success=True, skipped=True, message="resumed from state")
+
+        ctx.state.start_phase(self.legacy_state_id or 2)
+        ctx.state.save()
+
+        topology = collect_topology(ctx.console)
+        ctx.topology = topology
+        ctx.state.data["topology"] = asdict(topology)
+        ctx.state.complete_phase(self.legacy_state_id or 2)
+        ctx.state.save()
+        return PhaseResult(self.id, success=True)

--- a/acropolis/installer/phases/community/traefik.py
+++ b/acropolis/installer/phases/community/traefik.py
@@ -1,0 +1,37 @@
+"""CE Phase 8 — Generate Traefik dynamic routing configs."""
+from __future__ import annotations
+
+from acropolis.installer.phases.base import InstallerContext, Phase, PhaseResult
+from acropolis.installer.routing import write_route_configs
+
+
+class TraefikPhase(Phase):
+    """Materialize Traefik routes for every exposed service."""
+
+    id = "community.traefik"
+    order = 800
+    depends_on = ["community.deploy"]
+    legacy_state_id = 8
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        if ctx.state.is_completed(self.legacy_state_id or -1):
+            return PhaseResult(self.id, success=True, skipped=True, message="resumed from state")
+
+        if ctx.topology is None or ctx.edition is None or ctx.config is None:
+            return PhaseResult(self.id, success=False, message="topology + edition + config must run first")
+
+        ctx.state.start_phase(self.legacy_state_id or 8)
+        ctx.state.save()
+
+        write_route_configs(
+            services=ctx.services,
+            domain=ctx.config.domain,
+            topology_mode=ctx.topology.mode,
+            tier=ctx.edition.tier,
+            tls_mode=ctx.config.tls_mode,
+            acme_email=ctx.config.acme_email,
+            console=ctx.console,
+        )
+        ctx.state.complete_phase(self.legacy_state_id or 8)
+        ctx.state.save()
+        return PhaseResult(self.id, success=True)

--- a/acropolis/installer/phases/community/verify.py
+++ b/acropolis/installer/phases/community/verify.py
@@ -1,0 +1,57 @@
+"""CE Phase 9 — Smoke tests + day-2 CLI generator + state cleanup."""
+from __future__ import annotations
+
+from acropolis.installer.generator import write_acropolis_sh
+from acropolis.installer.phases.base import InstallerContext, Phase, PhaseResult
+from acropolis.installer.verify import display_summary, run_smoke_tests
+from acropolis.installer.version import write_version
+
+
+class VerifyPhase(Phase):
+    """Run smoke tests, write the day-2 ``acropolis.sh`` helper, clear state."""
+
+    id = "community.verify"
+    order = 900
+    depends_on = ["community.traefik"]
+    legacy_state_id = 9
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        if ctx.config is None or ctx.edition is None or ctx.topology is None:
+            return PhaseResult(self.id, success=False, message="topology + edition + config must run first")
+
+        ctx.state.start_phase(self.legacy_state_id or 9)
+        ctx.state.save()
+
+        passed, failed, skipped = run_smoke_tests(
+            ctx.config, ctx.edition, ctx.services, ctx.console
+        )
+        ctx.smoke_passed = passed
+        ctx.smoke_failed = failed
+        ctx.smoke_skipped = skipped
+
+        service_names = [s.name for s in ctx.services if s.expose]
+        write_acropolis_sh(
+            tier=ctx.edition.tier,
+            domain=ctx.config.domain,
+            topology_mode=ctx.topology.mode,
+            services=service_names,
+            parthenon_path=ctx.topology.parthenon_path,
+            parthenon_url=ctx.topology.parthenon_url,
+            parthenon_network=ctx.topology.parthenon_network,
+            console=ctx.console,
+        )
+
+        display_summary(
+            ctx.config,
+            ctx.topology,
+            ctx.edition,
+            ctx.services,
+            passed,
+            failed,
+            skipped,
+            ctx.console,
+        )
+
+        write_version(edition=ctx.edition.tier)
+        ctx.state.clear()
+        return PhaseResult(self.id, success=True)

--- a/acropolis/installer/phases/registry.py
+++ b/acropolis/installer/phases/registry.py
@@ -1,0 +1,185 @@
+"""Discovers, orders, and runs Acropolis installer phases.
+
+Discovery sources (in order):
+
+  1. **CE built-ins** — registered explicitly by ``cli.run()`` via
+     :func:`acropolis.installer.phases.community.register_into`.
+  2. **Setuptools entry points** — group ``parthenon.acropolis.phases``.
+     EE bundles register their phases here in their own ``pyproject.toml``.
+  3. **Runtime registration** — ``registry.register(MyPhase())`` for
+     ad-hoc development and tests.
+
+The registry topologically sorts by ``depends_on`` (Kahn's algorithm),
+breaks ties by ``Phase.order`` then ``Phase.id`` (lexicographic). It
+filters by edition and ``requires_enterprise`` before sorting so EE
+phases vanish on community installs without needing to be deregistered.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+from acropolis.installer.phases.base import (
+    InstallerContext,
+    Phase,
+    PhaseError,
+    PhaseResult,
+)
+
+
+class PhaseRegistry:
+    """Holds the ordered set of Phases for one installer invocation."""
+
+    #: Setuptools entry-point group EE bundles use to advertise phases.
+    ENTRY_POINT_GROUP = "parthenon.acropolis.phases"
+
+    def __init__(self, console: Console | None = None) -> None:
+        self._phases: list[Phase] = []
+        self._console = console
+
+    # ── Registration ───────────────────────────────────────────────────────
+
+    def register(self, phase: Phase) -> None:
+        """Add a phase. Raises ``ValueError`` if the id collides."""
+        if not phase.id:
+            raise ValueError(
+                f"Phase subclass {type(phase).__name__} has empty id"
+            )
+        if any(p.id == phase.id for p in self._phases):
+            raise ValueError(f"Phase id '{phase.id}' already registered")
+        self._phases.append(phase)
+
+    def discover_entry_points(self) -> list[str]:
+        """Load EE-published phases via setuptools entry points.
+
+        Returns the list of successfully loaded phase ids. Failures are
+        logged through the registry's console but do not abort discovery
+        — a single misbehaving EE plugin can't take the installer down.
+        """
+        loaded: list[str] = []
+        try:
+            eps = importlib.metadata.entry_points(group=self.ENTRY_POINT_GROUP)
+        except TypeError:
+            # Python < 3.10 fallback (Acropolis targets 3.12 but be defensive).
+            eps = importlib.metadata.entry_points().get(  # type: ignore[attr-defined]
+                self.ENTRY_POINT_GROUP, []
+            )
+        for ep in eps:
+            try:
+                phase_cls = ep.load()
+                phase = phase_cls() if isinstance(phase_cls, type) else phase_cls
+                self.register(phase)
+                loaded.append(phase.id)
+            except Exception as exc:  # noqa: BLE001 — defensive boundary
+                if self._console is not None:
+                    self._console.print(
+                        f"[yellow]warn:[/] failed to load phase '{ep.name}': {exc}"
+                    )
+        return loaded
+
+    def names(self) -> list[str]:
+        return [p.id for p in self._phases]
+
+    def phases(self) -> list[Phase]:
+        return list(self._phases)
+
+    def clear(self) -> None:
+        self._phases.clear()
+
+    # ── Ordering ───────────────────────────────────────────────────────────
+
+    def sorted_phases(
+        self,
+        edition: str,
+        *,
+        include_skipped: bool = False,
+    ) -> list[Phase]:
+        """Return phases topologically sorted with ties broken by ``order``.
+
+        Phases not applicable to ``edition`` are dropped unless
+        ``include_skipped=True``. Raises :class:`PhaseError` on missing
+        dependency or cycle.
+        """
+        applicable = [
+            p
+            for p in self._phases
+            if include_skipped or p.is_applicable(edition)
+        ]
+
+        indeg: dict[str, int] = {p.id: 0 for p in applicable}
+        graph: dict[str, list[str]] = {p.id: [] for p in applicable}
+        by_id = {p.id: p for p in applicable}
+
+        for p in applicable:
+            for dep in p.depends_on:
+                if dep not in indeg:
+                    raise PhaseError(
+                        p.id,
+                        f"depends_on '{dep}' is not registered or not applicable to edition '{edition}'",
+                    )
+                graph[dep].append(p.id)
+                indeg[p.id] += 1
+
+        ready = sorted(
+            (pid for pid, d in indeg.items() if d == 0),
+            key=lambda pid: (by_id[pid].order, pid),
+        )
+        result: list[Phase] = []
+        while ready:
+            pid = ready.pop(0)
+            result.append(by_id[pid])
+            for child in graph[pid]:
+                indeg[child] -= 1
+                if indeg[child] == 0:
+                    ready.append(child)
+            ready.sort(key=lambda pid: (by_id[pid].order, pid))
+
+        if len(result) != len(applicable):
+            cycle = [pid for pid, d in indeg.items() if d > 0]
+            raise PhaseError(
+                "registry",
+                f"depends_on cycle detected among phases: {cycle}",
+            )
+        return result
+
+    # ── Execution ──────────────────────────────────────────────────────────
+
+    def run_all(
+        self,
+        ctx: InstallerContext,
+        edition: str,
+    ) -> list[PhaseResult]:
+        """Run every applicable phase in order, returning the result list.
+
+        Resume behavior preserved from the legacy inline flow: when a
+        phase has a ``legacy_state_id`` already in ``ctx.state.completed_phases``,
+        the phase's :meth:`Phase.run` is responsible for re-hydrating any
+        derived data from ``ctx.state.data`` and returning
+        ``PhaseResult(skipped=True)``. The registry does not auto-skip;
+        phases need to handle their own resume because some phases re-run
+        partial work (e.g. the parthenon-install sub-phase re-discovers
+        services after install).
+        """
+        results: list[PhaseResult] = []
+        for phase in self.sorted_phases(edition):
+            t0 = time.time()
+            if self._console is not None:
+                self._console.rule(f"[bold cyan]{phase.id}[/]")
+            try:
+                r = phase.run(ctx)
+            except PhaseError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — boundary
+                raise PhaseError(
+                    phase.id, f"unhandled exception: {exc}"
+                ) from exc
+            r.duration_s = time.time() - t0
+            results.append(r)
+            if not r.success and not r.skipped:
+                raise PhaseError(phase.id, r.message or "phase reported failure", r.diagnostics)
+        return results

--- a/acropolis/tests/fixtures/__init__.py
+++ b/acropolis/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Test fixtures for Acropolis installer phase pluggability checks."""

--- a/acropolis/tests/fixtures/stub_fips_bootstrap_phase.py
+++ b/acropolis/tests/fixtures/stub_fips_bootstrap_phase.py
@@ -1,0 +1,26 @@
+"""Pluggability fixture — proves an EE-style phase plugs in without CE patches."""
+from __future__ import annotations
+
+from acropolis.installer.phases.base import InstallerContext, Phase, PhaseResult
+
+
+class StubFipsBootstrapPhase(Phase):
+    """Synthetic enterprise phase used in registry tests.
+
+    Mirrors the shape EE's real ``FipsBootstrapPhase`` will take: declares
+    ``requires_enterprise=True``, depends on a CE phase (preflight),
+    runs at a slot that respects every CE depends_on chain.
+    """
+
+    id = "stub.enterprise.fips_bootstrap"
+    order = 350
+    requires_enterprise = True
+    depends_on = ["community.preflight"]
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        return PhaseResult(
+            self.id,
+            success=True,
+            message="FIPS provider stub OK",
+            diagnostics={"provider": "stub-fips"},
+        )

--- a/acropolis/tests/test_phase_registry.py
+++ b/acropolis/tests/test_phase_registry.py
@@ -1,0 +1,231 @@
+"""Tests for the Acropolis installer phase registry (Plan 02-07)."""
+from __future__ import annotations
+
+import pytest
+
+from acropolis.installer.phases.base import (
+    InstallerContext,
+    Phase,
+    PhaseError,
+    PhaseResult,
+)
+from acropolis.installer.phases.registry import PhaseRegistry
+from acropolis.tests.fixtures.stub_fips_bootstrap_phase import StubFipsBootstrapPhase
+
+
+# ── Tiny in-test phase fixtures ──────────────────────────────────────────────
+
+class StubA(Phase):
+    id = "stub.a"
+    order = 100
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        return PhaseResult(self.id, success=True)
+
+
+class StubB(Phase):
+    id = "stub.b"
+    order = 200
+    depends_on = ["stub.a"]
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        return PhaseResult(self.id, success=True)
+
+
+class StubFailing(Phase):
+    id = "stub.fail"
+    order = 100
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        return PhaseResult(self.id, success=False, message="boom")
+
+
+class StubLogger(Phase):
+    """Phase that appends its id to a shared list when run."""
+
+    def __init__(self, log: list[str], pid: str, order: int = 0, depends_on: list[str] | None = None) -> None:
+        self.id = pid
+        self.order = order
+        self.depends_on = depends_on or []
+        self._log = log
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        self._log.append(self.id)
+        return PhaseResult(self.id, success=True)
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+def test_register_and_list():
+    reg = PhaseRegistry()
+    reg.register(StubA())
+    reg.register(StubB())
+    assert reg.names() == ["stub.a", "stub.b"]
+
+
+def test_empty_id_rejected():
+    class Bad(Phase):
+        id = ""
+
+        def run(self, ctx):
+            return PhaseResult(self.id, success=True)
+
+    reg = PhaseRegistry()
+    with pytest.raises(ValueError, match="empty id"):
+        reg.register(Bad())
+
+
+def test_topological_sort_respects_depends_on():
+    reg = PhaseRegistry()
+    reg.register(StubB())
+    reg.register(StubA())
+    sorted_ids = [p.id for p in reg.sorted_phases("community")]
+    assert sorted_ids.index("stub.a") < sorted_ids.index("stub.b")
+
+
+def test_ee_only_phase_excluded_in_community_edition():
+    reg = PhaseRegistry()
+    reg.register(StubA())
+    reg.register(StubFipsBootstrapPhase())
+    ids = [p.id for p in reg.sorted_phases("community")]
+    assert "stub.enterprise.fips_bootstrap" not in ids
+    assert "stub.a" in ids
+
+
+def test_ee_only_phase_included_in_enterprise_edition():
+    reg = PhaseRegistry()
+    reg.register(StubA())
+    reg.register(StubFipsBootstrapPhase())
+    # depends_on points at a community phase that IS applicable to
+    # enterprise — the registry's filter retains it.
+    class CommunityPreflight(Phase):
+        id = "community.preflight"
+        order = 100
+
+        def run(self, ctx):
+            return PhaseResult(self.id, success=True)
+
+    reg.register(CommunityPreflight())
+
+    ids = [p.id for p in reg.sorted_phases("enterprise")]
+    assert "stub.enterprise.fips_bootstrap" in ids
+    # depends_on must be respected
+    assert ids.index("community.preflight") < ids.index("stub.enterprise.fips_bootstrap")
+
+
+def test_duplicate_id_raises():
+    reg = PhaseRegistry()
+    reg.register(StubA())
+    with pytest.raises(ValueError, match="already registered"):
+        reg.register(StubA())
+
+
+def test_missing_dependency_raises():
+    class Orphan(Phase):
+        id = "orphan"
+        depends_on = ["does-not-exist"]
+
+        def run(self, ctx):
+            return PhaseResult(self.id, success=True)
+
+    reg = PhaseRegistry()
+    reg.register(Orphan())
+    with pytest.raises(PhaseError, match="depends_on"):
+        reg.sorted_phases("community")
+
+
+def test_cycle_detection():
+    class C1(Phase):
+        id = "c.1"
+        depends_on = ["c.2"]
+
+        def run(self, ctx):
+            return PhaseResult(self.id, success=True)
+
+    class C2(Phase):
+        id = "c.2"
+        depends_on = ["c.1"]
+
+        def run(self, ctx):
+            return PhaseResult(self.id, success=True)
+
+    reg = PhaseRegistry()
+    reg.register(C1())
+    reg.register(C2())
+    with pytest.raises(PhaseError, match="cycle"):
+        reg.sorted_phases("community")
+
+
+def test_run_all_executes_in_topological_order():
+    reg = PhaseRegistry()
+    log: list[str] = []
+    reg.register(StubLogger(log, "p.b", order=200, depends_on=["p.a"]))
+    reg.register(StubLogger(log, "p.a", order=100))
+
+    ctx = _stub_ctx()
+    reg.run_all(ctx, edition="community")
+    assert log == ["p.a", "p.b"]
+
+
+def test_run_all_aborts_on_failure_with_phase_error():
+    reg = PhaseRegistry()
+    reg.register(StubFailing())
+
+    ctx = _stub_ctx()
+    with pytest.raises(PhaseError, match="boom"):
+        reg.run_all(ctx, edition="community")
+
+
+def test_run_all_propagates_unhandled_exception():
+    class Throws(Phase):
+        id = "throws"
+
+        def run(self, ctx):
+            raise RuntimeError("kaboom")
+
+    reg = PhaseRegistry()
+    reg.register(Throws())
+    ctx = _stub_ctx()
+    with pytest.raises(PhaseError, match="kaboom"):
+        reg.run_all(ctx, edition="community")
+
+
+def test_pluggability_proof_stub_fips_phase_runs_when_registered_at_runtime():
+    """The headline pluggability proof: an EE-shaped stub plugs in via
+    a single ``register()`` call. CE never patches anything."""
+    from acropolis.installer.phases.community import register_into
+
+    reg = PhaseRegistry()
+    register_into(reg)
+    reg.register(StubFipsBootstrapPhase())
+
+    ids = [p.id for p in reg.sorted_phases("enterprise")]
+    assert "stub.enterprise.fips_bootstrap" in ids
+    # And it appears AFTER the community preflight per depends_on.
+    assert ids.index("community.preflight") < ids.index("stub.enterprise.fips_bootstrap")
+
+
+def test_clear_resets_the_registry():
+    reg = PhaseRegistry()
+    reg.register(StubA())
+    reg.register(StubB())
+    reg.clear()
+    assert reg.names() == []
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _stub_ctx() -> InstallerContext:
+    """Build a minimal ``InstallerContext`` for tests that don't read the state file."""
+    from rich.console import Console
+
+    from acropolis.installer.state import InstallState
+
+    state = InstallState.__new__(InstallState)
+    state.path = None  # type: ignore[assignment]
+    state.version = 1
+    state.started_at = ""
+    state.completed_phases = []
+    state.current_phase = None
+    state.data = {}
+    return InstallerContext(state=state, console=Console())

--- a/acropolis/tests/test_phases_smoke.py
+++ b/acropolis/tests/test_phases_smoke.py
@@ -1,0 +1,63 @@
+"""Smoke tests — every CE phase is importable, has metadata, and the
+canonical CE phase list resolves to the expected order."""
+from __future__ import annotations
+
+from acropolis.installer.phases import PhaseRegistry
+from acropolis.installer.phases.community import __all_phases__, register_into
+
+
+CE_EXPECTED_ORDER = [
+    "community.preflight",
+    "community.topology",
+    "community.edition",
+    "community.discovery",
+    "community.configuration",
+    "community.parthenon_install",
+    "community.network",
+    "community.deploy",
+    "community.traefik",
+    "community.verify",
+]
+
+
+def test_community_phases_exposes_ten_phases():
+    assert len(__all_phases__) == len(CE_EXPECTED_ORDER)
+
+
+def test_register_into_populates_canonical_order():
+    reg = PhaseRegistry()
+    register_into(reg)
+    actual = [p.id for p in reg.sorted_phases("community")]
+    assert actual == CE_EXPECTED_ORDER
+
+
+def test_every_ce_phase_has_required_metadata():
+    for cls in __all_phases__:
+        instance = cls()
+        assert instance.id, f"{cls.__name__} missing id"
+        assert instance.id.startswith("community."), f"{cls.__name__} id should be community-prefixed"
+        # Topology + Edition + Discovery + Configuration + Network + Deploy + Traefik + Verify
+        # all map to legacy_state_id; ParthenonInstall is intentionally None.
+        if cls.__name__ == "ParthenonInstallPhase":
+            assert instance.legacy_state_id is None
+        else:
+            assert isinstance(instance.legacy_state_id, int) and 1 <= instance.legacy_state_id <= 9
+
+
+def test_every_ce_phase_is_applicable_to_community_edition():
+    for cls in __all_phases__:
+        assert cls().is_applicable("community"), f"{cls.__name__} not applicable to community"
+
+
+def test_every_ce_phase_is_applicable_to_enterprise_edition_too():
+    for cls in __all_phases__:
+        assert cls().is_applicable("enterprise"), f"{cls.__name__} not applicable to enterprise"
+
+
+def test_build_registry_helper_includes_ce_phases():
+    from acropolis.installer.cli import build_registry
+
+    registry = build_registry()
+    names = registry.names()
+    for expected in CE_EXPECTED_ORDER:
+        assert expected in names

--- a/docs/architecture/extension-points.md
+++ b/docs/architecture/extension-points.md
@@ -21,7 +21,7 @@ Each extension point ships with:
 | 4 | Audit sink | `App\Contracts\AuditSinkInterface` | [audit-sink.md](extension-points/audit-sink.md) |
 | 5 | Observability shipper | `App\Contracts\ObservabilityShipperInterface` | [observability-shipper.md](extension-points/observability-shipper.md) |
 | 6 | Frontend feature flags + EnterpriseGate | `frontend/src/contracts/featureFlags.ts` | [feature-flags.md](extension-points/feature-flags.md) |
-| 7 | Acropolis installer phase registry | `acropolis/installer/phases/Phase` (Python) | (Plan 02-07) |
+| 7 | Acropolis installer phase registry | `acropolis/installer/phases/Phase` (Python) | [installer-phase-registry.md](extension-points/installer-phase-registry.md) |
 | 8 | Compose composition contract | `docker-compose.yml` override conventions | (Plan 02-08) |
 
 ## How to add a custom driver (community)

--- a/docs/architecture/extension-points/installer-phase-registry.md
+++ b/docs/architecture/extension-points/installer-phase-registry.md
@@ -1,0 +1,163 @@
+# Extension Point: Acropolis Installer Phase Registry
+
+**Backend (Python):** `acropolis.installer.phases`
+**Phase ABC:** `acropolis.installer.phases.base.Phase`
+**Result type:** `acropolis.installer.phases.base.PhaseResult`
+**Error type:** `acropolis.installer.phases.base.PhaseError`
+**Context object:** `acropolis.installer.phases.base.InstallerContext`
+**Registry:** `acropolis.installer.phases.registry.PhaseRegistry`
+**CE phases:** `acropolis.installer.phases.community.*`
+**Entry-point group (EE):** `parthenon.acropolis.phases`
+**Status:** Live since [Phase 2 #7](../../superpowers/plans/2026-05-09-ce-ee-fork-plan-02-07-installer-phase-registry.md)
+
+## Purpose
+
+Decouple the Acropolis installer's flow from a hardcoded sequence of inline `if not state.is_completed(N)` blocks. Each step is now a `Phase` subclass with declarative metadata (`id`, `order`, `depends_on`, `requires_enterprise`, `legacy_state_id`). The CLI builds a registry, lets EE register additional phases via setuptools entry points, topologically sorts, and runs everything in order.
+
+CE preserves byte-for-byte behavior — the legacy `.install-state.json` contract is intact (each CE phase carries the same numeric `legacy_state_id` it had before), so an installer interrupted mid-flow on the previous code base still resumes correctly after this refactor.
+
+EE plugs in by:
+
+1. Implementing `Phase` for each enterprise-only step (`FipsBootstrapPhase`, `MultiTenantInitPhase`, `KeycloakSetupPhase`, `SignedAuditSetupPhase`, ...).
+2. Declaring entry points in EE's `pyproject.toml`:
+   ```toml
+   [project.entry-points."parthenon.acropolis.phases"]
+   fips_bootstrap = "enterprise.installer.phases.fips:FipsBootstrapPhase"
+   multi_tenant_init = "enterprise.installer.phases.multi_tenant:MultiTenantInitPhase"
+   keycloak_setup = "enterprise.installer.phases.keycloak:KeycloakSetupPhase"
+   ```
+3. Setting `requires_enterprise=True` so CE deployments skip the phase even if the EE bundle is on the install path.
+
+## Architecture
+
+```
+                  ┌─────── PhaseRegistry ───────┐
+                  │  (one instance per run)     │
+   register_into  │                             │  discover_entry_points()
+   (CE phases) ──▶│  ordered list of Phases     │◀── EE entry points
+                  │                             │
+                  │  topological sort           │
+                  │   tied by .order, .id       │
+                  │                             │
+                  │  filter by edition          │
+                  │   skip requires_enterprise  │
+                  │   in community installs     │
+                  │                             │
+                  └─────────────┬───────────────┘
+                                │
+                                ▼
+                  ┌─────── run_all(ctx, edition) ──────┐
+                  │  for phase in sorted_phases:       │
+                  │    phase.run(ctx)  ── mutates ctx  │
+                  │  on PhaseError → halt + report     │
+                  └────────────────────────────────────┘
+```
+
+`InstallerContext` is the mutable bag every phase reads & writes — replaces the implicit local-variable bag the inline `cli.run()` flow used.
+
+## Phase contract
+
+```python
+class Phase(ABC):
+    id: str = ""                       # 'community.preflight', 'enterprise.fips_bootstrap'
+    order: int = 0                     # tie-breaker within depends_on cohort
+    editions: list[str] = []           # empty = all editions
+    depends_on: list[str] = []         # other phase ids
+    requires_enterprise: bool = False
+    legacy_state_id: int | None = None # for resume from old .install-state.json
+
+    @abstractmethod
+    def run(self, ctx: InstallerContext) -> PhaseResult: ...
+```
+
+### Resume contract (`legacy_state_id`)
+
+CE phases keep the same integer they had in the legacy state machine:
+
+| Phase | legacy_state_id |
+|-------|-----------------|
+| `community.preflight` | 1 |
+| `community.topology` | 2 |
+| `community.edition` | 3 |
+| `community.discovery` | 4 |
+| `community.configuration` | 5 |
+| `community.parthenon_install` | None (intentionally unnumbered) |
+| `community.network` | 6 |
+| `community.deploy` | 7 |
+| `community.traefik` | 8 |
+| `community.verify` | 9 |
+
+When a phase finds its `legacy_state_id` in `state.completed_phases`, its `run()` re-hydrates derived data from `state.data` and returns `PhaseResult(success=True, skipped=True)`. The registry treats this as a successful no-op and proceeds.
+
+EE phases that don't predate this refactor leave `legacy_state_id=None` and write their own resume markers in `state.data`.
+
+### Best-effort discovery
+
+`PhaseRegistry.discover_entry_points()` is defensive — a single misbehaving EE plugin can't take the installer down. Failed entry-point loads emit a warning to the registry's console and discovery continues.
+
+## CE phase wiring
+
+`acropolis/installer/phases/community/__init__.py` imports each phase class and exposes `register_into(registry)`:
+
+```python
+from acropolis.installer.phases import PhaseRegistry
+from acropolis.installer.phases.community import register_into
+
+registry = PhaseRegistry()
+register_into(registry)
+registry.discover_entry_points()  # adds EE phases if installed
+```
+
+`acropolis.installer.cli.build_registry()` does the above and is the public helper EE wrappers / tests use.
+
+## Pluggability proof
+
+`acropolis/tests/test_phase_registry.py::test_pluggability_proof_stub_fips_phase_runs_when_registered_at_runtime` is the headline test. It:
+
+1. Builds a registry pre-populated with all 10 CE phases.
+2. Registers `StubFipsBootstrapPhase` (a synthetic EE-shaped phase: `requires_enterprise=True`, `depends_on=['community.preflight']`, `order=350`).
+3. Calls `sorted_phases('enterprise')` and verifies the stub appears in order, after `community.preflight`, before any phase whose `order > 350`.
+
+The test passes without a single line of CE code modified — that's the contract.
+
+`test_phases_smoke.py` verifies the canonical CE phase list resolves to the expected order, every CE phase has correct metadata, and `build_registry()` includes all CE phases.
+
+## EE phase sketches
+
+```python
+# enterprise/installer/phases/fips.py
+from acropolis.installer.phases.base import InstallerContext, Phase, PhaseResult
+
+class FipsBootstrapPhase(Phase):
+    id = "enterprise.fips_bootstrap"
+    order = 350                              # Between configuration (500) and parthenon_install (550)
+    requires_enterprise = True
+    depends_on = ["community.configuration"]
+
+    def run(self, ctx: InstallerContext) -> PhaseResult:
+        # Validate FIPS-validated openssl, install crypto provider, etc.
+        ...
+        return PhaseResult(self.id, success=True)
+```
+
+```toml
+# enterprise/pyproject.toml
+[project.entry-points."parthenon.acropolis.phases"]
+fips_bootstrap = "enterprise.installer.phases.fips:FipsBootstrapPhase"
+```
+
+CE installer scans the entry-point group on every run; if EE is installed, the phase appears automatically.
+
+## Out of scope
+
+- **Per-phase parallel execution** — the installer is sequential by design (Docker network changes affect downstream services).
+- **Phase resumability inside a single phase** — phases are atomic units of work; a partially-complete phase re-runs from the start on resume.
+- **Web UI for phase progress** — operators see `rich.console` rules + status; a UI shell is a separate plan.
+- **EE phase implementations** (FIPS, multi-tenant init, Keycloak setup, signed audit shipper config) — Plan 04.
+
+## Anti-patterns
+
+- ❌ Don't read or mutate `state.data` outside of phases. Every state read/write goes through the phase.
+- ❌ Don't introduce hidden dependencies between phases through global module-level state. Use `InstallerContext` fields.
+- ❌ Don't raise plain `RuntimeError` from a phase — wrap in `PhaseError(phase_id, ...)` so the registry can attribute the failure correctly.
+- ❌ Don't skip the legacy resume contract on a CE phase. Old installations in the field have `.install-state.json` files keyed by integer phase id; preserving `legacy_state_id` is what keeps them resumable.


### PR DESCRIPTION
## Summary

Adds the seventh CE/EE extension-point seam — a Python plugin discovery pattern for the Acropolis installer flow. The 9-step inline `if not state.is_completed(N)` orchestration in `acropolis/installer/cli.py` is now a topologically-sorted phase registry. Every CE step keeps its legacy numeric `state_id`, so an installer interrupted on the prior code base resumes correctly after this refactor.

This is Plan 02-07 from the [Phase 2 umbrella](docs/superpowers/plans/2026-05-08-ce-ee-fork-plan-02-extension-points-umbrella.md). Independent of Plans 02-01..02-06.

## What landed

- **`Phase` ABC + `PhaseResult` + `PhaseError` + `InstallerContext`** in `acropolis/installer/phases/base.py`. The context object replaces the implicit local-variable bag the inline `cli.run()` flow used (config, topology, edition, services, connections all become `ctx.<field>`).
- **`PhaseRegistry`** in `acropolis/installer/phases/registry.py` with Kahn-algorithm topological sort, edition filter, and defensive setuptools entry-point discovery (group `parthenon.acropolis.phases`).
- **10 CE phase wrappers** under `acropolis/installer/phases/community/`: preflight (1), topology (2), edition (3), discovery (4), configuration (5), parthenon_install (5.5 — sub-phase, no `legacy_state_id`), network (6), deploy (7), traefik (8), verify (9).
- **`acropolis/installer/cli.py` refactored** — ~200 LOC of inlined if-blocks replaced with `build_registry()` + `registry.run_all(ctx, edition='enterprise')`. The public `build_registry()` helper is the seam EE wrappers and tests use.

R7 follow-through: `PhaseResult.warnings` field for non-fatal advisories from EE phases ("primary action OK, optional verification failed").

## Resume contract preserved

CE phases keep the same `legacy_state_id` they had in the inline flow. When a phase finds its id in `state.completed_phases`, it re-hydrates derived data from `state.data` and returns `PhaseResult(skipped=True)`. An old `.install-state.json` from before this refactor still resumes correctly — the field-by-field re-hydration logic for `topology`, `edition`, `services`, `config`, `network_connections` lives inside each phase.

## EE wiring (informational)

```toml
# enterprise/pyproject.toml
[project.entry-points."parthenon.acropolis.phases"]
fips_bootstrap = "enterprise.installer.phases.fips:FipsBootstrapPhase"
multi_tenant_init = "enterprise.installer.phases.multi_tenant:MultiTenantInitPhase"
keycloak_setup = "enterprise.installer.phases.keycloak:KeycloakSetupPhase"
signed_audit_setup = "enterprise.installer.phases.audit:SignedAuditSetupPhase"
```

CE installer scans the entry-point group on every run; if the EE bundle is on the install path, the phases appear automatically and topologically sort into the right slot via `depends_on`.

## Test plan

- [x] **19 new pytest tests, all green** via host Python 3.13 / pytest 9.0.2
- [x] `test_phase_registry.py` — register/dedupe/empty-id, topological sort, edition filter (CE excludes EE-only, enterprise includes), missing dependency, cycle detection, `run_all` order, abort-on-failure with `PhaseError`, unhandled-exception wrap, `clear()`.
- [x] `test_phases_smoke.py` — every CE phase has correct metadata, canonical CE order matches expected list, `build_registry()` returns the full CE set.
- [x] Pluggability proof: `StubFipsBootstrapPhase` (`requires_enterprise=True`, `depends_on=['community.preflight']`, `order=350`) plugs in via a single `registry.register(stub)` call. Test asserts it appears in `sorted_phases('enterprise')` AFTER `community.preflight` — no CE code modified.
- [x] `python3 -c "from acropolis.installer.cli import build_registry; print(build_registry().names())"` smoke check returns the 10-phase CE list in canonical order.

## Refs

- Spec: [`docs/superpowers/specs/2026-05-08-ce-ee-fork-and-agplv3-relicense-design.md`](docs/superpowers/specs/2026-05-08-ce-ee-fork-and-agplv3-relicense-design.md) §5 row 7
- Plan: [`docs/superpowers/plans/2026-05-09-ce-ee-fork-plan-02-07-installer-phase-registry.md`](docs/superpowers/plans/2026-05-09-ce-ee-fork-plan-02-07-installer-phase-registry.md)
- Cross-Plan Revision R7 — `PhaseResult.warnings` for non-fatal advisories.