### PR TITLE
feat: publish library Phase 1 + study-design accept-gate + queue idempotency

### DIFF
--- a/backend/app/Concerns/HasLibraryLifecycle.php
+++ b/backend/app/Concerns/HasLibraryLifecycle.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Concerns;
+
+use App\Enums\LibraryStatus;
+use App\Models\User;
+use App\Scopes\LibraryDefaultScope;
+use Illuminate\Database\Eloquent\Builder;
+
+trait HasLibraryLifecycle
+{
+    public static function bootHasLibraryLifecycle(): void
+    {
+        static::addGlobalScope(new LibraryDefaultScope);
+    }
+
+    public function initializeHasLibraryLifecycle(): void
+    {
+        $this->mergeCasts([
+            'status' => LibraryStatus::class,
+            'archived_at' => 'datetime',
+            'promoted_at' => 'datetime',
+        ]);
+    }
+
+    public function promote(User $actor): static
+    {
+        if ($this->status === LibraryStatus::ACTIVE) {
+            return $this;
+        }
+
+        $this->status = LibraryStatus::ACTIVE;
+
+        if ($this->promoted_at === null) {
+            $this->promoted_at = now();
+        }
+
+        $this->archived_at = null;
+        $this->archived_by = null;
+        $this->save();
+
+        return $this;
+    }
+
+    public function archive(User $actor): static
+    {
+        if ($this->status === LibraryStatus::ARCHIVED) {
+            return $this;
+        }
+
+        $this->status = LibraryStatus::ARCHIVED;
+        $this->archived_at = now();
+        $this->archived_by = $actor->id;
+        $this->save();
+
+        return $this;
+    }
+
+    public function restore_lifecycle(User $actor): static
+    {
+        if ($this->status !== LibraryStatus::ARCHIVED) {
+            return $this;
+        }
+
+        $this->status = LibraryStatus::ACTIVE;
+        $this->archived_at = null;
+        $this->archived_by = null;
+        $this->save();
+
+        return $this;
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where($this->getTable().'.status', LibraryStatus::ACTIVE->value);
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeDraft(Builder $query): Builder
+    {
+        return $query->where($this->getTable().'.status', LibraryStatus::DRAFT->value);
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeArchived(Builder $query): Builder
+    {
+        return $query->where($this->getTable().'.status', LibraryStatus::ARCHIVED->value);
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeOwnedBy(Builder $query, User $user): Builder
+    {
+        return $query->where($this->getTable().'.author_id', $user->id);
+    }
+}

--- a/backend/app/Enums/LibraryStatus.php
+++ b/backend/app/Enums/LibraryStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+enum LibraryStatus: string
+{
+    case DRAFT = 'draft';
+    case ACTIVE = 'active';
+    case ARCHIVED = 'archived';
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(fn (self $c) => $c->value, self::cases());
+    }
+}

--- a/backend/app/Http/Controllers/Api/V1/StudyDesignController.php
+++ b/backend/app/Http/Controllers/Api/V1/StudyDesignController.php
@@ -481,12 +481,32 @@ class StudyDesignController extends Controller
         $validated = $request->validate([
             'decision' => ['required', Rule::in(['accept', 'reject', 'defer'])],
             'review_notes' => ['nullable', 'string', 'max:5000'],
+            'acknowledge_warnings' => ['nullable', 'boolean'],
         ]);
 
-        if ($validated['decision'] === 'accept' && $this->requiresVerifiedAcceptance($asset) && $this->verificationValue($asset) !== StudyDesignVerificationStatus::VERIFIED->value) {
-            return response()->json([
-                'message' => 'Only deterministically verified Study Design assets can be accepted.',
-            ], 422);
+        if ($validated['decision'] === 'accept' && $this->requiresVerifiedAcceptance($asset)) {
+            $vstatus = $this->verificationValue($asset);
+            $verified = $vstatus === StudyDesignVerificationStatus::VERIFIED->value;
+            $partialAck = $vstatus === StudyDesignVerificationStatus::PARTIAL->value
+                && ($validated['acknowledge_warnings'] ?? false) === true;
+
+            if (! $verified && ! $partialAck) {
+                $message = $vstatus === StudyDesignVerificationStatus::PARTIAL->value
+                    ? 'This asset has verification warnings. Re-submit with acknowledge_warnings=true to accept anyway.'
+                    : 'Only verified Study Design assets can be accepted. Resolve blocking issues first.';
+
+                return response()->json(['message' => $message], 422);
+            }
+
+            if ($partialAck) {
+                $verificationJson = is_array($asset->verification_json) ? $asset->verification_json : [];
+                $verificationJson['acknowledged_warnings'] = [
+                    'by' => $request->user()?->id,
+                    'at' => now()->toIso8601String(),
+                    'warning_count' => count($verificationJson['warnings'] ?? []),
+                ];
+                $asset->verification_json = $verificationJson;
+            }
         }
 
         $asset->update([

--- a/backend/app/Jobs/Analysis/CareGapNightlyRefreshJob.php
+++ b/backend/app/Jobs/Analysis/CareGapNightlyRefreshJob.php
@@ -3,9 +3,11 @@
 namespace App\Jobs\Analysis;
 
 use App\Enums\DaimonType;
+use App\Jobs\Concerns\UniqueByExecutionKey;
 use App\Models\App\Source;
 use App\Services\Analysis\CareGapRefreshService;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -20,9 +22,15 @@ use Illuminate\Support\Facades\Log;
  * Dispatched by the scheduler daily at 02:00 AM.
  * Can also be triggered manually via: php artisan care-gaps:refresh
  */
-class CareGapNightlyRefreshJob implements ShouldQueue
+class CareGapNightlyRefreshJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use UniqueByExecutionKey;
+
+    public function uniqueId(): string
+    {
+        return 'care_gap_nightly_refresh';
+    }
 
     public int $timeout = 3600; // 1 hour max
 

--- a/backend/app/Jobs/Analysis/RunCareGapEvaluationJob.php
+++ b/backend/app/Jobs/Analysis/RunCareGapEvaluationJob.php
@@ -2,20 +2,28 @@
 
 namespace App\Jobs\Analysis;
 
+use App\Jobs\Concerns\UniqueByExecutionKey;
 use App\Models\App\CareGapEvaluation;
 use App\Models\App\ConditionBundle;
 use App\Models\App\Source;
 use App\Services\Analysis\CareGapService;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class RunCareGapEvaluationJob implements ShouldQueue
+class RunCareGapEvaluationJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use UniqueByExecutionKey;
+
+    public function uniqueId(): string
+    {
+        return 'care_gap_evaluation:'.$this->evaluation->id;
+    }
 
     /**
      * The number of seconds the job can run before timing out.

--- a/backend/app/Jobs/Analysis/RunCharacterizationJob.php
+++ b/backend/app/Jobs/Analysis/RunCharacterizationJob.php
@@ -3,22 +3,30 @@
 namespace App\Jobs\Analysis;
 
 use App\Enums\ExecutionStatus;
+use App\Jobs\Concerns\UniqueByExecutionKey;
 use App\Models\App\AnalysisExecution;
 use App\Models\App\Characterization;
 use App\Models\App\Source;
 use App\Services\Analysis\CharacterizationService;
 use App\Traits\NotifiesOnCompletion;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class RunCharacterizationJob implements ShouldQueue
+class RunCharacterizationJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
     use NotifiesOnCompletion;
+    use UniqueByExecutionKey;
+
+    public function uniqueId(): string
+    {
+        return 'characterization:execution:'.$this->execution->id;
+    }
 
     /**
      * The number of seconds the job can run before timing out.

--- a/backend/app/Jobs/Analysis/RunEstimationJob.php
+++ b/backend/app/Jobs/Analysis/RunEstimationJob.php
@@ -3,22 +3,30 @@
 namespace App\Jobs\Analysis;
 
 use App\Enums\ExecutionStatus;
+use App\Jobs\Concerns\UniqueByExecutionKey;
 use App\Models\App\AnalysisExecution;
 use App\Models\App\EstimationAnalysis;
 use App\Models\App\Source;
 use App\Services\Analysis\EstimationService;
 use App\Traits\NotifiesOnCompletion;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class RunEstimationJob implements ShouldQueue
+class RunEstimationJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
     use NotifiesOnCompletion;
+    use UniqueByExecutionKey;
+
+    public function uniqueId(): string
+    {
+        return 'estimation:execution:'.$this->execution->id;
+    }
 
     /**
      * The number of seconds the job can run before timing out.

--- a/backend/app/Jobs/Analysis/RunEvidenceSynthesisJob.php
+++ b/backend/app/Jobs/Analysis/RunEvidenceSynthesisJob.php
@@ -3,21 +3,29 @@
 namespace App\Jobs\Analysis;
 
 use App\Enums\ExecutionStatus;
+use App\Jobs\Concerns\UniqueByExecutionKey;
 use App\Models\App\AnalysisExecution;
 use App\Models\App\EvidenceSynthesisAnalysis;
 use App\Services\Analysis\EvidenceSynthesisService;
 use App\Traits\NotifiesOnCompletion;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class RunEvidenceSynthesisJob implements ShouldQueue
+class RunEvidenceSynthesisJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
     use NotifiesOnCompletion;
+    use UniqueByExecutionKey;
+
+    public function uniqueId(): string
+    {
+        return 'evidence_synthesis:execution:'.$this->execution->id;
+    }
 
     public int $timeout = 14400;
 

--- a/backend/app/Jobs/Analysis/RunIncidenceRateJob.php
+++ b/backend/app/Jobs/Analysis/RunIncidenceRateJob.php
@@ -3,22 +3,30 @@
 namespace App\Jobs\Analysis;
 
 use App\Enums\ExecutionStatus;
+use App\Jobs\Concerns\UniqueByExecutionKey;
 use App\Models\App\AnalysisExecution;
 use App\Models\App\IncidenceRateAnalysis;
 use App\Models\App\Source;
 use App\Services\Analysis\IncidenceRateService;
 use App\Traits\NotifiesOnCompletion;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class RunIncidenceRateJob implements ShouldQueue
+class RunIncidenceRateJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
     use NotifiesOnCompletion;
+    use UniqueByExecutionKey;
+
+    public function uniqueId(): string
+    {
+        return 'incidence_rate:execution:'.$this->execution->id;
+    }
 
     /**
      * The number of seconds the job can run before timing out.

--- a/backend/app/Jobs/Analysis/RunPathwayJob.php
+++ b/backend/app/Jobs/Analysis/RunPathwayJob.php
@@ -3,22 +3,30 @@
 namespace App\Jobs\Analysis;
 
 use App\Enums\ExecutionStatus;
+use App\Jobs\Concerns\UniqueByExecutionKey;
 use App\Models\App\AnalysisExecution;
 use App\Models\App\PathwayAnalysis;
 use App\Models\App\Source;
 use App\Services\Analysis\PathwayService;
 use App\Traits\NotifiesOnCompletion;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class RunPathwayJob implements ShouldQueue
+class RunPathwayJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
     use NotifiesOnCompletion;
+    use UniqueByExecutionKey;
+
+    public function uniqueId(): string
+    {
+        return 'pathway:execution:'.$this->execution->id;
+    }
 
     /**
      * The number of seconds the job can run before timing out.

--- a/backend/app/Jobs/Analysis/RunPhenotypeValidationJob.php
+++ b/backend/app/Jobs/Analysis/RunPhenotypeValidationJob.php
@@ -3,18 +3,26 @@
 namespace App\Jobs\Analysis;
 
 use App\Enums\ExecutionStatus;
+use App\Jobs\Concerns\UniqueByExecutionKey;
 use App\Models\App\CohortPhenotypeValidation;
 use App\Services\Analysis\PhenotypeValidationService;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class RunPhenotypeValidationJob implements ShouldQueue
+class RunPhenotypeValidationJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use UniqueByExecutionKey;
+
+    public function uniqueId(): string
+    {
+        return 'phenotype_validation:'.$this->validation->id;
+    }
 
     public int $timeout = 7200;
 

--- a/backend/app/Jobs/Analysis/RunPredictionJob.php
+++ b/backend/app/Jobs/Analysis/RunPredictionJob.php
@@ -3,22 +3,30 @@
 namespace App\Jobs\Analysis;
 
 use App\Enums\ExecutionStatus;
+use App\Jobs\Concerns\UniqueByExecutionKey;
 use App\Models\App\AnalysisExecution;
 use App\Models\App\PredictionAnalysis;
 use App\Models\App\Source;
 use App\Services\Analysis\PredictionService;
 use App\Traits\NotifiesOnCompletion;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class RunPredictionJob implements ShouldQueue
+class RunPredictionJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
     use NotifiesOnCompletion;
+    use UniqueByExecutionKey;
+
+    public function uniqueId(): string
+    {
+        return 'prediction:execution:'.$this->execution->id;
+    }
 
     /**
      * The number of seconds the job can run before timing out.

--- a/backend/app/Jobs/Analysis/RunSccsJob.php
+++ b/backend/app/Jobs/Analysis/RunSccsJob.php
@@ -3,22 +3,30 @@
 namespace App\Jobs\Analysis;
 
 use App\Enums\ExecutionStatus;
+use App\Jobs\Concerns\UniqueByExecutionKey;
 use App\Models\App\AnalysisExecution;
 use App\Models\App\SccsAnalysis;
 use App\Models\App\Source;
 use App\Services\Analysis\SccsService;
 use App\Traits\NotifiesOnCompletion;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class RunSccsJob implements ShouldQueue
+class RunSccsJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
     use NotifiesOnCompletion;
+    use UniqueByExecutionKey;
+
+    public function uniqueId(): string
+    {
+        return 'sccs:execution:'.$this->execution->id;
+    }
 
     public int $timeout = 14400;
 

--- a/backend/app/Jobs/Analysis/RunSelfControlledCohortJob.php
+++ b/backend/app/Jobs/Analysis/RunSelfControlledCohortJob.php
@@ -3,22 +3,30 @@
 namespace App\Jobs\Analysis;
 
 use App\Enums\ExecutionStatus;
+use App\Jobs\Concerns\UniqueByExecutionKey;
 use App\Models\App\AnalysisExecution;
 use App\Models\App\SelfControlledCohortAnalysis;
 use App\Models\App\Source;
 use App\Services\Analysis\SelfControlledCohortService;
 use App\Traits\NotifiesOnCompletion;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class RunSelfControlledCohortJob implements ShouldQueue
+class RunSelfControlledCohortJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
     use NotifiesOnCompletion;
+    use UniqueByExecutionKey;
+
+    public function uniqueId(): string
+    {
+        return 'self_controlled_cohort:execution:'.$this->execution->id;
+    }
 
     public int $timeout = 14400;
 

--- a/backend/app/Jobs/Cohort/GenerateCohortJob.php
+++ b/backend/app/Jobs/Cohort/GenerateCohortJob.php
@@ -3,20 +3,28 @@
 namespace App\Jobs\Cohort;
 
 use App\Enums\ExecutionStatus;
+use App\Jobs\Concerns\UniqueByExecutionKey;
 use App\Models\App\CohortDefinition;
 use App\Models\App\Source;
 use App\Notifications\CohortGeneratedNotification;
 use App\Services\Cohort\CohortGenerationService;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
-class GenerateCohortJob implements ShouldQueue
+class GenerateCohortJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use UniqueByExecutionKey;
+
+    public function uniqueId(): string
+    {
+        return 'cohort_generation:'.$this->cohortDefinition->id.':source:'.$this->source->id;
+    }
 
     /**
      * The number of seconds the job can run before timing out.

--- a/backend/app/Jobs/Concerns/UniqueByExecutionKey.php
+++ b/backend/app/Jobs/Concerns/UniqueByExecutionKey.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Jobs\Concerns;
+
+trait UniqueByExecutionKey
+{
+    public function uniqueFor(): int
+    {
+        return $this->timeout ?? 7200;
+    }
+}

--- a/backend/app/Models/App/ConceptSet.php
+++ b/backend/app/Models/App/ConceptSet.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\App;
 
+use App\Concerns\HasLibraryLifecycle;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -11,7 +12,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class ConceptSet extends Model
 {
-    use HasFactory, SoftDeletes;
+    use HasFactory, HasLibraryLifecycle, SoftDeletes;
 
     protected $fillable = [
         'name',

--- a/backend/app/Models/App/LibraryCleanupSuggestion.php
+++ b/backend/app/Models/App/LibraryCleanupSuggestion.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models\App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class LibraryCleanupSuggestion extends Model
+{
+    protected $table = 'library_cleanup_suggestions';
+
+    public $timestamps = false;
+
+    public $incrementing = false;
+
+    protected $primaryKey = null;
+
+    protected $fillable = [
+        'user_id',
+        'item_type',
+        'item_id',
+        'last_activity_at',
+        'computed_at',
+    ];
+
+    protected $casts = [
+        'last_activity_at' => 'datetime',
+        'computed_at' => 'datetime',
+    ];
+}

--- a/backend/app/Scopes/LibraryDefaultScope.php
+++ b/backend/app/Scopes/LibraryDefaultScope.php
@@ -2,17 +2,41 @@
 
 namespace App\Scopes;
 
+use App\Enums\LibraryStatus;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Support\Facades\Auth;
 
-/**
- * No-op stub. Full default-scope behavior is wired in Task A7.
- */
 class LibraryDefaultScope implements Scope
 {
+    /**
+     * @param  Builder<Model>  $builder
+     */
     public function apply(Builder $builder, Model $model): void
     {
-        // Intentionally empty — Task A7 wires the default visibility rules.
+        $userId = Auth::id();
+        $table = $model->getTable();
+
+        $builder->where(function (Builder $q) use ($table, $userId) {
+            $q->where("{$table}.status", LibraryStatus::ACTIVE->value);
+
+            if ($userId !== null) {
+                $q->orWhere(function (Builder $sub) use ($table, $userId) {
+                    $sub->where("{$table}.status", LibraryStatus::DRAFT->value)
+                        ->where("{$table}.author_id", $userId);
+                });
+            }
+        });
+    }
+
+    public function extend(Builder $builder): void
+    {
+        $bypass = fn (Builder $b) => $b->withoutGlobalScope(self::class);
+
+        $builder->macro('withAnyStatus', $bypass);
+        $builder->macro('withArchived', $bypass);
+        $builder->macro('withDrafts', $bypass);
+        $builder->macro('asSuperUser', $bypass);
     }
 }

--- a/backend/app/Scopes/LibraryDefaultScope.php
+++ b/backend/app/Scopes/LibraryDefaultScope.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+/**
+ * No-op stub. Full default-scope behavior is wired in Task A7.
+ */
+class LibraryDefaultScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        // Intentionally empty — Task A7 wires the default visibility rules.
+    }
+}

--- a/backend/database/factories/App/ConceptSetFactory.php
+++ b/backend/database/factories/App/ConceptSetFactory.php
@@ -21,6 +21,10 @@ class ConceptSetFactory extends Factory
             'author_id' => User::factory(),
             'is_public' => false,
             'tags' => [],
+            'status' => 'active',
+            'archived_at' => null,
+            'archived_by' => null,
+            'promoted_at' => null,
         ];
     }
 }

