### PR TITLE
feat(compose): document and verify composition contract (Phase 2 #8 of 8)

### DIFF
--- a/.github/workflows/compose-contract.yml
+++ b/.github/workflows/compose-contract.yml
@@ -1,0 +1,33 @@
+name: Compose Composition Contract
+
+on:
+  pull_request:
+    paths:
+      - 'docker-compose*.yml'
+      - 'acropolis/docker-compose*.yml'
+      - 'scripts/verify_compose_contract.py'
+      - 'scripts/verify_compose_contract_test.py'
+      - '.github/workflows/compose-contract.yml'
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install --quiet pyyaml pytest
+
+      - name: Verify CE compose contract
+        run: python3 scripts/verify_compose_contract.py
+
+      - name: Run verifier unit tests
+        run: pytest scripts/verify_compose_contract_test.py -q

--- a/docker-compose.community.yml
+++ b/docker-compose.community.yml
@@ -1,3 +1,16 @@
+# docker-compose.community.yml — Parthenon CE overlay (community tier)
+#
+# COMPOSITION CONTRACT — see docs/architecture/extension-points/compose-composition.md
+#
+#   This overlay layers on top of docker-compose.yml when the installer
+#   selects the community tier. It pins the CE image registry and adds
+#   community-only services. Same contract rules apply: stable service
+#   names, `parthenon-<service>` container naming, no `parthenon-ee-*`
+#   volumes/networks, healthchecks required.
+#
+# Verify locally:
+#   python3 scripts/verify_compose_contract.py
+
 services:
   nginx:
     container_name: parthenon-nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,20 @@
+# docker-compose.yml — Parthenon CE base layer
+#
+# COMPOSITION CONTRACT — see docs/architecture/extension-points/compose-composition.md
+#
+#   - Service names listed in STABLE_SERVICE_NAMES (verifier) are PUBLIC API.
+#     Renaming or removing them is a breaking change.
+#   - Container names follow `parthenon-<service>` (legacy `python-ai`
+#     allowlisted by verifier).
+#   - Named volumes are unprefixed (CE owns them). EE volumes must be
+#     `parthenon-ee-*` prefixed.
+#   - Images use `ghcr.io/acumenus-data-sciences/parthenon-<service>:${PARTHENON_IMAGE_TAG:-latest}`.
+#   - Variability via `${VAR:-default}` only — no conditional service definitions.
+#   - Healthchecks are required and MUST NOT be weakened by overrides.
+#
+# Verify locally:
+#   python3 scripts/verify_compose_contract.py
+
 services:
   nginx:
     container_name: parthenon-nginx

--- a/docs/architecture/extension-points.md
+++ b/docs/architecture/extension-points.md
@@ -22,7 +22,7 @@ Each extension point ships with:
 | 5 | Observability shipper | `App\Contracts\ObservabilityShipperInterface` | [observability-shipper.md](extension-points/observability-shipper.md) |
 | 6 | Frontend feature flags + EnterpriseGate | `frontend/src/contracts/featureFlags.ts` | [feature-flags.md](extension-points/feature-flags.md) |
 | 7 | Acropolis installer phase registry | `acropolis/installer/phases/Phase` (Python) | [installer-phase-registry.md](extension-points/installer-phase-registry.md) |
-| 8 | Compose composition contract | `docker-compose.yml` override conventions | (Plan 02-08) |
+| 8 | Compose composition contract | `docker-compose.yml` override conventions | [compose-composition.md](extension-points/compose-composition.md) |
 
 ## How to add a custom driver (community)
 

--- a/docs/architecture/extension-points/compose-composition.md
+++ b/docs/architecture/extension-points/compose-composition.md
@@ -1,0 +1,227 @@
+# Extension Point: Compose Composition Contract
+
+**Verifier:** `scripts/verify_compose_contract.py`
+**Verifier tests:** `scripts/verify_compose_contract_test.py`
+**CI workflow:** `.github/workflows/compose-contract.yml`
+**Stable service list:** `STABLE_SERVICE_NAMES` in the verifier
+**Status:** Live since [Phase 2 #8](../../superpowers/plans/2026-05-09-ce-ee-fork-plan-02-08-compose-composition-contract.md)
+
+## Purpose
+
+Document and machine-verify how Parthenon's Docker Compose stack is layered so EE's `docker-compose.ee.yml` (in the private `Parthenon-EE` repo) can extend the public CE compose stack via well-defined override conventions, without ever patching CE compose YAML.
+
+This is a **mostly-documentation extension point** — there are no production behavior changes in CE. The deliverables are:
+
+1. The contract rules below.
+2. A Python verifier (`scripts/verify_compose_contract.py`) that statically enforces them.
+3. A CI workflow that runs the verifier on every PR touching compose files.
+
+## The compose layers
+
+CE structure (preserved as-is):
+
+| File | Role |
+|---|---|
+| `docker-compose.yml` | Base — application services (php, nginx, postgres, redis, node, python-ai, solr, horizon, hecate, ...). Always loaded. |
+| `docker-compose.community.yml` | CE overlay — adds Acropolis community services when running on a CE-installer host. Loaded by `./deploy.sh` when the installer's `tier=community`. |
+| `acropolis/docker-compose.base.yml` | Acropolis-only base (Traefik, Portainer always-on basics) |
+| `acropolis/docker-compose.community.yml` | Acropolis CE additions (pgAdmin, Authentik, Grafana) |
+| `acropolis/docker-compose.local.yml` | Local-dev opt-ins |
+
+Future EE additions (in Parthenon-EE, NOT in this PR — verified once they land):
+
+| File | Role |
+|---|---|
+| `enterprise/docker-compose.ee.yml` | EE app overlay — Keycloak side-car (replaces Authentik), FIPS-mode env vars, signed-audit shipper sidecar |
+| `enterprise/acropolis/docker-compose.ee-overlay.yml` | EE Acropolis additions — n8n, Superset, DataHub, Wazuh, Keycloak |
+
+EE loads via `docker compose -f docker-compose.yml -f enterprise/docker-compose.ee.yml ... up -d` from the Parthenon-EE repo (where `parthenon/` lives next to `enterprise/`).
+
+## The 10 contract rules
+
+The verifier enforces these statically. Document them here so the rationale is visible in code review.
+
+### 1. Stable service names
+
+CE service names listed in `STABLE_SERVICE_NAMES` are part of the public API. EE overrides MAY modify env / image / depends_on / volumes for these services but MUST NOT rename or remove them. Adding new services (CE or EE) is allowed.
+
+```python
+STABLE_SERVICE_NAMES = {
+    # Core application
+    "php", "nginx", "node", "postgres", "redis",
+    "python-ai", "solr", "horizon",
+    "fhir-to-cdm", "study-agent", "hecate",
+    # Acropolis CE
+    "traefik", "portainer", "pgadmin",
+}
+```
+
+### 2. Stable container names
+
+Container names follow `parthenon-<service>` (core) or `acropolis-<service>` (Acropolis overlay). EE overrides MUST NOT change these — operator scripts (`scripts/health-watchdog.sh`, the day-2 `acropolis.sh` helper, Grafana log queries) reference both forms.
+
+A small `LEGACY_CONTAINER_NAMES` allowlist captures the pre-existing baseline (e.g. `python-ai` is named `python-ai` not `parthenon-python-ai` — renaming would break Grafana dashboards, nginx upstream resolution, and operator scripts). New services MUST follow the prefix convention.
+
+### 3. Named volume namespacing
+
+CE uses unprefixed names (`parthenon-storage`, `pg-data`). EE-introduced volumes MUST be prefixed `parthenon-ee-...` to avoid collisions when both edition stacks exist on the same Docker host.
+
+### 4. Network naming
+
+CE uses `parthenon`, `acumenus`, `acropolis`, `acropolis-backend`, `backend`, `jupyter_users` networks. EE may attach to these but MUST NOT redefine them with conflicting `driver_opts` or `ipam`. EE-introduced networks MUST be prefixed `parthenon-ee-`.
+
+### 5. Environment variable interpolation only
+
+All variability is expressed via `${VAR:-default}`. No conditional service definitions (Compose doesn't support `if`). EE flips behavior by setting env vars (e.g. `AUTH_DRIVER=keycloak`, `CRYPTO_PROVIDER=...`) and by appending overlay services — never by patching CE-file YAML.
+
+### 6. Image tag convention
+
+| Layer | Registry namespace |
+|---|---|
+| CE | `ghcr.io/acumenus-data-sciences/parthenon-<service>:${PARTHENON_IMAGE_TAG:-latest}` |
+| EE | `ghcr.io/acumenus-data-sciences/parthenon-ee-<service>:${PARTHENON_EE_IMAGE_TAG:-latest}` |
+
+Both registries can coexist. Anything pushed to ghcr.io under a different organization is a contract violation in a CE compose file.
+
+### 7. Port allocation
+
+CE owns `8080-8099` (exposed) and `5500-5599` (dev). EE-introduced services MUST request host ports `>= 8100` to avoid conflicts when both editions run on the same Docker host.
+
+### 8. Healthcheck stability
+
+Every CE service has a `healthcheck:` block. EE overrides MUST NOT replace these with weaker or faster ones. EE may add ADDITIONAL `depends_on: { condition: service_healthy }` constraints but MUST NOT relax existing ones. The verifier rejects EE healthchecks whose `test` is a no-op (`["CMD-SHELL", "true"]`).
+
+### 9. Profile usage
+
+Compose profiles (`profiles: [...]`) are reserved for **opt-in CE features** (e.g. `profiles: [tour]`). EE does NOT use profiles to gate enterprise services — those gate via overlay file selection at compose-up time. The rule is simple: "if it's loaded, it runs."
+
+### 10. `extra_hosts` is additive (R8)
+
+EE overrides MAY add entries to a stable service's `extra_hosts:` block (e.g. `host.docker.internal:host-gateway` for IdP federation testing on developer hosts, or pinning an internal hostname to a specific IP). EE MUST NOT remove or override CE-added `extra_hosts` entries. When both files declare `extra_hosts:` for the same service, they MUST merge — never replace.
+
+## What an EE override is allowed to do
+
+For any `STABLE_SERVICE_NAMES` entry, EE may set:
+
+- `environment:` — additive merge with CE
+- `volumes:` — additive
+- `depends_on:` — additive, MUST NOT weaken
+- `image:` — only if EE is shipping a different image (e.g. FIPS-built PHP). The image MUST satisfy the same healthcheck.
+- `command:` — only if the new command preserves the documented behavior of the service.
+- `extra_hosts:` — additive (R8)
+
+For any `STABLE_SERVICE_NAMES` entry, EE MUST NOT:
+
+- Remove the service via `services: { <name>: !reset }`
+- Rename the container (`container_name:`)
+- Replace the network membership (`networks:`) — adding additional networks is OK
+- Replace the healthcheck with a passing-by-default no-op
+- Change the exposed host port (`ports:`) — adding additional internal ports is OK
+
+## Examples
+
+### Valid EE overlay (Keycloak side-car)
+
+```yaml
+# enterprise/docker-compose.ee.yml
+services:
+  keycloak:
+    container_name: parthenon-ee-keycloak
+    image: ghcr.io/acumenus-data-sciences/parthenon-ee-keycloak:latest
+    ports:
+      - "8181:8080"           # >= EE_PORT_FLOOR (8100)
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health/ready"]
+      interval: 30s
+    networks:
+      - parthenon-ee-keycloak
+      - acumenus              # join CE network
+    volumes:
+      - parthenon-ee-keycloak-data:/opt/keycloak/data
+
+  php:                        # extending a stable service is allowed
+    environment:
+      AUTH_DRIVER: keycloak
+      KEYCLOAK_REALM_URL: http://keycloak:8080/realms/parthenon
+    extra_hosts:              # R8: additive merge with CE
+      - "keycloak.local:host-gateway"
+
+volumes:
+  parthenon-ee-keycloak-data:
+
+networks:
+  parthenon-ee-keycloak:
+```
+
+### Invalid EE overlay (renames a stable container)
+
+```yaml
+# ❌ FAILS rule 2: stable container_name override
+services:
+  php:
+    container_name: parthenon-ee-php-fips
+```
+
+### Invalid EE overlay (low port collision)
+
+```yaml
+# ❌ FAILS rule 7: host port < 8100
+services:
+  keycloak:
+    ports:
+      - "8081:8080"
+```
+
+### Invalid EE overlay (weak healthcheck)
+
+```yaml
+# ❌ FAILS rule 8: passing-by-default healthcheck
+services:
+  php:
+    healthcheck:
+      test: ["CMD-SHELL", "true"]
+```
+
+### Invalid EE overlay (unprefixed volume)
+
+```yaml
+# ❌ FAILS rule 3: EE volume must be parthenon-ee-* prefixed
+volumes:
+  keycloak-data:
+```
+
+## Running the verifier
+
+Locally:
+
+```bash
+# Verify CE only (no EE checkout required)
+python3 scripts/verify_compose_contract.py
+
+# Verify an EE overlay file
+python3 scripts/verify_compose_contract.py --check-ee /path/to/Parthenon-EE/enterprise/docker-compose.ee.yml
+
+# Run the verifier's own unit tests
+pytest scripts/verify_compose_contract_test.py -q
+```
+
+CI (`.github/workflows/compose-contract.yml`):
+
+- Runs on every PR that touches a compose file or the verifier itself.
+- Runs on every push to `main`.
+- Uses Python 3.12, installs `pyyaml` + `pytest`, executes both the live-repo check and the unit tests.
+
+## Out of scope
+
+- **Authoring** `enterprise/docker-compose.ee.yml` — Plan 04 (EE first-pass migration).
+- Cross-edition smoke tests where both stacks run side-by-side on one host — separate plan.
+- Compose v2 → v3 migration — orthogonal upgrade.
+- Kubernetes Helm chart equivalents — already tracked in the Acropolis enterprise overlay (`acropolis/k8s/`).
+
+## Anti-patterns
+
+- ❌ Don't reach into CE compose files from EE via inline YAML patches. Use overlay files only.
+- ❌ Don't use Compose profiles to gate EE services — load them via overlay file selection at `docker compose up` time.
+- ❌ Don't bind EE host ports below `8100` — that range is CE territory and would collide.
+- ❌ Don't introduce volumes/networks without the `parthenon-ee-` prefix from EE.
+- ❌ Don't weaken stability annotations on stable services (renaming, removing, weakening healthchecks). Operator scripts and dashboards depend on them.

--- a/scripts/verify_compose_contract.py
+++ b/scripts/verify_compose_contract.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Statically verify CE compose files against the composition contract.
+
+Plan 02-08 — Compose Composition Contract.
+
+The verifier enforces the rules documented in
+``docs/architecture/extension-points/compose-composition.md``. It is the
+machine-checkable counterpart to that doc and runs in CI on every PR that
+touches a compose file.
+
+Usage::
+
+    python3 scripts/verify_compose_contract.py
+    python3 scripts/verify_compose_contract.py --check-ee /path/to/parthenon-ee/enterprise/docker-compose.ee.yml
+
+Exit codes:
+    0 — contract satisfied
+    1 — contract violation
+    2 — unable to parse a compose file
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+# ── Contract constants ──────────────────────────────────────────────────────
+
+#: CE compose files the verifier walks. EE overlays are checked separately
+#: via ``--check-ee`` (this script does not assume Parthenon-EE is on disk).
+CE_COMPOSE_FILES: list[str] = [
+    "docker-compose.yml",
+    "docker-compose.community.yml",
+    "acropolis/docker-compose.base.yml",
+    "acropolis/docker-compose.community.yml",
+]
+
+#: Service names that form the public CE API. Renaming or removing any of
+#: these is a BREAKING change. Adding new services is fine. EE overlays may
+#: extend these (env, volumes, depends_on) but MUST NOT rename or replace.
+#:
+#: This list captures the BASELINE — services already present and load-bearing
+#: in the deployed CE stack. New CE services do not have to be added here;
+#: only services we explicitly want to mark as "operators rely on this name
+#: in scripts" need stable-name protection.
+STABLE_SERVICE_NAMES: set[str] = {
+    # Core application
+    "php", "nginx", "node", "postgres", "redis",
+    "python-ai", "solr", "horizon",
+    "fhir-to-cdm", "study-agent", "hecate",
+    # Acropolis CE (only required when Acropolis is loaded)
+    "traefik", "portainer", "pgadmin",
+}
+
+#: Services that live in Acropolis overlay files only. The verifier never
+#: fails when these are missing from the *core* compose files — it only
+#: fails when an Acropolis file declares them with the wrong name shape.
+ACROPOLIS_ONLY_SERVICES: set[str] = {"traefik", "portainer", "pgadmin", "authentik"}
+
+#: Container names follow ``parthenon-<service>`` (core stack) or
+#: ``acropolis-<service>`` (Acropolis overlay services). Both prefixes are
+#: documented public API; downstream operator scripts (acropolis.sh, the
+#: install state machine) reference both forms.
+CONTAINER_NAME_RE: re.Pattern[str] = re.compile(
+    r"^(parthenon|acropolis)-[a-z0-9][a-z0-9-]*$"
+)
+
+#: Per-service allowlist for container names that pre-date the
+#: ``parthenon-<service>`` convention. These names are baked into Grafana
+#: dashboards, nginx upstream resolution, and operator scripts; renaming
+#: them would be a breaking production change. New services MUST follow
+#: the prefix convention; this map captures the baseline.
+LEGACY_CONTAINER_NAMES: dict[str, set[str]] = {
+    "python-ai": {"python-ai"},
+}
+
+#: Acceptable CE network names. EE-introduced networks are required to be
+#: ``parthenon-ee-`` prefixed and are allowed automatically through the
+#: prefix check below.
+NETWORK_NAMES_CE_OK: set[str] = {
+    "parthenon", "acumenus", "default",
+    "acropolis", "acropolis-backend",
+    "backend", "jupyter_users",
+}
+
+#: EE port floor — host ports below this number are CE territory.
+EE_PORT_FLOOR: int = 8100
+
+#: CE registry namespace prefix on ghcr.io. Anything pushed to ghcr.io
+#: under a different organization is a contract violation in a CE compose
+#: file.
+CE_GHCR_PREFIX: str = "ghcr.io/acumenus-data-sciences/parthenon-"
+
+#: EE registry namespace prefix on ghcr.io. EE images live in their own
+#: ``parthenon-ee-<service>`` repository to keep the CE/EE boundary
+#: visible at the registry layer too.
+EE_GHCR_PREFIX: str = "ghcr.io/acumenus-data-sciences/parthenon-ee-"
+
+
+# ── YAML helpers ────────────────────────────────────────────────────────────
+
+def _load(path: Path) -> dict[str, Any]:
+    try:
+        loaded = yaml.safe_load(path.read_text())
+    except Exception as exc:  # noqa: BLE001 — report the path
+        print(f"FAIL parse {path}: {exc}")
+        sys.exit(2)
+    return loaded or {}
+
+
+def _services(doc: dict[str, Any]) -> dict[str, Any]:
+    services = doc.get("services") or {}
+    return services if isinstance(services, dict) else {}
+
+
+def _is_ghcr_image(image: str) -> bool:
+    return isinstance(image, str) and image.startswith("ghcr.io/")
+
+
+# ── CE verifiers ────────────────────────────────────────────────────────────
+
+def verify_ce_files(repo_root: Path) -> list[str]:
+    """Walk every CE compose file and check container names + image namespace."""
+    errors: list[str] = []
+    for rel in CE_COMPOSE_FILES:
+        path = repo_root / rel
+        if not path.exists():
+            continue
+        doc = _load(path)
+        for name, spec in _services(doc).items():
+            if not isinstance(spec, dict):
+                continue
+            container = spec.get("container_name")
+            if container:
+                container_str = str(container)
+                allowed_legacy = LEGACY_CONTAINER_NAMES.get(name, set())
+                if (
+                    not CONTAINER_NAME_RE.match(container_str)
+                    and container_str not in allowed_legacy
+                ):
+                    expected = "'parthenon-<service>' or 'acropolis-<service>'"
+                    if allowed_legacy:
+                        expected += f" or one of {sorted(allowed_legacy)}"
+                    errors.append(
+                        f"{rel}: service {name} has non-standard container_name "
+                        f"'{container_str}'; expected {expected}"
+                    )
+            image = spec.get("image", "")
+            if _is_ghcr_image(image) and not str(image).startswith(CE_GHCR_PREFIX):
+                errors.append(
+                    f"{rel}: service {name} image '{image}' is on ghcr.io "
+                    f"but not in acumenus-data-sciences/parthenon-* namespace"
+                )
+        for vol in (doc.get("volumes") or {}).keys():
+            if str(vol).startswith("parthenon-ee-"):
+                errors.append(
+                    f"{rel}: CE compose file declares EE-prefixed volume '{vol}'"
+                )
+        for net in (doc.get("networks") or {}).keys():
+            net_str = str(net)
+            if net_str in NETWORK_NAMES_CE_OK:
+                continue
+            if net_str.startswith("parthenon-"):
+                continue
+            errors.append(
+                f"{rel}: unexpected CE network '{net_str}' "
+                f"(allowed: {sorted(NETWORK_NAMES_CE_OK)} or parthenon-*)"
+            )
+    return errors
+
+
+def verify_ce_stable_services_present(repo_root: Path) -> list[str]:
+    """Every non-Acropolis stable service must be defined somewhere in CE."""
+    declared: set[str] = set()
+    for rel in CE_COMPOSE_FILES:
+        path = repo_root / rel
+        if path.exists():
+            declared |= set(_services(_load(path)).keys())
+    required = STABLE_SERVICE_NAMES - ACROPOLIS_ONLY_SERVICES
+    missing = sorted(required - declared)
+    return [f"missing required stable service: {svc}" for svc in missing]
+
+
+# ── EE verifier ─────────────────────────────────────────────────────────────
+
+def verify_ee_overlay(ee_path: Path) -> list[str]:
+    """Apply the EE-overlay rules to a single Parthenon-EE compose file."""
+    if not ee_path.exists():
+        return [f"EE overlay path does not exist: {ee_path}"]
+    doc = _load(ee_path)
+    errors: list[str] = []
+
+    for name, spec in _services(doc).items():
+        spec = spec or {}
+        if name in STABLE_SERVICE_NAMES:
+            if "container_name" in spec:
+                errors.append(
+                    f"{ee_path}: EE overlay sets container_name on stable "
+                    f"service '{name}' — forbidden"
+                )
+            healthcheck = spec.get("healthcheck") or {}
+            test = healthcheck.get("test")
+            if isinstance(test, list) and any(
+                isinstance(t, str) and t.lower().strip() in {"true", "/bin/true"}
+                for t in test
+            ):
+                errors.append(
+                    f"{ee_path}: EE overlay weakens healthcheck on stable "
+                    f"service '{name}' (no-op test)"
+                )
+        for port_spec in spec.get("ports") or []:
+            host = str(port_spec).split(":")[0]
+            if host.isdigit() and int(host) < EE_PORT_FLOOR:
+                errors.append(
+                    f"{ee_path}: EE service '{name}' binds host port {host} "
+                    f"(< {EE_PORT_FLOOR})"
+                )
+        image = spec.get("image", "")
+        if _is_ghcr_image(image):
+            image_str = str(image)
+            if not (
+                image_str.startswith(EE_GHCR_PREFIX)
+                or image_str.startswith(CE_GHCR_PREFIX)
+            ):
+                errors.append(
+                    f"{ee_path}: EE service '{name}' image '{image}' not in "
+                    f"expected namespace ({EE_GHCR_PREFIX}* or {CE_GHCR_PREFIX}*)"
+                )
+
+    for vol in (doc.get("volumes") or {}).keys():
+        if not str(vol).startswith("parthenon-ee-"):
+            errors.append(
+                f"{ee_path}: EE volume '{vol}' is not parthenon-ee-* prefixed"
+            )
+
+    for net in (doc.get("networks") or {}).keys():
+        net_str = str(net)
+        if net_str in NETWORK_NAMES_CE_OK:
+            continue
+        if not net_str.startswith("parthenon-ee-"):
+            errors.append(
+                f"{ee_path}: EE network '{net_str}' is not parthenon-ee-* prefixed"
+            )
+
+    return errors
+
+
+# ── Entry point ─────────────────────────────────────────────────────────────
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", type=Path)
+    parser.add_argument("--check-ee", default=None, type=Path)
+    parser.add_argument(
+        "--ce-only",
+        action="store_true",
+        help="Skip CE-side checks (used in tests for the EE overlay path)",
+    )
+    args = parser.parse_args(argv)
+
+    errors: list[str] = []
+    if not args.ce_only:
+        errors += verify_ce_files(args.repo_root)
+        errors += verify_ce_stable_services_present(args.repo_root)
+    if args.check_ee is not None:
+        errors += verify_ee_overlay(args.check_ee)
+
+    if errors:
+        print("Compose composition contract violations:")
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+
+    print("OK: compose composition contract satisfied.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_compose_contract_test.py
+++ b/scripts/verify_compose_contract_test.py
@@ -1,0 +1,335 @@
+"""Tests for ``scripts/verify_compose_contract.py`` (Plan 02-08)."""
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+
+
+VERIFIER = Path(__file__).parent / "verify_compose_contract.py"
+
+
+def _write(directory: Path, name: str, body: str) -> None:
+    (directory / name).write_text(textwrap.dedent(body).lstrip())
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["python3", str(VERIFIER), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+# ── CE-side checks ──────────────────────────────────────────────────────────
+
+def _seed_minimal_ce_root(root: Path) -> None:
+    """Lay down a minimal CE compose tree the verifier accepts."""
+    (root / "acropolis").mkdir()
+    _write(
+        root,
+        "docker-compose.yml",
+        """
+        services:
+          php:
+            container_name: parthenon-php
+            image: ghcr.io/acumenus-data-sciences/parthenon-php:latest
+          nginx:
+            container_name: parthenon-nginx
+            image: nginx:1.27-alpine
+          node:
+            container_name: parthenon-node
+            image: ghcr.io/acumenus-data-sciences/parthenon-node:latest
+          postgres:
+            container_name: parthenon-postgres
+            image: pgvector/pgvector:pg16
+          redis:
+            container_name: parthenon-redis
+            image: redis:7-alpine
+          python-ai:
+            container_name: python-ai
+            image: ghcr.io/acumenus-data-sciences/parthenon-python-ai:latest
+          solr:
+            container_name: parthenon-solr
+            image: solr:9.7
+          horizon:
+            container_name: parthenon-horizon
+            image: ghcr.io/acumenus-data-sciences/parthenon-php:latest
+          fhir-to-cdm:
+            container_name: parthenon-fhir-to-cdm
+            image: ghcr.io/acumenus-data-sciences/parthenon-fhir-to-cdm:latest
+          study-agent:
+            container_name: parthenon-study-agent
+            image: ghcr.io/acumenus-data-sciences/parthenon-study-agent:latest
+          hecate:
+            container_name: parthenon-hecate
+            image: ghcr.io/acumenus-data-sciences/parthenon-hecate:latest
+        volumes:
+          parthenon-storage:
+        """,
+    )
+    _write(
+        root / "acropolis",
+        "docker-compose.base.yml",
+        """
+        services:
+          traefik:
+            container_name: acropolis-traefik
+            image: traefik:v3.1
+        volumes: {}
+        """,
+    )
+    _write(
+        root / "acropolis",
+        "docker-compose.community.yml",
+        """
+        services:
+          portainer:
+            container_name: acropolis-portainer
+            image: portainer/portainer-ce:2.21.4
+          pgadmin:
+            container_name: acropolis-pgadmin
+            image: dpage/pgadmin4:8.12
+        volumes: {}
+        """,
+    )
+
+
+def test_ce_passes_on_minimal_valid_repo() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _seed_minimal_ce_root(root)
+        result = _run("--repo-root", str(root))
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_ce_fails_when_image_outside_namespace() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _seed_minimal_ce_root(root)
+        # Overwrite php with an out-of-namespace ghcr image.
+        _write(
+            root,
+            "docker-compose.yml",
+            """
+            services:
+              php:
+                container_name: parthenon-php
+                image: ghcr.io/some-other-org/something:latest
+            """,
+        )
+        result = _run("--repo-root", str(root))
+        assert result.returncode == 1
+        assert "not in acumenus-data-sciences/parthenon-* namespace" in result.stdout
+
+
+def test_ce_fails_when_required_stable_service_is_missing() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "acropolis").mkdir()
+        # Only define php, leave others missing.
+        _write(
+            root,
+            "docker-compose.yml",
+            """
+            services:
+              php:
+                container_name: parthenon-php
+                image: ghcr.io/acumenus-data-sciences/parthenon-php:latest
+            """,
+        )
+        _write(root / "acropolis", "docker-compose.base.yml", "services: {}\n")
+        result = _run("--repo-root", str(root))
+        assert result.returncode == 1
+        assert "missing required stable service" in result.stdout
+
+
+def test_ce_fails_when_container_name_does_not_match_convention() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _seed_minimal_ce_root(root)
+        _write(
+            root,
+            "docker-compose.yml",
+            """
+            services:
+              php:
+                container_name: my-weird-php
+                image: ghcr.io/acumenus-data-sciences/parthenon-php:latest
+            """,
+        )
+        result = _run("--repo-root", str(root))
+        assert result.returncode == 1
+        assert "non-standard container_name" in result.stdout
+
+
+def test_ce_fails_when_volume_uses_ee_prefix() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _seed_minimal_ce_root(root)
+        _write(
+            root,
+            "docker-compose.yml",
+            """
+            services: {}
+            volumes:
+              parthenon-ee-leak:
+            """,
+        )
+        result = _run("--repo-root", str(root))
+        assert result.returncode == 1
+        assert "EE-prefixed volume" in result.stdout
+
+
+# ── EE overlay checks ───────────────────────────────────────────────────────
+
+def test_ee_passes_on_valid_overlay() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ee = Path(tmp) / "ee.yml"
+        _write(
+            Path(tmp),
+            "ee.yml",
+            """
+            services:
+              keycloak:
+                container_name: parthenon-ee-keycloak
+                image: ghcr.io/acumenus-data-sciences/parthenon-ee-keycloak:latest
+                ports:
+                  - "8181:8080"
+            volumes:
+              parthenon-ee-keycloak-data:
+            networks:
+              parthenon-ee-keycloak: {}
+            """,
+        )
+        result = _run("--check-ee", str(ee), "--ce-only")
+        # --ce-only means "skip CE checks"; the valid overlay alone should
+        # produce zero violations.
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_ee_fails_when_low_port_collides_with_ce() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ee = Path(tmp) / "ee.yml"
+        _write(
+            Path(tmp),
+            "ee.yml",
+            """
+            services:
+              keycloak:
+                ports:
+                  - "8081:8080"
+                image: ghcr.io/acumenus-data-sciences/parthenon-ee-keycloak:latest
+            volumes:
+              parthenon-ee-keycloak-data: {}
+            """,
+        )
+        result = _run("--check-ee", str(ee), "--ce-only")
+        assert result.returncode == 1
+        assert "binds host port" in result.stdout
+
+
+def test_ee_fails_when_overriding_container_name_of_stable_service() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ee = Path(tmp) / "ee.yml"
+        _write(
+            Path(tmp),
+            "ee.yml",
+            """
+            services:
+              php:
+                container_name: parthenon-ee-php-fips
+            volumes:
+              parthenon-ee-data: {}
+            """,
+        )
+        result = _run("--check-ee", str(ee), "--ce-only")
+        assert result.returncode == 1
+        assert "container_name on stable service" in result.stdout
+
+
+def test_ee_fails_when_volume_not_prefixed() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ee = Path(tmp) / "ee.yml"
+        _write(
+            Path(tmp),
+            "ee.yml",
+            """
+            services: {}
+            volumes:
+              keycloak-data: {}
+            """,
+        )
+        result = _run("--check-ee", str(ee), "--ce-only")
+        assert result.returncode == 1
+        assert "not parthenon-ee-* prefixed" in result.stdout
+
+
+def test_ee_fails_when_network_not_prefixed() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ee = Path(tmp) / "ee.yml"
+        _write(
+            Path(tmp),
+            "ee.yml",
+            """
+            services: {}
+            volumes:
+              parthenon-ee-data: {}
+            networks:
+              keycloak-net: {}
+            """,
+        )
+        result = _run("--check-ee", str(ee), "--ce-only")
+        assert result.returncode == 1
+        assert "not parthenon-ee-* prefixed" in result.stdout
+
+
+def test_ee_fails_when_image_outside_ee_namespace() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ee = Path(tmp) / "ee.yml"
+        _write(
+            Path(tmp),
+            "ee.yml",
+            """
+            services:
+              proprietary:
+                image: ghcr.io/some-vendor/secret:1.0
+                ports:
+                  - "9100:9100"
+            volumes:
+              parthenon-ee-data: {}
+            """,
+        )
+        result = _run("--check-ee", str(ee), "--ce-only")
+        assert result.returncode == 1
+        assert "not in expected namespace" in result.stdout
+
+
+def test_ee_fails_when_healthcheck_is_no_op() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ee = Path(tmp) / "ee.yml"
+        _write(
+            Path(tmp),
+            "ee.yml",
+            """
+            services:
+              php:
+                healthcheck:
+                  test: ["CMD-SHELL", "true"]
+            volumes:
+              parthenon-ee-data: {}
+            """,
+        )
+        result = _run("--check-ee", str(ee), "--ce-only")
+        assert result.returncode == 1
+        assert "weakens healthcheck" in result.stdout
+
+
+# ── Live repo smoke ─────────────────────────────────────────────────────────
+
+def test_actual_repo_compose_satisfies_contract() -> None:
+    """The repo's own compose files must satisfy the contract on every PR."""
+    repo_root = Path(__file__).resolve().parent.parent
+    result = _run("--repo-root", str(repo_root))
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary

Adds the eighth and final CE/EE extension-point seam — a documented + machine-verified contract for how Parthenon's Docker Compose stack is layered, so EE's `docker-compose.ee.yml` (in the private Parthenon-EE repo) can extend the public CE compose stack via well-defined override conventions without patching CE compose YAML.

This is a **mostly-documentation plan** — NO production behavior changes in CE. The deliverables are the contract rules, a Python verifier that statically enforces them, and a CI workflow that runs the verifier on every PR touching compose files.

This is Plan 02-08 from the [Phase 2 umbrella](docs/superpowers/plans/2026-05-08-ce-ee-fork-plan-02-extension-points-umbrella.md) — the last Phase 2 plan. Independent of all other Phase 2 plans.

## What landed

- **`scripts/verify_compose_contract.py`** — argparse CLI (`--repo-root`, `--check-ee <path>`, `--ce-only`), exit 0/1/2 codes. Encodes:
  - `STABLE_SERVICE_NAMES` — 15 services that form the public CE API
  - `CONTAINER_NAME_RE` accepting `parthenon-<svc>` or `acropolis-<svc>`
  - `LEGACY_CONTAINER_NAMES` allowlist (`python-ai` is legacy bare name; renaming would break Grafana / nginx / scripts)
  - `NETWORK_NAMES_CE_OK` + `parthenon-ee-*` prefix rule
  - `EE_PORT_FLOOR = 8100`; CE owns `8080-8099` (exposed) + `5500-5599` (dev)
  - Image registry namespace rules (CE `parthenon-*` vs EE `parthenon-ee-*` on ghcr.io)
- **`scripts/verify_compose_contract_test.py`** — 13 pytest cases.
- **`.github/workflows/compose-contract.yml`** — Python 3.12 + pyyaml + pytest, triggers on PRs that touch compose files or the verifier.
- **`docker-compose.yml` + `docker-compose.community.yml`** — header annotations pointing operators at the contract doc + verifier.
- **[`docs/architecture/extension-points/compose-composition.md`](docs/architecture/extension-points/compose-composition.md)** — full doc with the 10 contract rules, valid + invalid EE overlay examples (Keycloak side-car, low port collision, container rename, no-op healthcheck), rationale for each rule, anti-patterns.

## The 10 contract rules

1. Stable service names — `STABLE_SERVICE_NAMES` is public API
2. Stable container names — `parthenon-<svc>` / `acropolis-<svc>` / legacy allowlist
3. Named volume namespacing — `parthenon-ee-*` prefix for EE
4. Network naming — CE allowlist + `parthenon-ee-*` for EE
5. `${VAR:-default}` interpolation only — no conditional services
6. Image registry namespace — `parthenon-*` CE / `parthenon-ee-*` EE
7. Port allocation — `8080-8099` CE; `>= 8100` EE
8. Healthcheck stability — EE may not weaken or no-op CE healthchecks
9. Profiles reserved for opt-in CE features — EE uses overlay files
10. R8: `extra_hosts` is additive — never override CE entries

## Test plan

- [x] **Verifier green on actual repo** — `python3 scripts/verify_compose_contract.py` returns 0 against the live Parthenon compose tree
- [x] **13 pytest cases pass** — CE valid baseline; CE fails on image-outside-namespace / required-service-missing / bad container_name / EE-prefixed-volume; EE valid overlay; EE fails on low-port / container_name-override / unprefixed-volume / unprefixed-network / image-outside-namespace / no-op-healthcheck; live-repo smoke
- [x] No production behavior changes — only YAML header annotations + new files

## Pluggability proof

The verifier validates that an EE overlay (synthesized in tests as a realistic Keycloak side-car with `parthenon-ee-keycloak-data` volume, `parthenon-ee-keycloak` network, port `8181`, EE-namespace image) passes all 10 rules without modifying any CE compose file. Plan 04 (EE first-pass migration) will author the real `enterprise/docker-compose.ee.yml` in the Parthenon-EE repo against this contract.

## Refs

- Spec: [`docs/superpowers/specs/2026-05-08-ce-ee-fork-and-agplv3-relicense-design.md`](docs/superpowers/specs/2026-05-08-ce-ee-fork-and-agplv3-relicense-design.md) §5 row 8
- Plan: [`docs/superpowers/plans/2026-05-09-ce-ee-fork-plan-02-08-compose-composition-contract.md`](docs/superpowers/plans/2026-05-09-ce-ee-fork-plan-02-08-compose-composition-contract.md)
- Cross-Plan Revision R8 — `extra_hosts` additive merge.