### PR TITLE
feat: support extra Laravel providers

### DIFF
--- a/backend/bootstrap/provider-extensions.php
+++ b/backend/bootstrap/provider-extensions.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\ServiceProvider;
+
+if (! function_exists('parthenon_bootstrap_env')) {
+    function parthenon_bootstrap_env(string $key, string $default = ''): string
+    {
+        if (array_key_exists($key, $_ENV) && is_scalar($_ENV[$key])) {
+            return (string) $_ENV[$key];
+        }
+        if (array_key_exists($key, $_SERVER) && is_scalar($_SERVER[$key])) {
+            return (string) $_SERVER[$key];
+        }
+
+        $value = getenv($key);
+
+        return $value === false ? $default : (string) $value;
+    }
+}
+
+if (! function_exists('parthenon_bootstrap_list')) {
+    /**
+     * @return list<string>
+     */
+    function parthenon_bootstrap_list(string $value): array
+    {
+        if (trim($value) === '') {
+            return [];
+        }
+
+        $items = preg_split('/[,;\r\n]+/', $value) ?: [];
+        $normalized = [];
+        foreach ($items as $item) {
+            $item = trim($item);
+            if ($item === '') {
+                continue;
+            }
+            $normalized[$item] = $item;
+        }
+
+        return array_values($normalized);
+    }
+}
+
+if (! function_exists('parthenon_bootstrap_path')) {
+    function parthenon_bootstrap_path(string $path, string $basePath): string
+    {
+        if ($path === '') {
+            throw new InvalidArgumentException('Bootstrap file path cannot be empty.');
+        }
+        if (str_starts_with($path, '/') || preg_match('/^[A-Za-z]:[\\\\\/]/', $path) === 1) {
+            return $path;
+        }
+
+        return rtrim($basePath, '/').'/'.$path;
+    }
+}
+
+if (! function_exists('parthenon_load_extra_bootstrap_files')) {
+    function parthenon_load_extra_bootstrap_files(string $basePath): void
+    {
+        foreach (parthenon_bootstrap_list(parthenon_bootstrap_env('PARTHENON_EXTRA_BOOTSTRAP_FILES')) as $path) {
+            $resolved = parthenon_bootstrap_path($path, $basePath);
+            if (! is_file($resolved) || ! is_readable($resolved)) {
+                throw new RuntimeException("Parthenon extra bootstrap file is not readable: {$resolved}");
+            }
+
+            require_once $resolved;
+        }
+    }
+}
+
+if (! function_exists('parthenon_extra_provider_classes')) {
+    /**
+     * @return list<class-string<ServiceProvider>>
+     */
+    function parthenon_extra_provider_classes(): array
+    {
+        $providers = [];
+        foreach (parthenon_bootstrap_list(parthenon_bootstrap_env('PARTHENON_EXTRA_PROVIDERS')) as $class) {
+            if (preg_match('/^(?:[A-Za-z_][A-Za-z0-9_]*\\\\)*[A-Za-z_][A-Za-z0-9_]*$/', $class) !== 1) {
+                throw new InvalidArgumentException("Invalid Parthenon extra provider class name: {$class}");
+            }
+            if (! class_exists($class)) {
+                throw new RuntimeException("Parthenon extra provider class is not autoloadable: {$class}");
+            }
+            if (! is_subclass_of($class, ServiceProvider::class)) {
+                throw new RuntimeException('Parthenon extra provider must extend '.ServiceProvider::class.": {$class}");
+            }
+
+            $providers[] = $class;
+        }
+
+        return $providers;
+    }
+}

--- a/backend/bootstrap/providers.php
+++ b/backend/bootstrap/providers.php
@@ -16,6 +16,10 @@ use App\Providers\SolrServiceProvider;
 use App\Providers\TemplatesServiceProvider;
 use App\Providers\TenancyServiceProvider;
 