--- a/backend/database/migrations/2026_05_13_190001_add_library_lifecycle_columns_to_concept_sets.php
+++ b/backend/database/migrations/2026_05_13_190001_add_library_lifecycle_columns_to_concept_sets.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Enums\LibraryStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('concept_sets', function (Blueprint $table) {
+            $table->string('status', 16)->default(LibraryStatus::ACTIVE->value)->index();
+            $table->timestamp('archived_at')->nullable();
+            $table->unsignedBigInteger('archived_by')->nullable();
+            $table->timestamp('promoted_at')->nullable();
+            $table->foreign('archived_by')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('concept_sets', function (Blueprint $table) {
+            $table->dropForeign(['archived_by']);
+            $table->dropColumn(['status', 'archived_at', 'archived_by', 'promoted_at']);
+        });
+    }
+};

--- a/backend/database/migrations/2026_05_13_190002_add_library_lifecycle_columns_to_cohort_definitions.php
+++ b/backend/database/migrations/2026_05_13_190002_add_library_lifecycle_columns_to_cohort_definitions.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Enums\LibraryStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('cohort_definitions', function (Blueprint $table) {
+            $table->string('status', 16)->default(LibraryStatus::ACTIVE->value)->index();
+            $table->timestamp('archived_at')->nullable();
+            $table->unsignedBigInteger('archived_by')->nullable();
+            $table->timestamp('promoted_at')->nullable();
+            $table->foreign('archived_by')->references('id')->on('users')->nullOnDelete();
+        });
+
+        // Fold existing deprecation into archived. Safe even if column doesn't exist.
+        if (Schema::hasColumn('cohort_definitions', 'deprecated_at')) {
+            DB::table('cohort_definitions')
+                ->whereNotNull('deprecated_at')
+                ->update([
+                    'status' => LibraryStatus::ARCHIVED->value,
+                    'archived_at' => DB::raw('deprecated_at'),
+                ]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('cohort_definitions', function (Blueprint $table) {
+            $table->dropForeign(['archived_by']);
+            $table->dropColumn(['status', 'archived_at', 'archived_by', 'promoted_at']);
+        });
+    }
+};

--- a/backend/database/migrations/2026_05_13_190003_add_library_lifecycle_columns_to_analyses.php
+++ b/backend/database/migrations/2026_05_13_190003_add_library_lifecycle_columns_to_analyses.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Enums\LibraryStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLES = [
+        'incidence_rate_analyses',
+        'pathway_analyses',
+        'estimation_analyses',
+        'prediction_analyses',
+        'feature_analyses',
+        'sccs_analyses',
+        'evidence_synthesis_analyses',
+        'self_controlled_cohort_analyses',
+    ];
+
+    public function up(): void
+    {
+        foreach (self::TABLES as $table) {
+            Schema::table($table, function (Blueprint $t) {
+                $t->string('status', 16)->default(LibraryStatus::ACTIVE->value)->index();
+                $t->timestamp('archived_at')->nullable();
+                $t->unsignedBigInteger('archived_by')->nullable();
+                $t->timestamp('promoted_at')->nullable();
+                $t->foreign('archived_by')->references('id')->on('users')->nullOnDelete();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (self::TABLES as $table) {
+            Schema::table($table, function (Blueprint $t) {
+                $t->dropForeign(['archived_by']);
+                $t->dropColumn(['status', 'archived_at', 'archived_by', 'promoted_at']);
+            });
+        }
+    }
+};

--- a/backend/database/migrations/2026_05_13_190004_create_library_cleanup_suggestions_table.php
+++ b/backend/database/migrations/2026_05_13_190004_create_library_cleanup_suggestions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('library_cleanup_suggestions', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id');
+            $table->string('item_type', 64);
+            $table->unsignedBigInteger('item_id');
+            $table->timestamp('last_activity_at')->nullable();
+            $table->timestamp('computed_at');
+
+            $table->primary(['user_id', 'item_type', 'item_id']);
+            $table->index('computed_at');
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('library_cleanup_suggestions');
+    }
+};

--- a/backend/tests/Feature/Api/V1/PublicationTest.php
+++ b/backend/tests/Feature/Api/V1/PublicationTest.php
@@ -242,3 +242,49 @@ it('exports and imports OHDSI report bundles from the publish API', function () 
 
     expect(PublicationReportBundle::query()->where('direction', 'import')->exists())->toBeTrue();
 });
+
+it('round-trips document_json with frozen SVG and tableData intact', function () {
+    $user = User::factory()->create();
+    $user->assignRole('researcher');
+
+    $document = [
+        'version' => 1,
+        'title' => 'Round-trip Test',
+        'authors' => ['Test Author'],
+        'template' => 'generic-ohdsi',
+        'step' => 2,
+        'selectedExecutions' => [
+            ['studyId' => 1, 'analysisId' => 42, 'executionId' => 99, 'analysisType' => 'characterization', 'designJson' => ['k' => 'v']],
+        ],
+        'sections' => [
+            [
+                'id' => 'results-characterization',
+                'type' => 'results',
+                'title' => 'Results',
+                'content' => 'narrative',
+                'included' => true,
+                'tableData' => ['headers' => ['A', 'B'], 'rows' => [['A' => 1, 'B' => 2]], 'caption' => 'Cohort A'],
+                'svgMarkup' => '<svg xmlns="http://www.w3.org/2000/svg"><rect x="1" y="2" width="3" height="4"/></svg>',
+                'diagramType' => 'kaplan-meier',
+            ],
+        ],
+    ];
+
+    $created = $this->actingAs($user)
+        ->postJson('/api/v1/publish/drafts', [
+            'title' => 'Round-trip Test',
+            'template' => 'generic-ohdsi',
+            'document_json' => $document,
+        ])
+        ->assertCreated()
+        ->json('data');
+
+    $loaded = $this->actingAs($user)
+        ->getJson('/api/v1/publish/drafts/'.$created['id'])
+        ->assertOk()
+        ->json('data');
+
+    expect($loaded['document_json'])->toEqual($document);
+    expect($loaded['document_json']['sections'][0]['svgMarkup'])->toContain('<svg');
+    expect($loaded['document_json']['sections'][0]['tableData']['rows'][0]['A'])->toBe(1);
+});

--- a/backend/tests/Feature/Api/V1/StudyDesignTest.php
+++ b/backend/tests/Feature/Api/V1/StudyDesignTest.php
@@ -2272,7 +2272,7 @@ it('blocks analysis plan acceptance for missing HADES packages and materializes 
             'decision' => 'accept',
         ])
         ->assertStatus(422)
-        ->assertJsonPath('message', 'Only deterministically verified Study Design assets can be accepted.');
+        ->assertJsonPath('message', 'Only verified Study Design assets can be accepted. Resolve blocking issues first.');
 
     $this->actingAs($this->user)
         ->postJson("/api/v1/studies/{$this->study->slug}/design-sessions/{$sessionId}/assets/{$assetId}/analysis-plans/materialize")
@@ -2459,4 +2459,121 @@ it('rejects locked version edits and cross-study package downloads', function ()
         ->assertNotFound();
 
     expect(StudyArtifact::find($artifactId)?->metadata['sha256'] ?? null)->not->toBeNull();
+});
+
+it('rejects accept on a partial-verification asset without acknowledge_warnings', function () {
+    $session = $this->study->designSessions()->create([
+        'created_by' => $this->user->id,
+        'title' => 'Partial accept gate',
+        'source_mode' => 'protocol_upload',
+        'status' => 'reviewing',
+    ]);
+    $version = $session->versions()->create([
+        'version_number' => 1,
+        'status' => 'reviewing',
+        'intent_json' => ['research_question' => 'Q'],
+        'provenance_json' => ['source' => 'test'],
+    ]);
+    $session->update(['active_version_id' => $version->id]);
+
+    $asset = StudyDesignAsset::create([
+        'session_id' => $session->id,
+        'version_id' => $version->id,
+        'asset_type' => 'analysis_plan',
+        'status' => 'needs_review',
+        'verification_status' => 'partial',
+        'draft_payload_json' => ['title' => 'Plan with warnings'],
+        'verification_json' => [
+            'warnings' => ['Feasibility evidence is limited.'],
+            'blocking_reasons' => [],
+        ],
+    ]);
+
+    $this->actingAs($this->user)
+        ->postJson("/api/v1/studies/{$this->study->slug}/design-sessions/{$session->id}/assets/{$asset->id}/review", [
+            'decision' => 'accept',
+        ])
+        ->assertStatus(422)
+        ->assertJsonPath('message', 'This asset has verification warnings. Re-submit with acknowledge_warnings=true to accept anyway.');
+
+    expect($asset->fresh()->status->value)->toBe('needs_review');
+});
+
+it('accepts a partial-verification asset when acknowledge_warnings is true and records the acknowledgement', function () {
+    $session = $this->study->designSessions()->create([
+        'created_by' => $this->user->id,
+        'title' => 'Partial accept ack',
+        'source_mode' => 'protocol_upload',
+        'status' => 'reviewing',
+    ]);
+    $version = $session->versions()->create([
+        'version_number' => 1,
+        'status' => 'reviewing',
+        'intent_json' => ['research_question' => 'Q'],
+        'provenance_json' => ['source' => 'test'],
+    ]);
+    $session->update(['active_version_id' => $version->id]);
+
+    $asset = StudyDesignAsset::create([
+        'session_id' => $session->id,
+        'version_id' => $version->id,
+        'asset_type' => 'analysis_plan',
+        'status' => 'needs_review',
+        'verification_status' => 'partial',
+        'draft_payload_json' => ['title' => 'Plan with warnings'],
+        'verification_json' => [
+            'warnings' => ['Feasibility evidence is limited.', 'HADES package version is older than recommended.'],
+            'blocking_reasons' => [],
+        ],
+    ]);
+
+    $this->actingAs($this->user)
+        ->postJson("/api/v1/studies/{$this->study->slug}/design-sessions/{$session->id}/assets/{$asset->id}/review", [
+            'decision' => 'accept',
+            'acknowledge_warnings' => true,
+            'review_notes' => 'Warnings reviewed; proceeding.',
+        ])
+        ->assertOk()
+        ->assertJsonPath('data.status', 'accepted')
+        ->assertJsonPath('data.verification_json.acknowledged_warnings.by', $this->user->id)
+        ->assertJsonPath('data.verification_json.acknowledged_warnings.warning_count', 2);
+});
+
+it('rejects accept on a blocked-verification asset regardless of acknowledge_warnings', function () {
+    $session = $this->study->designSessions()->create([
+        'created_by' => $this->user->id,
+        'title' => 'Blocked accept gate',
+        'source_mode' => 'protocol_upload',
+        'status' => 'reviewing',
+    ]);
+    $version = $session->versions()->create([
+        'version_number' => 1,
+        'status' => 'reviewing',
+        'intent_json' => ['research_question' => 'Q'],
+        'provenance_json' => ['source' => 'test'],
+    ]);
+    $session->update(['active_version_id' => $version->id]);
+
+    $asset = StudyDesignAsset::create([
+        'session_id' => $session->id,
+        'version_id' => $version->id,
+        'asset_type' => 'analysis_plan',
+        'status' => 'needs_review',
+        'verification_status' => 'blocked',
+        'draft_payload_json' => ['title' => 'Plan with blockers'],
+        'verification_json' => [
+            'warnings' => [],
+            'blocking_reasons' => ['CohortMethod is not installed.'],
+        ],
+    ]);
+
+    $this->actingAs($this->user)
+        ->postJson("/api/v1/studies/{$this->study->slug}/design-sessions/{$session->id}/assets/{$asset->id}/review", [
+            'decision' => 'accept',
+            'acknowledge_warnings' => true,
+        ])
+        ->assertStatus(422)
+        ->assertJsonPath('message', 'Only verified Study Design assets can be accepted. Resolve blocking issues first.');
+
+    expect($asset->fresh()->status->value)->toBe('needs_review');
 });

--- a/backend/tests/Feature/Migrations/LibraryLifecycleColumnsTest.php
+++ b/backend/tests/Feature/Migrations/LibraryLifecycleColumnsTest.php
@@ -47,4 +47,23 @@ class LibraryLifecycleColumnsTest extends TestCase
         // via the Task D8 backfill command on real data.
         $this->markTestSkipped('Data fold tested via Task D8 backfill command on real data.');
     }
+
+    public function test_all_analyses_tables_have_lifecycle_columns(): void
+    {
+        foreach ([
+            'incidence_rate_analyses',
+            'pathway_analyses',
+            'estimation_analyses',
+            'prediction_analyses',
+            'feature_analyses',
+            'sccs_analyses',
+            'evidence_synthesis_analyses',
+            'self_controlled_cohort_analyses',
+        ] as $table) {
+            $this->assertTrue(
+                Schema::hasColumns($table, ['status', 'archived_at', 'archived_by', 'promoted_at']),
+                "{$table} missing lifecycle columns"
+            );
+        }
+    }
 }

--- a/backend/tests/Feature/Migrations/LibraryLifecycleColumnsTest.php
+++ b/backend/tests/Feature/Migrations/LibraryLifecycleColumnsTest.php
@@ -31,4 +31,20 @@ class LibraryLifecycleColumnsTest extends TestCase
 
         $this->assertSame('active', \DB::table('concept_sets')->where('id', $id)->value('status'));
     }
+
+    public function test_cohort_definitions_has_lifecycle_columns(): void
+    {
+        $this->assertTrue(Schema::hasColumns('cohort_definitions', [
+            'status', 'archived_at', 'archived_by', 'promoted_at',
+        ]));
+    }
+
+    public function test_cohort_definitions_deprecated_at_folded_to_archived(): void
+    {
+        // Data fold runs at migration time on a real DB; testing it in isolation
+        // would require inserting rows before the migration runs. The schema-level
+        // test above confirms the target columns exist. Fold correctness is verified
+        // via the Task D8 backfill command on real data.
+        $this->markTestSkipped('Data fold tested via Task D8 backfill command on real data.');
+    }
 }

--- a/backend/tests/Feature/Migrations/LibraryLifecycleColumnsTest.php
+++ b/backend/tests/Feature/Migrations/LibraryLifecycleColumnsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature\Migrations;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class LibraryLifecycleColumnsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_concept_sets_has_lifecycle_columns(): void
+    {
+        $this->assertTrue(Schema::hasColumns('concept_sets', [
+            'status', 'archived_at', 'archived_by', 'promoted_at',
+        ]));
+    }
+
+    public function test_concept_sets_status_defaults_to_active(): void
+    {
+        $user = User::factory()->create();
+
+        $id = \DB::table('concept_sets')->insertGetId([
+            'name' => 'test',
+            'author_id' => $user->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->assertSame('active', \DB::table('concept_sets')->where('id', $id)->value('status'));
+    }
+}

--- a/backend/tests/Unit/Concerns/HasLibraryLifecycleTest.php
+++ b/backend/tests/Unit/Concerns/HasLibraryLifecycleTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Unit\Concerns;
+
+use App\Enums\LibraryStatus;
+use App\Models\App\ConceptSet;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class HasLibraryLifecycleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeSet(LibraryStatus $status): ConceptSet
+    {
+        $owner = User::factory()->create();
+
+        return ConceptSet::factory()->create([
+            'author_id' => $owner->id,
+            'status' => $status->value,
+        ]);
+    }
+
+    public function test_promote_marks_active_and_stamps_promoted_at(): void
+    {
+        $set = $this->makeSet(LibraryStatus::DRAFT);
+        $actor = User::factory()->create();
+
+        $set->promote($actor);
+
+        $this->assertSame(LibraryStatus::ACTIVE, $set->fresh()->status);
+        $this->assertNotNull($set->fresh()->promoted_at);
+    }
+
+    public function test_archive_stamps_archived_at_and_archived_by(): void
+    {
+        $set = $this->makeSet(LibraryStatus::ACTIVE);
+        $actor = User::factory()->create();
+
+        $set->archive($actor);
+
+        $fresh = $set->fresh();
+        $this->assertSame(LibraryStatus::ARCHIVED, $fresh->status);
+        $this->assertSame($actor->id, $fresh->archived_by);
+        $this->assertNotNull($fresh->archived_at);
+    }
+
+    public function test_restore_lifecycle_from_archived_clears_archive_stamps(): void
+    {
+        $archiver = User::factory()->create();
+        $set = $this->makeSet(LibraryStatus::ARCHIVED);
+        $set->forceFill(['archived_at' => now(), 'archived_by' => $archiver->id])->save();
+
+        $set->restore_lifecycle(User::factory()->create());
+
+        $fresh = $set->fresh();
+        $this->assertSame(LibraryStatus::ACTIVE, $fresh->status);
+        $this->assertNull($fresh->archived_at);
+        $this->assertNull($fresh->archived_by);
+    }
+
+    public function test_promote_on_already_active_is_noop_does_not_stamp_again(): void
+    {
+        $set = $this->makeSet(LibraryStatus::ACTIVE);
+        $set->forceFill(['promoted_at' => now()->subDays(5)])->save();
+        $originalPromotedAt = $set->fresh()->promoted_at;
+
+        $set->promote(User::factory()->create());
+
+        $this->assertEquals($originalPromotedAt->timestamp, $set->fresh()->promoted_at->timestamp);
+    }
+
+    public function test_archive_on_already_archived_is_noop(): void
+    {
+        $originalArchiver = User::factory()->create();
+        $set = $this->makeSet(LibraryStatus::ARCHIVED);
+        $originalArchivedAt = now()->subDays(3);
+        $set->forceFill(['archived_at' => $originalArchivedAt, 'archived_by' => $originalArchiver->id])->save();
+
+        $set->archive(User::factory()->create());
+
+        $fresh = $set->fresh();
+        $this->assertSame($originalArchiver->id, $fresh->archived_by);
+        $this->assertEquals($originalArchivedAt->timestamp, $fresh->archived_at->timestamp);
+    }
+}

--- a/backend/tests/Unit/Enums/LibraryStatusTest.php
+++ b/backend/tests/Unit/Enums/LibraryStatusTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\LibraryStatus;
+use Tests\TestCase;
+
+class LibraryStatusTest extends TestCase
+{
+    public function test_has_three_cases_with_string_values(): void
+    {
+        $this->assertSame('draft', LibraryStatus::DRAFT->value);
+        $this->assertSame('active', LibraryStatus::ACTIVE->value);
+        $this->assertSame('archived', LibraryStatus::ARCHIVED->value);
+    }
+
+    public function test_values_helper_returns_all_string_values(): void
+    {
+        $this->assertSame(
+            ['draft', 'active', 'archived'],
+            LibraryStatus::values()
+        );
+    }
+}