+require_once __DIR__.'/provider-extensions.php';
+
+parthenon_load_extra_bootstrap_files(dirname(__DIR__));
+
 return [
     AppServiceProvider::class,
     CryptoProviderServiceProvider::class,
@@ -32,4 +36,5 @@ return [
     PopulationCharacterizationServiceProvider::class,
     SolrServiceProvider::class,
     TemplatesServiceProvider::class,
+    ...parthenon_extra_provider_classes(),
 ];

--- a/backend/tests/Fixtures/ExtraProviderStub.php
+++ b/backend/tests/Fixtures/ExtraProviderStub.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+use Illuminate\Support\ServiceProvider;
+
+class ExtraProviderStub extends ServiceProvider {}

--- a/backend/tests/Fixtures/NotAServiceProviderStub.php
+++ b/backend/tests/Fixtures/NotAServiceProviderStub.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures;
+
+class NotAServiceProviderStub {}

--- a/backend/tests/Unit/Services/BootstrapProviderExtensionsTest.php
+++ b/backend/tests/Unit/Services/BootstrapProviderExtensionsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\Fixtures\ExtraProviderStub;
+use Tests\Fixtures\NotAServiceProviderStub;
+
+require_once dirname(__DIR__, 3).'/bootstrap/provider-extensions.php';
+
+beforeEach(function (): void {
+    clearParthenonExtraProviderEnv();
+});
+
+afterEach(function (): void {
+    clearParthenonExtraProviderEnv();
+});
+
+function clearParthenonExtraProviderEnv(): void
+{
+    foreach (['PARTHENON_EXTRA_BOOTSTRAP_FILES', 'PARTHENON_EXTRA_PROVIDERS'] as $key) {
+        unset($_ENV[$key], $_SERVER[$key]);
+        putenv($key);
+    }
+}
+
+it('returns no extra providers when no environment is configured', function (): void {
+    expect(parthenon_extra_provider_classes())->toBe([]);
+});
+
+it('parses and de-duplicates configured provider classes', function (): void {
+    $_ENV['PARTHENON_EXTRA_PROVIDERS'] = implode(',', [
+        ExtraProviderStub::class,
+        ExtraProviderStub::class,
+    ]);
+
+    expect(parthenon_extra_provider_classes())->toBe([ExtraProviderStub::class]);
+});
+
+it('loads extra bootstrap files before resolving providers', function (): void {
+    $file = tempnam(sys_get_temp_dir(), 'parthenon-extra-bootstrap-');
+    file_put_contents($file, '<?php $GLOBALS["parthenon_extra_bootstrap_loaded"] = true;');
+
+    $_ENV['PARTHENON_EXTRA_BOOTSTRAP_FILES'] = $file;
+    $GLOBALS['parthenon_extra_bootstrap_loaded'] = false;
+
+    parthenon_load_extra_bootstrap_files(dirname(__DIR__, 3));
+
+    expect($GLOBALS['parthenon_extra_bootstrap_loaded'])->toBeTrue();
+
+    unlink($file);
+});
+
+it('fails clearly for unreadable extra bootstrap files', function (): void {
+    $_ENV['PARTHENON_EXTRA_BOOTSTRAP_FILES'] = '/tmp/parthenon-missing-bootstrap.php';
+
+    parthenon_load_extra_bootstrap_files(dirname(__DIR__, 3));
+})->throws(RuntimeException::class, 'Parthenon extra bootstrap file is not readable');
+
+it('fails clearly for malformed provider class names', function (): void {
+    $_ENV['PARTHENON_EXTRA_PROVIDERS'] = 'not a class';
+
+    parthenon_extra_provider_classes();
+})->throws(InvalidArgumentException::class, 'Invalid Parthenon extra provider class name');
+
+it('fails clearly when a provider class cannot be autoloaded', function (): void {
+    $_ENV['PARTHENON_EXTRA_PROVIDERS'] = 'Acumenus\\Missing\\Provider';
+
+    parthenon_extra_provider_classes();
+})->throws(RuntimeException::class, 'Parthenon extra provider class is not autoloadable');
+
+it('requires configured providers to extend Laravel ServiceProvider', function (): void {
+    $_ENV['PARTHENON_EXTRA_PROVIDERS'] = NotAServiceProviderStub::class;
+
+    parthenon_extra_provider_classes();
+})->throws(RuntimeException::class, 'Parthenon extra provider must extend');


### PR DESCRIPTION
## Summary
- Add a CE bootstrap extension hook for optional extra bootstrap files and Laravel service providers.
- Support `PARTHENON_EXTRA_BOOTSTRAP_FILES` and `PARTHENON_EXTRA_PROVIDERS` without hard-coding EE classes into CE.
- Validate configured provider classes are autoloadable `Illuminate\Support\ServiceProvider` subclasses.

## Verification
- `php -l backend/bootstrap/provider-extensions.php backend/bootstrap/providers.php backend/tests/Fixtures/ExtraProviderStub.php backend/tests/Fixtures/NotAServiceProviderStub.php backend/tests/Unit/Services/BootstrapProviderExtensionsTest.php`
- `APP_ENV=testing CACHE_STORE=array QUEUE_CONNECTION=sync SESSION_DRIVER=array vendor/bin/pest tests/Unit/Services/BootstrapProviderExtensionsTest.php`
- `APP_ENV=testing CACHE_STORE=array QUEUE_CONNECTION=sync SESSION_DRIVER=array PARTHENON_EXTRA_PROVIDERS='Tests\\Fixtures\\ExtraProviderStub' php artisan about --only=environment`
- `docker compose exec php sh -c 'cd /var/www/html && vendor/bin/pint'`
- `graphify update .`

## Notes
This is the CE-side prerequisite for the Parthenon-EE bare-metal/VPS readiness branch. It gives EE a stable Laravel provider registration surface without editing CE files directly.