--- a/backend/tests/Unit/Models/LibraryCleanupSuggestionTest.php
+++ b/backend/tests/Unit/Models/LibraryCleanupSuggestionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\App\LibraryCleanupSuggestion;
+use App\Models\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LibraryCleanupSuggestionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_persist_and_read(): void
+    {
+        $user = User::factory()->create();
+        $row = LibraryCleanupSuggestion::create([
+            'user_id' => $user->id,
+            'item_type' => 'cohort_definition',
+            'item_id' => 42,
+            'last_activity_at' => now()->subDays(120),
+            'computed_at' => now(),
+        ]);
+
+        $this->assertSame('cohort_definition', $row->item_type);
+        $this->assertSame(42, $row->item_id);
+        $this->assertSame($user->id, $row->user_id);
+    }
+
+    public function test_composite_primary_key_enforced(): void
+    {
+        $user = User::factory()->create();
+        LibraryCleanupSuggestion::create([
+            'user_id' => $user->id,
+            'item_type' => 'cohort_definition',
+            'item_id' => 1,
+            'last_activity_at' => now(),
+            'computed_at' => now(),
+        ]);
+
+        $this->expectException(QueryException::class);
+        LibraryCleanupSuggestion::create([
+            'user_id' => $user->id,
+            'item_type' => 'cohort_definition',
+            'item_id' => 1,
+            'last_activity_at' => now(),
+            'computed_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Unit/Scopes/LibraryDefaultScopeTest.php
+++ b/backend/tests/Unit/Scopes/LibraryDefaultScopeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\Scopes;
+
+use App\Models\App\ConceptSet;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LibraryDefaultScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_default_query_hides_archived_and_non_owner_drafts(): void
+    {
+        $alice = User::factory()->create();
+        $bob = User::factory()->create();
+
+        $aliceActive = ConceptSet::factory()->create(['author_id' => $alice->id, 'status' => 'active']);
+        $aliceDraft = ConceptSet::factory()->create(['author_id' => $alice->id, 'status' => 'draft']);
+        $aliceArchived = ConceptSet::factory()->create(['author_id' => $alice->id, 'status' => 'archived']);
+        $bobActive = ConceptSet::factory()->create(['author_id' => $bob->id, 'status' => 'active']);
+        $bobDraft = ConceptSet::factory()->create(['author_id' => $bob->id, 'status' => 'draft']);
+
+        $this->actingAs($alice);
+
+        $ids = ConceptSet::query()->pluck('id')->all();
+
+        // Alice sees: her active + her draft + Bob's active. NOT her archived, NOT Bob's draft.
+        $this->assertContains($aliceActive->id, $ids);
+        $this->assertContains($aliceDraft->id, $ids);
+        $this->assertContains($bobActive->id, $ids);
+        $this->assertNotContains($aliceArchived->id, $ids);
+        $this->assertNotContains($bobDraft->id, $ids);
+        $this->assertCount(3, $ids);
+    }
+
+    public function test_with_archived_macro_includes_archived(): void
+    {
+        $alice = User::factory()->create();
+        $this->actingAs($alice);
+        ConceptSet::factory()->create(['author_id' => $alice->id, 'status' => 'archived']);
+
+        $this->assertCount(1, ConceptSet::query()->withArchived()->get());
+        $this->assertCount(0, ConceptSet::query()->get());
+    }
+
+    public function test_with_any_status_macro_returns_everything(): void
+    {
+        $alice = User::factory()->create();
+        $bob = User::factory()->create();
+        $this->actingAs($alice);
+        ConceptSet::factory()->create(['author_id' => $alice->id, 'status' => 'active']);
+        ConceptSet::factory()->create(['author_id' => $bob->id, 'status' => 'draft']);
+        ConceptSet::factory()->create(['author_id' => $alice->id, 'status' => 'archived']);
+
+        $this->assertCount(3, ConceptSet::query()->withAnyStatus()->get());
+    }
+
+    public function test_unauthenticated_request_sees_only_active(): void
+    {
+        $alice = User::factory()->create();
+        // No actingAs.
+        ConceptSet::factory()->create(['author_id' => $alice->id, 'status' => 'active']);
+        ConceptSet::factory()->create(['author_id' => $alice->id, 'status' => 'draft']);
+        ConceptSet::factory()->create(['author_id' => $alice->id, 'status' => 'archived']);
+
+        $this->assertCount(1, ConceptSet::query()->get());
+    }
+}

--- a/docs/lineage/modules/2026-05-13-library-cleanup-suggestions-table.md
+++ b/docs/lineage/modules/2026-05-13-library-cleanup-suggestions-table.md
@@ -1,0 +1,86 @@
+---
+doc_type: lineage
+status: historical
+date: 2026-05-13
+owner: acumenus
+module: studies
+lineage_anchor: true
+supersedes: []
+superseded_by: null
+related_code:
+  - backend/database/migrations/2026_05_13_190004_create_library_cleanup_suggestions_table.php
+  - backend/app/Models/App/LibraryCleanupSuggestion.php
+related_prs: []
+---
+# 2026-05-13 — Library cleanup suggestions cache table (Phase A, Task A5)
+
+Part of the publish-library-phase-1 feature branch. Creates the
+`app.library_cleanup_suggestions` table and its corresponding Eloquent model,
+which together serve as the denormalized cache backing the Cleanup Suggestions
+UI page.
+
+## Purpose
+
+The Cleanup Suggestions page surfaces library items (cohort definitions, concept
+sets, analyses) that have gone stale — i.e. have not been used or modified in a
+configurable threshold period. Computing staleness on-the-fly at page load would
+require scanning all 10 lifecycle-aware tables across potentially millions of
+rows. Instead, `SuggestLibraryCleanupJob` runs nightly via the scheduler,
+evaluates each item, and writes one row per (user, item_type, item_id) triplet
+into this cache. The UI reads from the cache directly — O(1) per user.
+
+## Schema — `app.library_cleanup_suggestions` (new table)
+
+`backend/database/migrations/2026_05_13_190004_create_library_cleanup_suggestions_table.php`
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `user_id` | `bigint unsigned` | no | FK → `app.users(id)` ON DELETE CASCADE |
+| `item_type` | `varchar(64)` | no | Discriminator: `cohort_definition`, `concept_set`, `analysis`, etc. |
+| `item_id` | `bigint unsigned` | no | PK of the referenced item in its own table |
+| `last_activity_at` | `timestamp` | yes | Latest of: promoted_at, last_run_at, updated_at for the item |
+| `computed_at` | `timestamp` | no | When `SuggestLibraryCleanupJob` wrote this row; indexed |
+
+### Primary key
+
+The table uses a **composite primary key** `(user_id, item_type, item_id)`. This
+choice encodes the conceptual identity of each suggestion — a given item can
+produce at most one suggestion row per user — and gives upsert semantics for
+free: `INSERT ... ON CONFLICT DO UPDATE` (or the Laravel equivalent) can refresh
+`last_activity_at` and `computed_at` without separate DELETE/INSERT logic.
+
+There is no surrogate `id` column. `Model::$incrementing = false` and
+`Model::$primaryKey = null` are set accordingly; Eloquent's `create()` still
+works because it delegates to a raw INSERT, and the table's uniqueness
+constraint is enforced at the database level.
+
+### Indexes
+
+- `PRIMARY (user_id, item_type, item_id)` — identity + uniqueness
+- `INDEX (computed_at)` — allows the nightly job to age-out stale cache rows
+  efficiently: `DELETE WHERE computed_at < now() - interval '2 days'`
+
+### Foreign key
+
+`user_id` references `app.users(id)` with `ON DELETE CASCADE`. When a user
+account is removed, all their cleanup suggestions are automatically purged —
+consistent with the rest of the `app.*` user-scoped tables.
+
+## Eloquent model
+
+`backend/app/Models/App/LibraryCleanupSuggestion.php`
+
+- `$timestamps = false` — the table has no `created_at`/`updated_at`; staleness
+  is tracked via `computed_at` instead.
+- `$fillable` lists all five columns explicitly (no `$guarded = []`).
+- `$casts` maps both timestamp columns to `datetime` for Carbon interop.
+
+## Test coverage
+
+`backend/tests/Unit/Models/LibraryCleanupSuggestionTest.php` — two tests written
+RED before the migration existed (TDD):
+
+1. `test_can_persist_and_read` — verifies `create()` works and scalar attributes
+   round-trip correctly.
+2. `test_composite_primary_key_enforced` — verifies the database rejects a
+   duplicate `(user_id, item_type, item_id)` triplet with `QueryException`.

--- a/docs/lineage/modules/2026-05-13-library-lifecycle-columns-analyses.md
+++ b/docs/lineage/modules/2026-05-13-library-lifecycle-columns-analyses.md
@@ -1,0 +1,54 @@
+---
+doc_type: lineage
+status: historical
+date: 2026-05-13
+owner: acumenus
+module: analyses
+lineage_anchor: true
+supersedes: []
+superseded_by: null
+related_code:
+  - backend/database/migrations/2026_05_13_190003_add_library_lifecycle_columns_to_analyses.php
+related_prs: []
+---
+# 2026-05-13 — Library lifecycle columns on 8 analyses tables (Phase A, Task A4)
+
+Part of the publish-library-phase-1 feature branch. Adds four lifecycle columns
+to all eight OHDSI analysis tables in the `app` schema, completing the schema
+phase of the library publish workflow for analyses.
+
+## Affected tables
+
+- `incidence_rate_analyses`
+- `pathway_analyses`
+- `estimation_analyses`
+- `prediction_analyses`
+- `feature_analyses`
+- `sccs_analyses`
+- `evidence_synthesis_analyses`
+- `self_controlled_cohort_analyses`
+
+## Schema — additive columns (all 8 tables)
+
+`backend/database/migrations/2026_05_13_190003_add_library_lifecycle_columns_to_analyses.php`
+
+| Column | Type | Default | Notes |
+|---|---|---|---|
+| `status` | `varchar(16)` | `'active'` | Indexed. Values from `LibraryStatus` enum: draft, active, archived |
+| `archived_at` | `timestamp` | `null` | Set when status transitions to archived |
+| `archived_by` | `bigint` | `null` | FK → `app.users(id)` ON DELETE SET NULL |
+| `promoted_at` | `timestamp` | `null` | Set when a draft is promoted to active |
+
+The migration loops over all eight tables in a single class, applying identical
+column additions to each. The `down()` path drops the FK constraint before
+dropping the four columns, in the same loop. No data fold is required — none
+of these tables had a prior deprecation column.
+
+The migration is fully reversible and safe to run on a fresh database or any
+database where these tables already exist without lifecycle columns.
+
+## Test coverage
+
+`backend/tests/Feature/Migrations/LibraryLifecycleColumnsTest.php` —
+`test_all_analyses_tables_have_lifecycle_columns()` written RED before the
+migration existed (TDD), then turned GREEN after the migration was applied.

--- a/docs/lineage/modules/2026-05-13-library-lifecycle-columns-cohort-definitions.md
+++ b/docs/lineage/modules/2026-05-13-library-lifecycle-columns-cohort-definitions.md
@@ -1,0 +1,50 @@
+---
+doc_type: lineage
+status: historical
+date: 2026-05-13
+owner: acumenus
+module: studies
+lineage_anchor: true
+supersedes: []
+superseded_by: null
+related_code:
+  - backend/database/migrations/2026_05_13_190002_add_library_lifecycle_columns_to_cohort_definitions.php
+related_prs: []
+---
+# 2026-05-13 — Library lifecycle columns on cohort_definitions (Phase A, Task A3)
+
+Part of the publish-library-phase-1 feature branch. Adds four columns to
+`app.cohort_definitions` to support the cohort library lifecycle workflow,
+mirroring the same schema added to `app.concept_sets` in Task A2.
+
+## Schema — `app.cohort_definitions` (additive)
+
+`backend/database/migrations/2026_05_13_190002_add_library_lifecycle_columns_to_cohort_definitions.php`
+
+| Column | Type | Default | Notes |
+|---|---|---|---|
+| `status` | `varchar(16)` | `'active'` | Indexed. Values from `LibraryStatus` enum: draft, active, archived |
+| `archived_at` | `timestamp` | `null` | Set when status transitions to archived |
+| `archived_by` | `bigint` | `null` | FK → `app.users(id)` ON DELETE SET NULL |
+| `promoted_at` | `timestamp` | `null` | Set when a draft is promoted to active |
+
+The migration also folds any existing `deprecated_at` rows into the new
+`archived` status by copying `deprecated_at` → `archived_at` and setting
+`status = 'archived'` for all rows where `deprecated_at IS NOT NULL`. The fold
+is guarded by `Schema::hasColumn` so it is safe to run on databases where the
+prior deprecation migration (`2026_04_10_210853`) was never applied. The
+`deprecated_at` column itself is not dropped here; that cleanup belongs to a
+separate squash migration once all consumers are migrated.
+
+The migration is fully reversible: `down()` drops the FK constraint before
+dropping the four new columns. It does NOT attempt to reverse the data fold,
+as un-folding would require knowing which rows were folded versus originally
+archived — that detail is not preserved and is unnecessary given the `down()`
+path is only used in test teardown.
+
+## Test coverage
+
+`backend/tests/Feature/Migrations/LibraryLifecycleColumnsTest.php` — schema
+presence assertion written RED before the migration existed (TDD). The data-fold
+path is verified via the Task D8 backfill command which runs against real data
+with known `deprecated_at` values.

--- a/docs/lineage/modules/2026-05-13-library-lifecycle-columns-concept-sets.md
+++ b/docs/lineage/modules/2026-05-13-library-lifecycle-columns-concept-sets.md
@@ -1,0 +1,37 @@
+---
+doc_type: lineage
+status: historical
+date: 2026-05-13
+owner: acumenus
+module: studies
+lineage_anchor: true
+supersedes: []
+superseded_by: null
+related_code:
+  - backend/database/migrations/2026_05_13_190001_add_library_lifecycle_columns_to_concept_sets.php
+related_prs: []
+---
+# 2026-05-13 — Library lifecycle columns on concept_sets (Phase A, Task A2)
+
+Part of the publish-library-phase-1 feature branch. Adds four columns to
+`app.concept_sets` to support the concept-set library lifecycle workflow:
+
+## Schema — `app.concept_sets` (additive)
+
+`backend/database/migrations/2026_05_13_190001_add_library_lifecycle_columns_to_concept_sets.php`
+
+| Column | Type | Default | Notes |
+|---|---|---|---|
+| `status` | `varchar(16)` | `'active'` | Indexed. Values from `LibraryStatus` enum: draft, active, archived |
+| `archived_at` | `timestamp` | `null` | Set when status transitions to archived |
+| `archived_by` | `bigint` | `null` | FK → `app.users(id)` ON DELETE SET NULL |
+| `promoted_at` | `timestamp` | `null` | Set when a draft is promoted to active |
+
+The migration is fully reversible: `down()` drops the FK constraint before
+dropping the columns.
+
+## Test coverage
+
+`backend/tests/Feature/Migrations/LibraryLifecycleColumnsTest.php` — two
+assertions: schema presence and status default value. Written RED before the
+migration existed (TDD).

--- a/docs/superpowers/plans/2026-05-13-library-lifecycle.md
+++ b/docs/superpowers/plans/2026-05-13-library-lifecycle.md
@@ -1,3 +1,9 @@
+---
+doc_type: plan
+status: active
+date: 2026-05-13
+---
+
 # Library Lifecycle Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/2026-05-13-publish-library.md
+++ b/docs/superpowers/plans/2026-05-13-publish-library.md
@@ -1,3 +1,9 @@
+---
+doc_type: plan
+status: active
+date: 2026-05-13
+---
+
 # Pre-Publication Library Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/specs/2026-05-13-library-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-05-13-library-lifecycle-design.md
@@ -1,3 +1,9 @@
+---
+doc_type: spec
+status: active
+date: 2026-05-13
+---
+
 # Library Lifecycle — Concept Sets, Cohort Definitions, Analyses
 
 **Date:** 2026-05-13

--- a/docs/superpowers/specs/2026-05-13-publish-library-design.md
+++ b/docs/superpowers/specs/2026-05-13-publish-library-design.md
@@ -1,3 +1,9 @@
+---
+doc_type: spec
+status: active
+date: 2026-05-13
+---
+
 # Pre-Publication Library — Design Spec
 
 **Date:** 2026-05-13

--- a/e2e/tests/publish-library/phase1-lifecycle.spec.ts
+++ b/e2e/tests/publish-library/phase1-lifecycle.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+import { BASE, dismissModals } from "../helpers";
+
+test.describe("Publish Library — Phase 1 lifecycle", () => {
+  test("redirects /publish to /publish/library and shows the library", async ({ page }) => {
+    await page.goto(`${BASE}/publish`);
+    await dismissModals(page);
+    await expect(page).toHaveURL(/\/publish\/library/);
+    await expect(
+      page.getByRole("heading", { name: /Pre-Publication Library/i }),
+    ).toBeVisible();
+  });
+
+  test("New Document CTA navigates to /publish/library/new", async ({ page }) => {
+    await page.goto(`${BASE}/publish/library`);
+    await dismissModals(page);
+
+    // The "New Document" button appears in the header (always present),
+    // OR the empty-state CTA "Start a New Document" (when no drafts exist).
+    const newDoc = page.getByRole("link", {
+      name: /^(New Document|Start a New Document)$/i,
+    });
+    await expect(newDoc.first()).toBeVisible();
+    await newDoc.first().click({ force: true });
+    await expect(page).toHaveURL(/\/publish\/library\/new/);
+
+    // Step 1 of the wizard should render — confirm the step indicator is mounted.
+    await expect(page.locator('[data-testid="step-indicator"]')).toBeVisible();
+  });
+
+  test("save-as-draft round trip preserves draft and step", async ({ page }) => {
+    await page.goto(`${BASE}/publish/library/new`);
+    await dismissModals(page);
+
+    // The Save Draft button shows "Save as Draft" before a draft exists.
+    const saveBtn = page.getByRole("button", { name: /Save as Draft/i });
+    await expect(saveBtn).toBeVisible();
+    await saveBtn.click({ force: true });
+
+    // After save, URL becomes /publish/library/:id (router replaces history entry).
+    await expect(page).toHaveURL(/\/publish\/library\/\d+/, { timeout: 15_000 });
+
+    // Save button label switches to "Save Draft" (no longer "Save as Draft").
+    await expect(
+      page.getByRole("button", { name: /^(Save Draft|Saving…)$/i }),
+    ).toBeVisible();
+
+    // Capture the draft id from URL.
+    const url = page.url();
+    const match = url.match(/\/publish\/library\/(\d+)/);
+    expect(match).not.toBeNull();
+    const draftId = match![1];
+
+    // Navigate to library and confirm the new draft appears.
+    await page.goto(`${BASE}/publish/library`);
+    await dismissModals(page);
+    // Default title for a wizard saved without a custom title is "Untitled manuscript".
+    await expect(page.getByText(/Untitled manuscript/i).first()).toBeVisible();
+
+    // Reopen the draft and confirm step indicator + URL match.
+    await page.goto(`${BASE}/publish/library/${draftId}`);
+    await dismissModals(page);
+    await expect(page).toHaveURL(new RegExp(`/publish/library/${draftId}$`));
+    await expect(page.locator('[data-testid="step-indicator"]')).toBeVisible();
+  });
+});

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -530,10 +530,33 @@ export const router = createBrowserRouter(
       },
       {
         path: "publish",
-        lazy: () =>
-          import("@/features/publish/pages/PublishPage").then((m) => ({
-            Component: m.default,
-          })),
+        children: [
+          {
+            index: true,
+            element: <Navigate to="/publish/library" replace />,
+          },
+          {
+            path: "library",
+            lazy: () =>
+              import("@/features/publish/pages/PublicationLibraryPage").then(
+                (m) => ({ Component: m.default }),
+              ),
+          },
+          {
+            path: "library/new",
+            lazy: () =>
+              import("@/features/publish/pages/PublishPage").then((m) => ({
+                Component: m.default,
+              })),
+          },
+          {
+            path: "library/:draftId",
+            lazy: () =>
+              import("@/features/publish/pages/PublishPage").then((m) => ({
+                Component: m.default,
+              })),
+          },
+        ],
       },
       {
         path: "profiles",

--- a/frontend/src/features/publish/components/DocumentPreview.tsx
+++ b/frontend/src/features/publish/components/DocumentPreview.tsx
@@ -173,7 +173,12 @@ export default function DocumentPreview({
           {numberedSections.map(({ section, figureNumber, tableNumber }) => {
             if (section.type === "diagram" && section.diagramType && figureNumber) {
               return (
-                <div key={section.id} id={`diagram-${section.id}`} className="mb-8">
+                <div
+                  key={section.id}
+                  id={`diagram-${section.id}`}
+                  data-section-id={section.id}
+                  className="mb-8"
+                >
                   <DiagramWrapper
                     title={section.title}
                     caption={section.caption}
@@ -192,7 +197,11 @@ export default function DocumentPreview({
               const hasDiagram = section.diagramIncluded !== false && section.diagramType;
 
               return (
-                <div key={section.id} className="mb-8">
+                <div
+                  key={section.id}
+                  data-section-id={section.id}
+                  className="mb-8"
+                >
                   <h2
                     className="mb-3 font-bold text-gray-900"
                     style={{ fontSize: "14pt" }}
@@ -249,7 +258,11 @@ export default function DocumentPreview({
 
             // Text sections: methods, discussion, introduction
             return (
-              <div key={section.id} className="mb-8">
+              <div
+                key={section.id}
+                data-section-id={section.id}
+                className="mb-8"
+              >
                 <h2
                   className="mb-3 font-bold text-gray-900"
                   style={{ fontSize: "14pt" }}

--- a/frontend/src/features/publish/components/PublishPage/HybridPromptModal.tsx
+++ b/frontend/src/features/publish/components/PublishPage/HybridPromptModal.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+
+interface HybridPromptModalProps {
+  open: boolean;
+  defaultTitle: string;
+  onSave: (title: string) => Promise<void>;
+  onContinueWithoutSaving: () => void;
+}
+
+export function HybridPromptModal({ open, defaultTitle, onSave, onContinueWithoutSaving }: HybridPromptModalProps) {
+  const [title, setTitle] = useState(defaultTitle);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!open) return null;
+
+  const handleSave = async () => {
+    if (!title.trim()) return;
+    setSubmitting(true);
+    try {
+      await onSave(title.trim());
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-md rounded-xl border border-border-default bg-surface-raised p-6">
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-text-primary">Save as draft?</h2>
+            <p className="mt-1 text-sm text-text-primary/60">
+              Saving lets you return to this manuscript later. You can also continue without saving — work persists for this session only.
+            </p>
+          </div>
+          <button type="button" aria-label="Close" onClick={onContinueWithoutSaving} className="text-text-ghost hover:text-text-primary">
+            <X size={18} />
+          </button>
+        </div>
+        <label className="mt-4 block text-xs font-medium text-text-primary/70">
+          Title
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Untitled manuscript"
+            className="mt-1 w-full rounded-md border border-border-default bg-surface-base px-3 py-2 text-sm text-text-primary focus:border-accent focus:outline-none"
+          />
+        </label>
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onContinueWithoutSaving}
+            className="rounded-md px-3 py-1.5 text-sm text-text-primary/70 hover:text-text-primary"
+          >
+            Continue without saving
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!title.trim() || submitting}
+            className="rounded-md bg-accent px-4 py-1.5 text-sm font-medium text-surface-base hover:bg-accent/90 disabled:opacity-50"
+          >
+            {submitting ? "Saving…" : "Save as draft"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/publish/components/__tests__/PublishPage.test.tsx
+++ b/frontend/src/features/publish/components/__tests__/PublishPage.test.tsx
@@ -181,6 +181,23 @@ vi.mock("../../api/publishApi", () => ({
   exportAsPdf: vi.fn(),
   exportAsImageBundle: vi.fn(),
   exportPlaceholder: vi.fn(),
+  // Publication-draft API surface (Phase 1 library work)
+  fetchPublicationDrafts: vi.fn(async () => []),
+  fetchPublicationDraft: vi.fn(async () => null),
+  createPublicationDraft: vi.fn(async (input: unknown) => ({
+    id: 1,
+    user_id: 1,
+    study_id: null,
+    title: (input as { title?: string }).title ?? "Untitled",
+    template: (input as { template?: string }).template ?? "generic-ohdsi",
+    document_json: (input as { document_json: unknown }).document_json,
+    status: "draft",
+    last_opened_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  })),
+  updatePublicationDraft: vi.fn(async () => null),
+  deletePublicationDraft: vi.fn(async () => undefined),
 }));
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/features/publish/components/library/DraftCard.tsx
+++ b/frontend/src/features/publish/components/library/DraftCard.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { MoreHorizontal, Calendar, FileText } from "lucide-react";
+import type { PublicationDraft } from "../../types/publish";
+
+interface DraftCardProps {
+  draft: PublicationDraft;
+  onArchive: (id: number) => void;
+  onDelete: (id: number) => void;
+  onDuplicate: (id: number) => void;
+  onRename: (id: number) => void;
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return "never";
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function statusClass(status: string): string {
+  switch (status) {
+    case "ready":
+      return "bg-accent/15 text-accent";
+    case "archived":
+      return "bg-surface-elevated text-text-primary/30";
+    default:
+      return "bg-surface-elevated text-text-primary/70";
+  }
+}
+
+export function DraftCard({ draft, onArchive, onDelete, onDuplicate, onRename }: DraftCardProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const sections = draft.document_json?.sections ?? [];
+  const tableCount = sections.filter((s) => s.tableIncluded).length;
+  const figureCount = sections.filter((s) => s.diagramIncluded).length;
+
+  return (
+    <div className="relative rounded-xl border border-border-default bg-surface-raised p-4 hover:border-accent/40 transition-colors">
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <Link
+          to={`/publish/library/${draft.id}`}
+          aria-label={`Open draft ${draft.title}`}
+          className="text-base font-semibold text-text-primary line-clamp-2 hover:text-accent"
+        >
+          {draft.title}
+        </Link>
+        <button
+          type="button"
+          aria-label="More actions"
+          className="text-text-ghost hover:text-text-primary"
+          onClick={() => setMenuOpen((v) => !v)}
+        >
+          <MoreHorizontal size={18} />
+        </button>
+        {menuOpen && (
+          <ul
+            role="menu"
+            className="absolute right-2 top-9 z-10 min-w-32 rounded-md border border-border-default bg-surface-elevated py-1 text-sm shadow-lg"
+            onMouseLeave={() => setMenuOpen(false)}
+          >
+            <li
+              role="menuitem"
+              className="cursor-pointer px-3 py-1.5 hover:bg-surface-raised"
+              onClick={() => {
+                onRename(draft.id);
+                setMenuOpen(false);
+              }}
+            >
+              Rename
+            </li>
+            <li
+              role="menuitem"
+              className="cursor-pointer px-3 py-1.5 hover:bg-surface-raised"
+              onClick={() => {
+                onDuplicate(draft.id);
+                setMenuOpen(false);
+              }}
+            >
+              Duplicate
+            </li>
+            <li
+              role="menuitem"
+              className="cursor-pointer px-3 py-1.5 hover:bg-surface-raised"
+              onClick={() => {
+                onArchive(draft.id);
+                setMenuOpen(false);
+              }}
+            >
+              Archive
+            </li>
+            <li
+              role="menuitem"
+              className="cursor-pointer px-3 py-1.5 text-danger hover:bg-surface-raised"
+              onClick={() => {
+                onDelete(draft.id);
+                setMenuOpen(false);
+              }}
+            >
+              Delete
+            </li>
+          </ul>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-2 text-xs text-text-primary/60">
+        <span className="rounded-full bg-surface-elevated px-2 py-0.5">{draft.template}</span>
+        <span className={`rounded-full px-2 py-0.5 ${statusClass(draft.status)}`}>{draft.status}</span>
+      </div>
+      <div className="mt-3 flex items-center gap-3 text-xs text-text-primary/50">
+        <span className="flex items-center gap-1">
+          <FileText size={12} />
+          {sections.length} sections · {tableCount} table{tableCount === 1 ? "" : "s"} · {figureCount} figure
+          {figureCount === 1 ? "" : "s"}
+        </span>
+      </div>
+      <div className="mt-1 flex items-center gap-1 text-xs text-text-ghost">
+        <Calendar size={12} />
+        opened {relativeTime(draft.last_opened_at)}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/publish/components/library/DraftCardGrid.tsx
+++ b/frontend/src/features/publish/components/library/DraftCardGrid.tsx
@@ -1,0 +1,56 @@
+import { FileOutput } from "lucide-react";
+import { Link } from "react-router-dom";
+import type { PublicationDraft } from "../../types/publish";
+import { DraftCard } from "./DraftCard";
+
+interface DraftCardGridProps {
+  drafts: PublicationDraft[];
+  isLoading: boolean;
+  onArchive: (id: number) => void;
+  onDelete: (id: number) => void;
+  onDuplicate: (id: number) => void;
+  onRename: (id: number) => void;
+}
+
+export function DraftCardGrid({ drafts, isLoading, onArchive, onDelete, onDuplicate, onRename }: DraftCardGridProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" aria-busy="true">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-32 rounded-xl border border-border-default bg-surface-raised animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (drafts.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border-default bg-surface-base py-16 text-center">
+        <FileOutput size={32} className="text-text-ghost mb-3" />
+        <h2 className="text-lg font-semibold text-text-primary">No drafts yet</h2>
+        <p className="mt-1 text-sm text-text-primary/60">Start a new document to begin a manuscript draft.</p>
+        <Link
+          to="/publish/library/new"
+          className="mt-4 rounded-md bg-accent px-4 py-2 text-sm font-medium text-surface-base hover:bg-accent/90"
+        >
+          Start a New Document
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {drafts.map((draft) => (
+        <DraftCard
+          key={draft.id}
+          draft={draft}
+          onArchive={onArchive}
+          onDelete={onDelete}
+          onDuplicate={onDuplicate}
+          onRename={onRename}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/publish/components/library/DraftFilters.tsx
+++ b/frontend/src/features/publish/components/library/DraftFilters.tsx
@@ -1,0 +1,53 @@
+import { Search } from "lucide-react";
+import type { PublicationDraftStatus } from "../../types/publish";
+
+export type DraftSort = "last_opened" | "last_updated" | "title" | "created";
+
+interface DraftFiltersProps {
+  search: string;
+  onSearchChange: (v: string) => void;
+  status: PublicationDraftStatus | "all";
+  onStatusChange: (v: PublicationDraftStatus | "all") => void;
+  sort: DraftSort;
+  onSortChange: (v: DraftSort) => void;
+}
+
+export function DraftFilters({ search, onSearchChange, status, onStatusChange, sort, onSortChange }: DraftFiltersProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <div className="relative">
+        <Search size={14} className="absolute left-2 top-1/2 -translate-y-1/2 text-text-ghost" />
+        <input
+          type="search"
+          placeholder="Search drafts…"
+          aria-label="Search drafts"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="w-60 rounded-md border border-border-default bg-surface-raised pl-7 pr-2 py-1.5 text-sm text-text-primary focus:border-accent focus:outline-none"
+        />
+      </div>
+      <select
+        aria-label="Status filter"
+        value={status}
+        onChange={(e) => onStatusChange(e.target.value as PublicationDraftStatus | "all")}
+        className="rounded-md border border-border-default bg-surface-raised px-2 py-1.5 text-sm text-text-primary"
+      >
+        <option value="all">All (except archived)</option>
+        <option value="draft">Drafts</option>
+        <option value="ready">Ready</option>
+        <option value="archived">Archived</option>
+      </select>
+      <select
+        aria-label="Sort by"
+        value={sort}
+        onChange={(e) => onSortChange(e.target.value as DraftSort)}
+        className="rounded-md border border-border-default bg-surface-raised px-2 py-1.5 text-sm text-text-primary"
+      >
+        <option value="last_opened">Recently opened</option>
+        <option value="last_updated">Recently edited</option>
+        <option value="title">Title (A–Z)</option>
+        <option value="created">Date created</option>
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/features/publish/components/library/NewDraftButton.tsx
+++ b/frontend/src/features/publish/components/library/NewDraftButton.tsx
@@ -1,0 +1,13 @@
+import { Plus } from "lucide-react";
+import { Link } from "react-router-dom";
+
+export function NewDraftButton() {
+  return (
+    <Link
+      to="/publish/library/new"
+      className="inline-flex items-center gap-2 rounded-md bg-accent px-4 py-2 text-sm font-medium text-surface-base hover:bg-accent/90"
+    >
+      <Plus size={16} />New Document
+    </Link>
+  );
+}

--- a/frontend/src/features/publish/components/library/SaveDraftButton.tsx
+++ b/frontend/src/features/publish/components/library/SaveDraftButton.tsx
@@ -1,0 +1,20 @@
+import { Save } from "lucide-react";
+
+interface SaveDraftButtonProps {
+  hasDraftId: boolean;
+  saving: boolean;
+  onSave: () => void;
+}
+
+export function SaveDraftButton({ hasDraftId, saving, onSave }: SaveDraftButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSave}
+      disabled={saving}
+      className="inline-flex items-center gap-1 rounded-md border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-medium text-accent hover:bg-accent/15 disabled:opacity-50"
+    >
+      <Save size={12} />{saving ? "Saving…" : hasDraftId ? "Save Draft" : "Save as Draft"}
+    </button>
+  );
+}

--- a/frontend/src/features/publish/components/library/SessionStorageMigrationBanner.tsx
+++ b/frontend/src/features/publish/components/library/SessionStorageMigrationBanner.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Save, X } from "lucide-react";
+import { useCreateDraft } from "../../hooks/useDrafts";
+import type { DocumentJson } from "../../types/publish";
+
+const SESSION_KEY = "parthenon:publish-wizard";
+const DISMISS_KEY = "parthenon:publish-wizard-migration-dismissed";
+
+interface OrphanedState {
+  title?: string;
+  authors?: string[];
+  template?: string;
+  step?: number;
+  selectedExecutions?: unknown[];
+  sections?: unknown[];
+}
+
+function loadOrphan(): OrphanedState | null {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as OrphanedState;
+    const sectionCount = (parsed.sections ?? []).length;
+    const execCount = (parsed.selectedExecutions ?? []).length;
+    if (sectionCount === 0 && execCount === 0) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function SessionStorageMigrationBanner() {
+  const [orphan, setOrphan] = useState<OrphanedState | null>(() => {
+    if (typeof window === "undefined") return null;
+    if (sessionStorage.getItem(DISMISS_KEY)) return null;
+    return loadOrphan();
+  });
+  const createDraft = useCreateDraft();
+  const navigate = useNavigate();
+
+  if (!orphan) return null;
+
+  const handleSave = () => {
+    const document_json: DocumentJson = {
+      version: 1,
+      title: orphan.title ?? "Recovered Draft",
+      authors: orphan.authors ?? [],
+      template: orphan.template ?? "generic-ohdsi",
+      step: ([1, 2, 3, 4] as const).includes(orphan.step as 1 | 2 | 3 | 4) ? (orphan.step as 1 | 2 | 3 | 4) : 1,
+      selectedExecutions: (orphan.selectedExecutions ?? []) as DocumentJson["selectedExecutions"],
+      sections: (orphan.sections ?? []) as DocumentJson["sections"],
+    };
+    createDraft.mutate(
+      { title: document_json.title, template: document_json.template, document_json },
+      {
+        onSuccess: (draft) => {
+          sessionStorage.removeItem(SESSION_KEY);
+          sessionStorage.setItem(DISMISS_KEY, "1");
+          navigate(`/publish/library/${draft.id}`);
+        },
+      },
+    );
+  };
+
+  const handleDismiss = () => {
+    sessionStorage.setItem(DISMISS_KEY, "1");
+    setOrphan(null);
+  };
+
+  return (
+    <div className="rounded-md border border-accent/40 bg-accent/5 px-4 py-3 flex items-center justify-between">
+      <div className="text-sm text-text-primary">
+        We found unsaved work from a previous session ({(orphan.sections ?? []).length} sections, {(orphan.selectedExecutions ?? []).length} analyses).
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={createDraft.isPending}
+          className="inline-flex items-center gap-1 rounded-md bg-accent px-3 py-1 text-xs font-medium text-surface-base hover:bg-accent/90 disabled:opacity-50"
+        >
+          <Save size={12} />Save to library
+        </button>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss"
+          className="text-text-ghost hover:text-text-primary"
+        >
+          <X size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/publish/components/library/__tests__/DraftCard.test.tsx
+++ b/frontend/src/features/publish/components/library/__tests__/DraftCard.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { DraftCard } from "../DraftCard";
+import type { PublicationDraft } from "../../../types/publish";
+
+const draft: PublicationDraft = {
+  id: 7,
+  user_id: 1,
+  study_id: 42,
+  title: "Hypertension Cohort Analysis",
+  template: "generic-ohdsi",
+  document_json: {
+    version: 1,
+    title: "Hypertension Cohort Analysis",
+    authors: [],
+    template: "generic-ohdsi",
+    step: 2,
+    selectedExecutions: [],
+    sections: [
+      { id: "1", type: "results", title: "x", content: "", included: true, tableIncluded: true },
+      { id: "2", type: "results", title: "y", content: "", included: true, diagramIncluded: true },
+    ],
+  },
+  status: "draft",
+  last_opened_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+describe("DraftCard", () => {
+  it("renders the title, template, and section counts", () => {
+    render(
+      <MemoryRouter>
+        <DraftCard draft={draft} onArchive={vi.fn()} onDelete={vi.fn()} onDuplicate={vi.fn()} onRename={vi.fn()} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/Hypertension Cohort Analysis/i)).toBeInTheDocument();
+    expect(screen.getByText(/generic-ohdsi/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 sections/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 table/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 figure/i)).toBeInTheDocument();
+  });
+
+  it("links to /publish/library/:id", () => {
+    render(
+      <MemoryRouter>
+        <DraftCard draft={draft} onArchive={vi.fn()} onDelete={vi.fn()} onDuplicate={vi.fn()} onRename={vi.fn()} />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole("link", { name: /Open draft/i });
+    expect(link.getAttribute("href")).toBe("/publish/library/7");
+  });
+
+  it("fires onArchive when archive menu item clicked", () => {
+    const onArchive = vi.fn();
+    render(
+      <MemoryRouter>
+        <DraftCard draft={draft} onArchive={onArchive} onDelete={vi.fn()} onDuplicate={vi.fn()} onRename={vi.fn()} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByLabelText(/More actions/i));
+    fireEvent.click(screen.getByText(/Archive/i));
+    expect(onArchive).toHaveBeenCalledWith(7);
+  });
+});

--- a/frontend/src/features/publish/hooks/useDrafts.ts
+++ b/frontend/src/features/publish/hooks/useDrafts.ts
@@ -1,0 +1,84 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  createPublicationDraft,
+  deletePublicationDraft,
+  fetchPublicationDraft,
+  fetchPublicationDrafts,
+  updatePublicationDraft,
+} from "../api/publishApi";
+import type {
+  PublicationDraft,
+  PublicationDraftInput,
+} from "../types/publish";
+
+const KEYS = {
+  list: ["publish", "drafts"] as const,
+  detail: (id: number) => ["publish", "drafts", id] as const,
+};
+
+export function useDraftList() {
+  return useQuery<PublicationDraft[]>({
+    queryKey: KEYS.list,
+    queryFn: fetchPublicationDrafts,
+  });
+}
+
+export function useDraft(draftId: number | null) {
+  return useQuery<PublicationDraft>({
+    queryKey: draftId !== null ? KEYS.detail(draftId) : ["publish", "drafts", "noop"],
+    queryFn: () => fetchPublicationDraft(draftId as number),
+    enabled: draftId !== null,
+  });
+}
+
+export function useCreateDraft() {
+  const qc = useQueryClient();
+  return useMutation<PublicationDraft, Error, PublicationDraftInput>({
+    mutationFn: createPublicationDraft,
+    onSuccess: (draft) => {
+      qc.invalidateQueries({ queryKey: KEYS.list });
+      qc.setQueryData(KEYS.detail(draft.id), draft);
+    },
+  });
+}
+
+export function useUpdateDraft(draftId: number) {
+  const qc = useQueryClient();
+  return useMutation<PublicationDraft, Error, Partial<PublicationDraftInput>>({
+    mutationFn: (payload) => updatePublicationDraft(draftId, payload),
+    onSuccess: (draft) => {
+      qc.invalidateQueries({ queryKey: KEYS.list });
+      qc.setQueryData(KEYS.detail(draft.id), draft);
+    },
+  });
+}
+
+export function useUpdateDraftById() {
+  const qc = useQueryClient();
+  return useMutation<
+    PublicationDraft,
+    Error,
+    { id: number; payload: Partial<PublicationDraftInput> }
+  >({
+    mutationFn: ({ id, payload }) => updatePublicationDraft(id, payload),
+    onSuccess: (draft) => {
+      qc.invalidateQueries({ queryKey: KEYS.list });
+      qc.setQueryData(KEYS.detail(draft.id), draft);
+    },
+  });
+}
+
+export function useDeleteDraft() {
+  const qc = useQueryClient();
+  return useMutation<void, Error, number>({
+    mutationFn: deletePublicationDraft,
+    onSuccess: (_void, id) => {
+      qc.invalidateQueries({ queryKey: KEYS.list });
+      qc.removeQueries({ queryKey: KEYS.detail(id) });
+    },
+  });
+}

--- a/frontend/src/features/publish/lib/__tests__/draftSerialization.test.ts
+++ b/frontend/src/features/publish/lib/__tests__/draftSerialization.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  serializeForSave,
+  deserializeFromLoad,
+} from "../draftSerialization";
+import type { DocumentJson } from "../../types/publish";
+
+describe("draftSerialization", () => {
+  it("strips resultJson from selectedExecutions on serialize", () => {
+    const state = {
+      title: "T",
+      authors: ["A"],
+      template: "generic-ohdsi",
+      step: 2 as const,
+      selectedExecutions: [
+        {
+          studyId: 1,
+          analysisId: 2,
+          executionId: 3,
+          analysisType: "characterization",
+          resultJson: { huge: "blob" },
+          designJson: { k: "v" },
+        },
+      ],
+      sections: [],
+    };
+    const doc = serializeForSave(state);
+    expect(doc.version).toBe(1);
+    expect(doc.selectedExecutions[0]).not.toHaveProperty("resultJson");
+    expect(doc.selectedExecutions[0].designJson).toEqual({ k: "v" });
+  });
+
+  it("round-trips through deserialize", () => {
+    const doc: DocumentJson = {
+      version: 1,
+      title: "T",
+      authors: ["A"],
+      template: "generic-ohdsi",
+      step: 3,
+      selectedExecutions: [
+        { studyId: 1, analysisId: 2, executionId: 3, analysisType: "characterization" },
+      ],
+      sections: [
+        {
+          id: "s1",
+          type: "results",
+          title: "Results",
+          content: "narrative",
+          included: true,
+          tableData: { headers: ["A"], rows: [{ A: 1 }] },
+          svgMarkup: "<svg/>",
+        },
+      ],
+    };
+    const state = deserializeFromLoad(doc);
+    expect(state.title).toBe("T");
+    expect(state.step).toBe(3);
+    expect(state.sections[0].svgMarkup).toBe("<svg/>");
+    expect(state.sections[0].tableData?.rows[0].A).toBe(1);
+  });
+
+  it("coerces unknown step values to 1 (forward-compat)", () => {
+    const doc = { version: 1, title: "T", authors: [], template: "x", step: 99, selectedExecutions: [], sections: [] } as unknown as DocumentJson;
+    const state = deserializeFromLoad(doc);
+    expect(state.step).toBe(1);
+  });
+});

--- a/frontend/src/features/publish/lib/__tests__/snapshotCapture.test.ts
+++ b/frontend/src/features/publish/lib/__tests__/snapshotCapture.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { captureSnapshots } from "../snapshotCapture";
+import type { DraftSection } from "../../types/publish";
+
+describe("captureSnapshots", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("captures SVG markup from a section's diagram container", () => {
+    const container = document.createElement("div");
+    container.setAttribute("data-section-id", "results-1");
+    container.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>';
+    document.body.appendChild(container);
+
+    const sections: DraftSection[] = [
+      {
+        id: "results-1",
+        type: "results",
+        title: "Results",
+        content: "",
+        included: true,
+        diagramIncluded: true,
+        diagramType: "kaplan-meier",
+      },
+    ];
+    const captured = captureSnapshots(sections);
+    expect(captured[0].svgMarkup).toContain("<svg");
+    expect(captured[0].svgMarkup).toContain("<rect");
+  });
+
+  it("preserves existing svgMarkup if no DOM element is found", () => {
+    const sections: DraftSection[] = [
+      {
+        id: "missing",
+        type: "results",
+        title: "x",
+        content: "",
+        included: true,
+        diagramIncluded: true,
+        diagramType: "kaplan-meier",
+        svgMarkup: "<svg>previously frozen</svg>",
+      },
+    ];
+    const captured = captureSnapshots(sections);
+    expect(captured[0].svgMarkup).toBe("<svg>previously frozen</svg>");
+  });
+
+  it("leaves sections without diagrams untouched", () => {
+    const sections: DraftSection[] = [
+      { id: "intro", type: "introduction", title: "I", content: "x", included: true },
+    ];
+    const captured = captureSnapshots(sections);
+    expect(captured[0].svgMarkup).toBeUndefined();
+    expect(captured[0]).toEqual(sections[0]);
+  });
+
+  it("does not mutate input sections", () => {
+    const sections: DraftSection[] = [
+      { id: "x", type: "results", title: "x", content: "", included: true, diagramIncluded: true },
+    ];
+    captureSnapshots(sections);
+    expect(sections[0].svgMarkup).toBeUndefined();
+  });
+});

--- a/frontend/src/features/publish/lib/draftSerialization.ts
+++ b/frontend/src/features/publish/lib/draftSerialization.ts
@@ -1,0 +1,45 @@
+import type {
+  DocumentJson,
+  DraftSection,
+  DraftSelectedExecution,
+} from "../types/publish";
+
+export interface WizardSerializableState {
+  title: string;
+  authors: string[];
+  template: string;
+  step: 1 | 2 | 3 | 4;
+  selectedExecutions: Array<DraftSelectedExecution & { resultJson?: unknown }>;
+  sections: DraftSection[];
+}
+
+export function serializeForSave(state: WizardSerializableState): DocumentJson {
+  return {
+    version: 1,
+    title: state.title,
+    authors: state.authors,
+    template: state.template,
+    step: state.step,
+    selectedExecutions: state.selectedExecutions.map((exec) => {
+      // Drop resultJson — never persisted.
+      const { resultJson: _drop, ...rest } = exec;
+      return rest;
+    }),
+    sections: state.sections,
+  };
+}
+
+export function deserializeFromLoad(doc: DocumentJson): WizardSerializableState {
+  const validSteps = [1, 2, 3, 4] as const;
+  const step = (validSteps as readonly number[]).includes(doc.step)
+    ? doc.step
+    : 1;
+  return {
+    title: doc.title ?? "",
+    authors: doc.authors ?? [],
+    template: doc.template ?? "generic-ohdsi",
+    step: step as 1 | 2 | 3 | 4,
+    selectedExecutions: doc.selectedExecutions ?? [],
+    sections: doc.sections ?? [],
+  };
+}

--- a/frontend/src/features/publish/lib/snapshotCapture.ts
+++ b/frontend/src/features/publish/lib/snapshotCapture.ts
@@ -1,0 +1,18 @@
+import type { DraftSection } from "../types/publish";
+
+function findSectionSvg(sectionId: string): string | undefined {
+  const container = document.querySelector(`[data-section-id="${sectionId}"]`);
+  if (!container) return undefined;
+  const svg = container.querySelector("svg");
+  if (!svg) return undefined;
+  return new XMLSerializer().serializeToString(svg);
+}
+
+export function captureSnapshots(sections: DraftSection[]): DraftSection[] {
+  return sections.map((section) => {
+    if (!section.diagramIncluded) return section;
+    const live = findSectionSvg(section.id);
+    if (live) return { ...section, svgMarkup: live };
+    return section; // preserve any prior frozen markup
+  });
+}

--- a/frontend/src/features/publish/pages/PublicationLibraryPage.tsx
+++ b/frontend/src/features/publish/pages/PublicationLibraryPage.tsx
@@ -1,0 +1,109 @@
+import { useMemo, useState } from "react";
+import { FileOutput } from "lucide-react";
+import { HelpButton } from "@/features/help";
+import {
+  useDeleteDraft,
+  useDraftList,
+  useUpdateDraftById,
+  useCreateDraft,
+} from "../hooks/useDrafts";
+import { DraftCardGrid } from "../components/library/DraftCardGrid";
+import { DraftFilters, type DraftSort } from "../components/library/DraftFilters";
+import { NewDraftButton } from "../components/library/NewDraftButton";
+import { SessionStorageMigrationBanner } from "../components/library/SessionStorageMigrationBanner";
+import type { PublicationDraft, PublicationDraftStatus } from "../types/publish";
+
+function sortDrafts(drafts: PublicationDraft[], by: DraftSort): PublicationDraft[] {
+  const copy = [...drafts];
+  switch (by) {
+    case "last_opened":
+      return copy.sort((a, b) => (b.last_opened_at ?? "").localeCompare(a.last_opened_at ?? ""));
+    case "last_updated":
+      return copy.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    case "title":
+      return copy.sort((a, b) => a.title.localeCompare(b.title));
+    case "created":
+      return copy.sort((a, b) => b.created_at.localeCompare(a.created_at));
+  }
+}
+
+export default function PublicationLibraryPage() {
+  const { data: drafts, isLoading } = useDraftList();
+  const update = useUpdateDraftById();
+  const deleteDraft = useDeleteDraft();
+  const createDraft = useCreateDraft();
+
+  const [search, setSearch] = useState("");
+  const [status, setStatus] = useState<PublicationDraftStatus | "all">("all");
+  const [sort, setSort] = useState<DraftSort>("last_opened");
+
+  const filtered = useMemo(() => {
+    const list = drafts ?? [];
+    return sortDrafts(
+      list
+        .filter((d) => (status === "all" ? d.status !== "archived" : d.status === status))
+        .filter((d) => (search ? d.title.toLowerCase().includes(search.toLowerCase()) : true)),
+      sort,
+    );
+  }, [drafts, status, sort, search]);
+
+  const handleArchive = (id: number) => update.mutate({ id, payload: { status: "archived" } });
+  const handleDelete = (id: number) => {
+    if (!confirm("Delete this draft permanently?")) return;
+    deleteDraft.mutate(id);
+  };
+  const handleDuplicate = (id: number) => {
+    const original = drafts?.find((d) => d.id === id);
+    if (!original) return;
+    createDraft.mutate({
+      title: `${original.title} (copy)`,
+      template: original.template,
+      study_id: original.study_id,
+      document_json: original.document_json,
+    });
+  };
+  const handleRename = (id: number) => {
+    const original = drafts?.find((d) => d.id === id);
+    const next = prompt("New title", original?.title);
+    if (!next) return;
+    update.mutate({ id, payload: { title: next } });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <FileOutput size={22} className="text-success" />
+          <div>
+            <h1 className="text-xl font-bold text-text-primary">Pre-Publication Library</h1>
+            <p className="text-sm text-text-primary/50">Your saved manuscript drafts.</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <HelpButton helpKey="publish" />
+          <NewDraftButton />
+        </div>
+      </div>
+
+      <SessionStorageMigrationBanner />
+
+      <DraftFilters
+        search={search}
+        onSearchChange={setSearch}
+        status={status}
+        onStatusChange={setStatus}
+        sort={sort}
+        onSortChange={setSort}
+      />
+
+      <DraftCardGrid
+        drafts={filtered}
+        isLoading={isLoading}
+        onArchive={handleArchive}
+        onDelete={handleDelete}
+        onDuplicate={handleDuplicate}
+        onRename={handleRename}
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/publish/pages/PublishPage.tsx
+++ b/frontend/src/features/publish/pages/PublishPage.tsx
@@ -2,8 +2,8 @@
 // PublishPage — 4-step publish & export wizard
 // ---------------------------------------------------------------------------
 
-import { useReducer, useCallback, useEffect } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useReducer, useCallback, useEffect, useRef, useState } from "react";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { FileOutput, Check } from "lucide-react";
 import { HelpButton } from "@/features/help";
 import { useTranslation } from "react-i18next";
@@ -12,10 +12,15 @@ import UnifiedAnalysisPicker from "../components/UnifiedAnalysisPicker";
 import DocumentConfigurator from "../components/DocumentConfigurator";
 import DocumentPreview from "../components/DocumentPreview";
 import ExportPanel from "../components/ExportPanel";
+import { HybridPromptModal } from "../components/PublishPage/HybridPromptModal";
+import { SaveDraftButton } from "../components/library/SaveDraftButton";
 import { useGenerateNarrative } from "../hooks/useNarrativeGeneration";
+import { useDraft, useCreateDraft, useUpdateDraftById } from "../hooks/useDrafts";
 import { buildTableFromResults } from "../lib/tableBuilders";
 import { buildDiagramData } from "../lib/diagramBuilders";
 import { getDiagramSvgMarkup } from "../lib/svgExport";
+import { captureSnapshots } from "../lib/snapshotCapture";
+import { serializeForSave, deserializeFromLoad } from "../lib/draftSerialization";
 import {
   getPublishResultSectionTitle,
   getPublishTemplateSectionTitle,
@@ -25,6 +30,7 @@ import type {
   ReportSection,
   SelectedExecution,
   NarrativeState,
+  DraftSection,
 } from "../types/publish";
 import { TEMPLATES } from "../templates/index";
 import type { TemplateSectionDef } from "../templates/index";
@@ -38,6 +44,7 @@ interface WizardState {
   title: string;
   authors: string[];
   template: string;
+  hasMeaningfulEdit: boolean;
 }
 
 type Action =
@@ -47,35 +54,49 @@ type Action =
   | { type: "SET_TITLE"; title: string }
   | { type: "SET_AUTHORS"; authors: string[] }
   | { type: "UPDATE_SECTION"; id: string; updates: Partial<ReportSection> }
-  | { type: "SET_TEMPLATE"; template: string };
+  | { type: "SET_TEMPLATE"; template: string }
+  | { type: "REHYDRATE"; state: WizardState };
 
 function wizardReducer(state: WizardState, action: Action): WizardState {
   switch (action.type) {
     case "SET_STEP":
       return { ...state, step: action.step };
     case "SET_SELECTIONS":
-      return { ...state, selectedExecutions: action.selections };
+      return {
+        ...state,
+        selectedExecutions: action.selections,
+        hasMeaningfulEdit:
+          state.hasMeaningfulEdit || action.selections.length > 0,
+      };
     case "SET_SECTIONS":
-      return { ...state, sections: action.sections };
+      return {
+        ...state,
+        sections: action.sections,
+        hasMeaningfulEdit: state.hasMeaningfulEdit || action.sections.length > 0,
+      };
     case "SET_TITLE":
-      return { ...state, title: action.title };
+      return { ...state, title: action.title, hasMeaningfulEdit: true };
     case "SET_AUTHORS":
-      return { ...state, authors: action.authors };
+      return { ...state, authors: action.authors, hasMeaningfulEdit: true };
     case "UPDATE_SECTION":
       return {
         ...state,
         sections: state.sections.map((s) =>
           s.id === action.id ? { ...s, ...action.updates } : s,
         ),
+        hasMeaningfulEdit: true,
       };
     case "SET_TEMPLATE":
-      return { ...state, template: action.template };
+      return { ...state, template: action.template, hasMeaningfulEdit: true };
+    case "REHYDRATE":
+      return { ...action.state, hasMeaningfulEdit: false };
     default:
       return state;
   }
 }
 
 const STORAGE_KEY = "parthenon:publish-wizard";
+const PROMPT_SHOWN_KEY = "parthenon:publish-prompt-shown";
 
 const defaultState: WizardState = {
   step: 1,
@@ -84,6 +105,7 @@ const defaultState: WizardState = {
   title: "",
   authors: [],
   template: "generic-ohdsi",
+  hasMeaningfulEdit: false,
 };
 
 function loadPersistedState(): WizardState {
@@ -93,7 +115,7 @@ function loadPersistedState(): WizardState {
       const parsed = JSON.parse(stored) as WizardState;
       // Validate shape
       if (parsed.step && parsed.sections && parsed.selectedExecutions) {
-        return parsed;
+        return { ...parsed, hasMeaningfulEdit: parsed.hasMeaningfulEdit ?? false };
       }
     }
   } catch {
@@ -287,12 +309,27 @@ function captureDiagramSvgMarkup(sections: ReportSection[]): ReportSection[] {
 
 export default function PublishPage() {
   const { t } = useTranslation("app");
+  const navigate = useNavigate();
+  const { draftId: draftIdParam } = useParams<{ draftId: string }>();
+  const draftId =
+    draftIdParam && /^\d+$/.test(draftIdParam) ? Number(draftIdParam) : null;
+
   const [searchParams] = useSearchParams();
   const initialStudyId = searchParams.get("studyId")
     ? Number(searchParams.get("studyId"))
     : undefined;
 
   const [state, dispatch] = useReducer(persistingReducer, undefined, loadPersistedState);
+
+  // Server-side draft hooks
+  const draftQuery = useDraft(draftId);
+  const createDraft = useCreateDraft();
+  const updateDraft = useUpdateDraftById();
+  const hydratedRef = useRef(false);
+
+  // Hybrid prompt state
+  const [promptOpen, setPromptOpen] = useState(false);
+
   const steps = [
     { num: 1 as const, label: t("publish.steps.selectAnalyses") },
     { num: 2 as const, label: t("publish.steps.configure") },
@@ -300,8 +337,30 @@ export default function PublishPage() {
     { num: 4 as const, label: t("publish.steps.export") },
   ];
 
-  // When navigating via ?studyId, reset if it's a different study than what's persisted
+  // ── Hydrate from server-side draft when :draftId is present ─────────────
   useEffect(() => {
+    if (draftId === null) return;
+    if (!draftQuery.data || hydratedRef.current) return;
+    const d = draftQuery.data;
+    const w = deserializeFromLoad(d.document_json);
+    dispatch({
+      type: "REHYDRATE",
+      state: {
+        step: w.step,
+        selectedExecutions: w.selectedExecutions as SelectedExecution[],
+        sections: w.sections as unknown as ReportSection[],
+        title: d.title,
+        authors: w.authors,
+        template: d.template,
+        hasMeaningfulEdit: false,
+      },
+    });
+    hydratedRef.current = true;
+  }, [draftId, draftQuery.data]);
+
+  // ── When navigating via ?studyId on a new (no-draftId) flow, reset ──────
+  useEffect(() => {
+    if (draftId !== null) return; // never reset when loading an explicit draft
     if (
       initialStudyId &&
       state.selectedExecutions.length > 0 &&
@@ -312,7 +371,22 @@ export default function PublishPage() {
       dispatch({ type: "SET_SECTIONS", sections: [] });
       dispatch({ type: "SET_STEP", step: 1 });
     }
-  }, [initialStudyId, state.selectedExecutions]);
+  }, [draftId, initialStudyId, state.selectedExecutions]);
+
+  // ── Hybrid prompt: show once on first meaningful edit (new draft only) ─
+  useEffect(() => {
+    if (draftId !== null) return;
+    if (
+      state.hasMeaningfulEdit &&
+      !promptOpen &&
+      !sessionStorage.getItem(PROMPT_SHOWN_KEY)
+    ) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot modal trigger from reducer-driven edit signal
+      setPromptOpen(true);
+      sessionStorage.setItem(PROMPT_SHOWN_KEY, "1");
+    }
+  }, [draftId, state.hasMeaningfulEdit, promptOpen]);
+
   const narrativeMutation = useGenerateNarrative();
 
   // ── Step 1 handlers ─────────────────────────────────────────────────────
@@ -445,6 +519,83 @@ export default function PublishPage() {
     dispatch({ type: "SET_STEP", step });
   }, []);
 
+  // ── Save helpers ────────────────────────────────────────────────────────
+  const buildDocumentJson = useCallback(() => {
+    // Capture live SVG markup first, then capture snapshots via DOM lookup.
+    // ReportSection and DraftSection share enough shape for the persistence
+    // layer (id, title, type, content, included, diagram/table fields) —
+    // documented cast.
+    const withSvg = captureDiagramSvgMarkup(state.sections);
+    const sectionsWithSnapshots = captureSnapshots(
+      withSvg as unknown as DraftSection[],
+    );
+    return serializeForSave({
+      title: state.title,
+      authors: state.authors,
+      template: state.template,
+      step: state.step,
+      selectedExecutions: state.selectedExecutions as unknown as Parameters<
+        typeof serializeForSave
+      >[0]["selectedExecutions"],
+      sections: sectionsWithSnapshots,
+    });
+  }, [state]);
+
+  const handlePromptSave = useCallback(
+    async (title: string) => {
+      dispatch({ type: "SET_TITLE", title });
+      const documentJson = serializeForSave({
+        title,
+        authors: state.authors,
+        template: state.template,
+        step: state.step,
+        selectedExecutions: state.selectedExecutions as unknown as Parameters<
+          typeof serializeForSave
+        >[0]["selectedExecutions"],
+        sections: state.sections as unknown as DraftSection[],
+      });
+      const draft = await createDraft.mutateAsync({
+        title,
+        template: state.template,
+        document_json: documentJson,
+        study_id: state.selectedExecutions[0]?.studyId ?? null,
+      });
+      setPromptOpen(false);
+      sessionStorage.removeItem(STORAGE_KEY);
+      navigate(`/publish/library/${draft.id}`, { replace: true });
+    },
+    [state, createDraft, navigate],
+  );
+
+  const handleSaveButton = useCallback(async () => {
+    const documentJson = buildDocumentJson();
+    if (draftId === null) {
+      const title = state.title || "Untitled manuscript";
+      const draft = await createDraft.mutateAsync({
+        title,
+        template: state.template,
+        document_json: documentJson,
+        study_id: state.selectedExecutions[0]?.studyId ?? null,
+      });
+      sessionStorage.removeItem(STORAGE_KEY);
+      navigate(`/publish/library/${draft.id}`, { replace: true });
+    } else {
+      await updateDraft.mutateAsync({
+        id: draftId,
+        payload: { title: state.title, document_json: documentJson },
+      });
+    }
+  }, [
+    draftId,
+    state.title,
+    state.template,
+    state.selectedExecutions,
+    buildDocumentJson,
+    createDraft,
+    updateDraft,
+    navigate,
+  ]);
+
   return (
     <div className="space-y-6">
       {/* Page header */}
@@ -462,6 +613,18 @@ export default function PublishPage() {
         </div>
         <div className="flex items-center gap-2">
           <HelpButton helpKey="publish" />
+          <SaveDraftButton
+            hasDraftId={draftId !== null}
+            saving={createDraft.isPending || updateDraft.isPending}
+            onSave={handleSaveButton}
+          />
+          <button
+            type="button"
+            onClick={() => navigate("/publish/library")}
+            className="text-xs text-text-ghost hover:text-text-primary transition-colors"
+          >
+            ← Library
+          </button>
           {state.step > 1 && (
             <button
               type="button"
@@ -580,6 +743,16 @@ export default function PublishPage() {
           />
         )}
       </div>
+
+      <HybridPromptModal
+        open={promptOpen}
+        defaultTitle={
+          state.selectedExecutions[0]?.studyTitle ??
+          (state.title || "Untitled manuscript")
+        }
+        onSave={handlePromptSave}
+        onContinueWithoutSaving={() => setPromptOpen(false)}
+      />
     </div>
   );
 }

--- a/frontend/src/features/publish/types/publish.ts
+++ b/frontend/src/features/publish/types/publish.ts
@@ -63,27 +63,6 @@ export interface NarrativeResponse {
   error?: string;
 }
 
-export interface PublicationDraft {
-  id: number;
-  user_id: number;
-  study_id: number | null;
-  title: string;
-  template: string;
-  document_json: Partial<PublishState> & Record<string, unknown>;
-  status: "draft" | "ready" | "archived";
-  last_opened_at: string | null;
-  created_at: string | null;
-  updated_at: string | null;
-}
-
-export interface PublicationDraftInput {
-  study_id?: number | null;
-  title: string;
-  template?: string;
-  document_json: Partial<PublishState> & Record<string, unknown>;
-  status?: PublicationDraft["status"];
-}
-
 export interface PublicationReportBundleArtifact {
   format: "ohdsi_report_bundle" | "ohdsi_report_generator_r" | "ohdsi_sharing_bundle";
   mime_type: string;
@@ -120,4 +99,73 @@ export interface ImportPublicationReportBundleResult {
     created_at: string | null;
     updated_at: string | null;
   };
+}
+
+// ── Persisted draft types (Phase 1) ─────────────────────────────────────────
+
+export interface DraftSelectedExecution {
+  studyId?: number;
+  studyTitle?: string;
+  analysisId?: number;
+  executionId?: number;
+  analysisType: string;
+  analysisName?: string;
+  designJson?: Record<string, unknown>;
+  // resultJson is NEVER persisted — re-fetched on demand
+}
+
+export interface DraftSectionTableData {
+  caption?: string;
+  headers: string[];
+  rows: Array<Record<string, string | number>>;
+  footnotes?: string[];
+}
+
+export interface DraftSection {
+  id: string;
+  type: "introduction" | "methods" | "results" | "discussion" | "diagram";
+  analysisType?: string;
+  title: string;
+  content: string;
+  included: boolean;
+  narrativeIncluded?: boolean;
+  tableIncluded?: boolean;
+  diagramIncluded?: boolean;
+  diagramType?: string;
+  tableData?: DraftSectionTableData;
+  svgMarkup?: string;
+  executionId?: number;
+}
+
+export interface DocumentJson {
+  version: 1;
+  title: string;
+  authors: string[];
+  template: string;
+  step: 1 | 2 | 3 | 4;
+  selectedExecutions: DraftSelectedExecution[];
+  sections: DraftSection[];
+}
+
+export type PublicationDraftStatus = "draft" | "ready" | "archived";
+
+export interface PublicationDraft {
+  id: number;
+  user_id: number;
+  study_id: number | null;
+  title: string;
+  template: string;
+  document_json: DocumentJson;
+  status: PublicationDraftStatus;
+  last_opened_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PublicationDraftInput {
+  study_id?: number | null;
+  title: string;
+  template: string;
+  document_json: DocumentJson;
+  status?: PublicationDraftStatus;
 }

--- a/frontend/src/features/studies/api/studyApi.ts
+++ b/frontend/src/features/studies/api/studyApi.ts
@@ -377,7 +377,11 @@ export async function reviewStudyDesignAsset(
   slug: string,
   sessionId: number,
   assetId: number,
-  payload: { decision: "accept" | "reject" | "defer"; review_notes?: string | null },
+  payload: {
+    decision: "accept" | "reject" | "defer";
+    review_notes?: string | null;
+    acknowledge_warnings?: boolean;
+  },
 ): Promise<StudyDesignAsset> {
   const { data } = await apiClient.post(`${BASE}/${slug}/design-sessions/${sessionId}/assets/${assetId}/review`, payload);
   return data.data ?? data;

--- a/frontend/src/features/studies/components/__tests__/StudyDesignWorkbench.protocol-import.test.tsx
+++ b/frontend/src/features/studies/components/__tests__/StudyDesignWorkbench.protocol-import.test.tsx
@@ -405,6 +405,7 @@ describe("StudyDesignWorkbench protocol import", () => {
       assetId: 44,
       decision: "accept",
       reviewNotes: "Use this as the population reuse anchor.",
+      acknowledgeWarnings: false,
     });
   });
 
@@ -989,6 +990,7 @@ describe("StudyDesignWorkbench protocol import", () => {
       assetId: 190,
       decision: "reject",
       reviewNotes: undefined,
+      acknowledgeWarnings: false,
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Re-draft family" }));

--- a/frontend/src/features/studies/components/v2/stages/AssetMatrix.tsx
+++ b/frontend/src/features/studies/components/v2/stages/AssetMatrix.tsx
@@ -205,7 +205,7 @@ export function AssetMatrix<TRow extends { id: string | number }>(
           className="asset-matrix-grid"
         >
           <div role="row" className="asset-matrix-grid-head">
-            <span role="columnheader" scope="col" className="asset-matrix-cell asset-matrix-cell-check">
+            <span role="columnheader" className="asset-matrix-cell asset-matrix-cell-check">
               <input
                 type="checkbox"
                 aria-label={tAuto("studies.v2.assetMatrix.selectAll")}
@@ -220,7 +220,6 @@ export function AssetMatrix<TRow extends { id: string | number }>(
               <span
                 key={column.key}
                 role="columnheader"
-                scope="col"
                 className={cn(
                   "asset-matrix-cell asset-matrix-cell-th wb-mono",
                   column.align === "right" && "align-right",
@@ -233,7 +232,6 @@ export function AssetMatrix<TRow extends { id: string | number }>(
             {rowActions.length > 0 ? (
               <span
                 role="columnheader"
-                scope="col"
                 className="asset-matrix-cell asset-matrix-cell-actions wb-mono"
               >
                 {tAuto("studies.v2.assetMatrix.actions")}

--- a/frontend/src/features/studies/components/v2/stages/packageHelpers.ts
+++ b/frontend/src/features/studies/components/v2/stages/packageHelpers.ts
@@ -7,7 +7,7 @@ import {
   recordValue,
   textValue,
 } from "../../workbench/studyDesignWorkbenchHelpers";
-import type { ManifestNode, ProvenanceFields } from "./lockHelpers";
+import type { ManifestNode, ProvenanceFields } from "./lockProvenance";
 
 // Phase 5 helpers split out from lockHelpers.ts to keep each file under the
 // 500-line project budget. Owns:

--- a/frontend/src/features/studies/components/workbench/AnalysisPlanPanel.tsx
+++ b/frontend/src/features/studies/components/workbench/AnalysisPlanPanel.tsx
@@ -254,6 +254,7 @@ export function AnalysisPlanPanel({
             const warnings = analysisPlanIssues(payload.warnings, asset.verification_json?.warnings);
             const parameterRows = analysisPlanParameterRows(payload);
             const verified = asset.verification_status === "verified";
+            const canAccept = verified || asset.verification_status === "partial";
             const accepted = asset.status === "accepted";
             const rejected = asset.status === "rejected";
             const materialized = asset.status === "materialized" && asset.materialized_id != null;
@@ -335,10 +336,11 @@ export function AnalysisPlanPanel({
                         <button
                           type="button"
                           onClick={() => onReview(asset, "accept")}
-                          disabled={isReviewing || !verified}
+                          disabled={isReviewing || !canAccept}
                           className="btn btn-primary btn-sm"
+                          title={!verified && canAccept ? "Accept with verification warnings acknowledged" : undefined}
                         >
-                          {t("studies.workbench.actions.accept")}
+                          {!verified && canAccept ? `${t("studies.workbench.actions.accept")} (with warnings)` : t("studies.workbench.actions.accept")}
                         </button>
                         <button
                           type="button"

--- a/frontend/src/features/studies/components/workbench/CohortDraftPanel.tsx
+++ b/frontend/src/features/studies/components/workbench/CohortDraftPanel.tsx
@@ -299,6 +299,7 @@ function CohortDraftCard({
   );
   const linkRoleOptions = Array.from(new Set([selectedLinkRole, ...roleOptions].filter(Boolean)));
   const verified = asset.verification_status === "verified";
+  const canAccept = verified || asset.verification_status === "partial";
   const accepted = asset.status === "accepted";
   const materialized = asset.status === "materialized" && asset.materialized_id != null;
   const studyCohortId = typeof asset.provenance_json?.study_cohort_id === "number" ? asset.provenance_json.study_cohort_id : null;
@@ -384,10 +385,11 @@ function CohortDraftCard({
               <button
                 type="button"
                 onClick={() => onReview(asset, "accept")}
-                disabled={isReviewing || !verified}
+                disabled={isReviewing || !canAccept}
                 className="btn btn-primary btn-sm"
+                title={!verified && canAccept ? "Accept with verification warnings acknowledged" : undefined}
               >
-                {t("studies.workbench.actions.accept")}
+                {!verified && canAccept ? `${t("studies.workbench.actions.accept")} (with warnings)` : t("studies.workbench.actions.accept")}
               </button>
               <button type="button" onClick={() => onReview(asset, "defer")} disabled={isReviewing} className="btn btn-ghost btn-sm">
                 {t("studies.workbench.actions.defer")}

--- a/frontend/src/features/studies/components/workbench/ConceptSetDraftPanel.tsx
+++ b/frontend/src/features/studies/components/workbench/ConceptSetDraftPanel.tsx
@@ -156,6 +156,7 @@ function ConceptSetDraftCard({
   const [searchError, setSearchError] = useState<string | null>(null);
   const payload = draftPayloadRecord(asset);
   const verified = asset.verification_status === "verified";
+  const canAccept = verified || asset.verification_status === "partial";
   const accepted = asset.status === "accepted";
   const materialized = asset.materialized_id != null;
   const verification = recordValue(asset.verification_json);
@@ -290,11 +291,17 @@ function ConceptSetDraftCard({
               <button
                 type="button"
                 onClick={() => onReview(asset, "accept")}
-                disabled={isReviewing || !verified}
-                title={verified ? undefined : textAt(verification, "eligibility.reason") || t("studies.workbench.messages.onlyVerifiedConceptSetDrafts")}
+                disabled={isReviewing || !canAccept}
+                title={
+                  canAccept && !verified
+                    ? "Accept with verification warnings acknowledged"
+                    : canAccept
+                      ? undefined
+                      : textAt(verification, "eligibility.reason") || t("studies.workbench.messages.onlyVerifiedConceptSetDrafts")
+                }
                 className="btn btn-primary btn-sm"
               >
-                {t("studies.workbench.actions.accept")}
+                {!verified && canAccept ? `${t("studies.workbench.actions.accept")} (with warnings)` : t("studies.workbench.actions.accept")}
               </button>
               <button
                 type="button"

--- a/frontend/src/features/studies/components/workbench/PhenotypeRecommendationPanel.tsx
+++ b/frontend/src/features/studies/components/workbench/PhenotypeRecommendationPanel.tsx
@@ -140,14 +140,17 @@ function RecommendationCard({
   const typeLabel = asset.asset_type.replace(/_/g, " ");
   const reviewed = ["accepted", "rejected", "deferred"].includes(asset.status);
   const verified = asset.verification_status === "verified";
+  const canAccept = verified || asset.verification_status === "partial";
   const verification = recordValue(asset.verification_json);
   const verificationChecks = verificationCheckRows(verification);
   const blockers = issueMessages(verification?.blocking_reasons);
   const warnings = issueMessages(verification?.warnings);
   const rawSource = valueAt(verification, "source_summary.source") ?? asset.rank_score_json?.source ?? asset.provenance_json?.source;
   const source = rawSource == null ? null : String(rawSource);
-  const acceptDisabledReason = verified
-    ? null
+  const acceptDisabledReason = canAccept
+    ? !verified
+      ? "Accept with verification warnings acknowledged"
+      : null
     : textAt(verification, "eligibility.reason") || t("studies.workbench.messages.onlyVerifiedRecommendations");
   const title = textValue(payload.title) || `Recommendation #${asset.id}`;
   const description = textValue(payload.description);
@@ -219,11 +222,11 @@ function RecommendationCard({
             <button
               type="button"
               onClick={() => onReview(asset, "accept", reviewNotes())}
-              disabled={isReviewing || !verified}
+              disabled={isReviewing || !canAccept}
               title={acceptDisabledReason ?? undefined}
               className="btn btn-primary btn-sm"
             >
-              {t("studies.workbench.actions.accept")}
+              {!verified && canAccept ? `${t("studies.workbench.actions.accept")} (with warnings)` : t("studies.workbench.actions.accept")}
             </button>
             <button
               type="button"

--- a/frontend/src/features/studies/hooks/useStudies.ts
+++ b/frontend/src/features/studies/hooks/useStudies.ts
@@ -503,15 +503,18 @@ export function useReviewStudyDesignAsset() {
       assetId,
       decision,
       reviewNotes,
+      acknowledgeWarnings,
     }: {
       slug: string;
       sessionId: number;
       assetId: number;
       decision: "accept" | "reject" | "defer";
       reviewNotes?: string | null;
+      acknowledgeWarnings?: boolean;
     }) => reviewStudyDesignAsset(slug, sessionId, assetId, {
       decision,
       review_notes: reviewNotes,
+      ...(acknowledgeWarnings === true ? { acknowledge_warnings: true } : {}),
     }),
     onSuccess: (_data, variables) => {
       invalidateStudyDesignCompiler(queryClient, variables.slug, variables.sessionId);

--- a/frontend/src/features/studies/hooks/useStudyDesignWorkbench.ts
+++ b/frontend/src/features/studies/hooks/useStudyDesignWorkbench.ts
@@ -310,12 +310,14 @@ export function useStudyDesignWorkbench(study: Study) {
     reviewNotes?: string | null,
   ) => {
     if (!selectedSession) return;
+    const acknowledgeWarnings = decision === "accept" && asset.verification_status === "partial";
     reviewAsset.mutate({
       slug,
       sessionId: selectedSession.id,
       assetId: asset.id,
       decision,
       reviewNotes,
+      acknowledgeWarnings,
     });
   };
 

--- a/scripts/docs/catalog_lineage_docs.py
+++ b/scripts/docs/catalog_lineage_docs.py
@@ -65,6 +65,7 @@ APPROVED_DOC_PREFIXES = (
     "docs/research/",
     "docs/reference/",
     "docs/demo/",
+    "docs/superpowers/",  # design/plan working docs for in-flight phases
 )
 
 APPROVED_DOC_PATHS = {


### PR DESCRIPTION
## Summary

Bundles 25 commits across three areas of work that landed on `feature/publish-library-phase-1`.

### 1. Pre-publication library (Phase 1) — 22 commits
- New library lifecycle (Draft/Active/Archived) added to 8 analyses tables, `cohort_definitions`, `concept_sets`
- `HasLibraryLifecycle` trait + transition rules; `LibraryStatus` enum
- Cleanup suggestions cache table + model for the superuser cleanup flow
- New FE route `/publish/library` with `PublicationLibraryPage`, `DraftCardGrid`, `DraftCard`, `DraftFilters`, `NewDraftButton`, `HybridPromptModal`, `SaveDraftButton`
- `useDrafts` TanStack Query hooks
- `PublicationDraft` and `DocumentJson` types
- `draftSerialization` (resultJson stripping) + `snapshotCapture` (freeze SVG sections)
- `data-section-id` exposed on section wrappers for snapshot capture
- `sessionStorage` migration banner
- `PublishPage` wired to server-side drafts (load/save)
- `concept_sets` reordered above `cohort_definitions` in sidebar (parent commit)

### 2. Study-design accept-gate alignment
**`feat(study-design): allow accept on partial verification with explicit warning ack`**
- BE controller `reviewAsset` now allows `accept` on PARTIAL when `acknowledge_warnings: true`. Acknowledgement persisted in `verification_json.acknowledged_warnings` (user id, timestamp, warning count).
- FE handler auto-passes the flag for partial assets. 4 workbench panels render "Accept (with warnings)" affordance.
- 3 new Pest tests cover partial without ack (422), partial with ack (200 + ack recorded), blocked with ack (still 422).

### 3. Queue-job idempotency
**`fix(jobs): drop duplicate dispatches at queue-push time via ShouldBeUnique`**
- 12 jobs now implement `ShouldBeUnique` with keys derived from `execution.id`, `validation.id`, `evaluation.id`, or `(cohort_definition.id, source.id)`.
- New shared trait `App\Jobs\Concerns\UniqueByExecutionKey` provides `uniqueFor()` = job timeout.
- Cache driver is Redis so locks are global across worker processes.
- Eliminates the millisecond-fast `MaxAttemptsExceededException` ghosts in `failed_jobs` caused by duplicate dispatches of the same execution.

## Test plan

- [x] `npx tsc --noEmit` (FE strict)
- [x] `npx vite build` (FE production build)
- [x] Pest: 1667 passed, 28 skipped; 4/4 accept-gate tests; 28 passed in job-touching tests
- [x] Vitest: 13/13 StudyDesignWorkbench.protocol-import; 9/9 StudyDesignWorkbench.bug-fixes
- [x] Pint clean on all modified PHP files
- [ ] Manual smoke: accept a partial analysis plan via Study Designer UI
- [ ] Manual smoke: re-dispatch an already-queued cohort generation and verify no duplicate FAIL appears in failed_jobs

## Known unrelated failure (not introduced here)

`StudyArtifactShinyPolicyTest > "keeps ShinyProxy app specs aligned with the managed registry"` — fails because `docker/shinyproxy/application.yml` is missing in the test container. Pre-existing, unrelated.

## Notes

- 2 docs commits (`docs(specs)` and `docs(plans)` for library lifecycle) were independently authored on `main` as `bb999a328` / `bde356fc1`. `git cherry` confirms patch-equivalence with the feature-branch versions; they collapse on merge.