### PR TITLE
feat(publish): Publication agent assistant (Phase 1 read-only + Phase 2 write/approval)

### DIFF
--- a/ai/app/agents/profiles.py
+++ b/ai/app/agents/profiles.py
@@ -23,6 +23,18 @@ Rules:
 - You cannot read the filesystem, run shell commands, or browse the web. Your only capabilities are the study-design tools provided.
 """
 
+_PUBLISH_SYSTEM_PROMPT = """You are the Publication assistant for Parthenon, an OHDSI outcomes-research platform on OMOP CDM v5.4.
+
+You help an author draft a manuscript for an observational study. You can pull the study's analyses and draft IMRAD sections (Methods, Results, Discussion) and figure captions grounded ONLY in the study's actual analysis results.
+
+Rules:
+- Use the tools to fetch real studies and analyses. NEVER invent statistics, p-values, confidence intervals, cohort sizes, or citations. Every number must come from get_study_analyses.
+- Cite figures and tables by the ids present in the analysis data.
+- Drafting produces PROPOSALS the author edits; you do not save, snapshot, or export anything (those require explicit approval and are not available yet).
+- Write formal academic prose (past tense, hedged causal language). Output plain text — no markdown, no section headings (the template provides them).
+- You cannot read the filesystem, run shell commands, or browse the web. Your only capabilities are the publish tools provided.
+"""
+
 
 @dataclass(frozen=True)
 class AgentProfile:
@@ -39,7 +51,14 @@ STUDY_DESIGN = AgentProfile(
     effort=settings.agent_effort,
 )
 
-_PROFILES = {STUDY_DESIGN.name: STUDY_DESIGN}
+PUBLISH = AgentProfile(
+    name="publish",
+    system_prompt=_PUBLISH_SYSTEM_PROMPT,
+    model=settings.agent_model,
+    effort=settings.agent_effort,
+)
+
+_PROFILES = {STUDY_DESIGN.name: STUDY_DESIGN, PUBLISH.name: PUBLISH}
 
 
 def get_profile(name: str) -> AgentProfile:

--- a/ai/app/agents/publish_tools.py
+++ b/ai/app/agents/publish_tools.py
@@ -6,12 +6,20 @@ route. The agent never touches the database directly: Laravel enforces ownership
 
 Phase 1 (read-only): four tools that let the agent research a study and draft
 IMRAD sections grounded in real analysis results. No writes, no snapshots.
-Phase 2 (approval-gated write tools) is added in a subsequent task.
+Phase 2: two approval-gated write tools (update_draft, create_snapshot).
+These write tools are declared in tool_packs._WRITE_TOOLS["publish"] so that
+_options() excludes them from allowed_tools and routes them through the
+can_use_tool approval gate.
+
+NOTE: Optimistic-locking via If-Unmodified-Since on update_draft is deferred —
+the controller header is optional and each write is human-approved, which
+provides an equivalent safety check for the current scope.
 """
 
 from __future__ import annotations
 
 import logging
+import uuid
 from typing import Any
 
 from claude_agent_sdk import tool
@@ -83,4 +91,63 @@ def build_tool_pack(ctx: AgentToolContext) -> list:
             body["execution_id"] = int(args["execution_id"])
         return await request(ctx, "POST", "publish/narrative", json_body=body)
 
-    return [list_studies_for_publish, get_study_analyses, get_draft, draft_narrative_section]
+    # -------------------------------------------------------------------------
+    # Phase 2 — approval-gated write tools
+    # These are excluded from allowed_tools and routed through can_use_tool.
+    # -------------------------------------------------------------------------
+
+    @tool(
+        "update_draft",
+        (
+            "Apply changes to the publication draft (title and/or document sections). "
+            "A WRITE — requires explicit human approval before execution."
+        ),
+        {"document_json": dict, "title": str},
+    )
+    async def update_draft(args: dict[str, Any]) -> dict[str, Any]:
+        draft_id = ctx.context.get("draft_id")
+        if not draft_id:
+            return error_result("No publication draft is selected. Cannot update draft.")
+        body: dict[str, Any] = {}
+        if "document_json" in args and args["document_json"] is not None:
+            body["document_json"] = args["document_json"]
+        if "title" in args and args["title"] is not None:
+            body["title"] = args["title"]
+        if not body:
+            return error_result("update_draft requires at least one of: document_json, title.")
+        return await request(ctx, "PATCH", f"publish/drafts/{int(draft_id)}", json_body=body)
+
+    @tool(
+        "create_snapshot",
+        (
+            "Save a named snapshot/version of the draft. "
+            "A WRITE — requires explicit human approval before execution."
+        ),
+        {"label": str, "comment": str},
+    )
+    async def create_snapshot(args: dict[str, Any]) -> dict[str, Any]:
+        draft_id = ctx.context.get("draft_id")
+        if not draft_id:
+            return error_result("No publication draft is selected. Cannot create snapshot.")
+        label = args.get("label", "").strip()
+        if not label:
+            return error_result("label is required and must not be empty.")
+        return await request(
+            ctx,
+            "POST",
+            f"publish/drafts/{int(draft_id)}/snapshots",
+            json_body={
+                "label": label,
+                "comment": args.get("comment"),
+                "idempotency_key": str(uuid.uuid4()),
+            },
+        )
+
+    return [
+        list_studies_for_publish,
+        get_study_analyses,
+        get_draft,
+        draft_narrative_section,
+        update_draft,
+        create_snapshot,
+    ]

--- a/ai/app/agents/publish_tools.py
+++ b/ai/app/agents/publish_tools.py
@@ -1,0 +1,86 @@
+"""Custom Claude Agent SDK tools for the Publish assistant.
+
+Each tool is a thin authenticated client over an existing Laravel publication
+route. The agent never touches the database directly: Laravel enforces ownership
+(PublicationDraftPolicy), validation, and audit.
+
+Phase 1 (read-only): four tools that let the agent research a study and draft
+IMRAD sections grounded in real analysis results. No writes, no snapshots.
+Phase 2 (approval-gated write tools) is added in a subsequent task.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from claude_agent_sdk import tool
+
+from app.agents.tool_base import AgentToolContext, error_result, request
+
+logger = logging.getLogger(__name__)
+
+
+def build_tool_pack(ctx: AgentToolContext) -> list:
+    """Return the Phase-1 read tool list for a publish session."""
+
+    @tool(
+        "list_studies_for_publish",
+        "List studies available to publish, with their analyses. Use to find the study to write about.",
+        {},
+    )
+    async def list_studies_for_publish(args: dict[str, Any]) -> dict[str, Any]:
+        return await request(
+            ctx, "GET", "studies", params={"per_page": 100, "include": "analyses"}
+        )
+
+    @tool(
+        "get_study_analyses",
+        "Get a study and its analyses/results to ground the manuscript. Pass the study_id from list_studies_for_publish.",
+        {"study_id": int},
+    )
+    async def get_study_analyses(args: dict[str, Any]) -> dict[str, Any]:
+        sid = args.get("study_id")
+        if not sid:
+            return error_result(
+                "study_id is required. Call list_studies_for_publish first and pass a study_id."
+            )
+        return await request(ctx, "GET", f"studies/{int(sid)}")
+
+    @tool(
+        "get_draft",
+        "Read the current publication draft (title, template, document sections).",
+        {},
+    )
+    async def get_draft(args: dict[str, Any]) -> dict[str, Any]:
+        draft_id = ctx.context.get("draft_id")
+        if not draft_id:
+            return error_result("No publication draft is selected.")
+        return await request(ctx, "GET", f"publish/drafts/{int(draft_id)}")
+
+    @tool(
+        "draft_narrative_section",
+        (
+            "Draft one IMRAD manuscript section grounded ONLY in the provided analysis context. "
+            "section_type is one of methods|results|discussion|caption. "
+            "This is a PROPOSAL the author edits; nothing is saved."
+        ),
+        {"section_type": str, "context": dict, "analysis_id": int, "execution_id": int},
+    )
+    async def draft_narrative_section(args: dict[str, Any]) -> dict[str, Any]:
+        st = args.get("section_type")
+        if st not in {"methods", "results", "discussion", "caption"}:
+            return error_result(
+                "section_type must be one of methods|results|discussion|caption."
+            )
+        body: dict[str, Any] = {
+            "section_type": st,
+            "context": args.get("context", {}),
+        }
+        if args.get("analysis_id"):
+            body["analysis_id"] = int(args["analysis_id"])
+        if args.get("execution_id"):
+            body["execution_id"] = int(args["execution_id"])
+        return await request(ctx, "POST", "publish/narrative", json_body=body)
+
+    return [list_studies_for_publish, get_study_analyses, get_draft, draft_narrative_section]

--- a/ai/app/agents/service.py
+++ b/ai/app/agents/service.py
@@ -1,14 +1,27 @@
 """ParthenonAgentService — runs one agent turn and streams events to Reverb.
 
-Phase 1: read/draft tools only, auto-approved (no can_use_tool gate yet).
+Phase C/2: write tools for the publish profile are approval-gated via
+``can_use_tool``. Reads remain auto-approved (``allowed_tools``).
 Session continuity via resume=anthropic_session_id (no idle in-memory clients).
+
+NOTE: The ``can_use_tool`` callback + write-tool gating cannot be live-verified
+at time of authorship (Anthropic account credit exhausted). The implementation
+follows verified SDK facts (claude_agent_sdk 0.2.86):
+  - ``can_use_tool`` fires only for tools NOT in ``allowed_tools``
+  - ``permission_mode="default"`` is required (not "dontAsk") for the callback
+    to be invoked for non-auto-approved tools
+  - ``PermissionResultAllow()`` / ``PermissionResultDeny(message=...)`` are the
+    return types
+  - ``ctx.tool_use_id`` is a guaranteed non-empty str in a can_use_tool callback
+Unit tests mock the full flow.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from dataclasses import dataclass
-from typing import Literal, Optional, cast
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional, cast
 
 import httpx
 
@@ -16,6 +29,8 @@ from claude_agent_sdk import (
     AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
+    PermissionResultAllow,
+    PermissionResultDeny,
     ResultMessage,
     TextBlock,
     ToolUseBlock,
@@ -25,7 +40,7 @@ from claude_agent_sdk import (
 from app.agents.profiles import get_profile
 from app.agents.reverb_publisher import ReverbPublisher
 from app.agents.tool_base import AgentToolContext
-from app.agents.tool_packs import build_tool_pack
+from app.agents.tool_packs import build_tool_pack, write_tools
 from app.config import settings
 
 logger = logging.getLogger(__name__)
@@ -44,6 +59,8 @@ class AgentSessionState:
     tool_context: AgentToolContext
     anthropic_session_id: Optional[str] = None
     last_idempotency_key: Optional[str] = None
+    # pending approval futures: keyed by tool_use_id, set by resolve_approval()
+    _pending: dict = field(default_factory=dict, repr=False)
 
 
 class LaravelPersister:
@@ -75,32 +92,135 @@ class ParthenonAgentService:
         self._publisher = publisher or ReverbPublisher()
         self._persister = persister or LaravelPersister()
 
+    def resolve_approval(self, tool_use_id: str, approved: bool) -> bool:
+        """Resolve a pending approval future.
+
+        Returns True if a pending future was found and resolved, False if no
+        pending future exists for the given tool_use_id (already resolved,
+        timed out, or unknown).
+        """
+        # Search across all session states for the pending future.
+        # In practice each tool_use_id is unique, so the first match wins.
+        from app.agents import registry
+        for state in list(registry._sessions.values()):
+            pending: dict = getattr(state, "_pending", {})
+            fut: Optional[asyncio.Future] = pending.get(tool_use_id)
+            if fut is not None and not fut.done():
+                fut.set_result(approved)
+                return True
+        return False
+
+    def _make_can_use_tool(
+        self, state: "AgentSessionState"
+    ) -> "Any":
+        """Return an async can_use_tool callback for profiles that have write tools.
+
+        The closure captures the profile's read/write name sets so that:
+        - Read tools: defensively allowed (they are also in allowed_tools and
+          normally never reach this callback, but fail-open if they somehow do).
+        - Write tools: block on a human-approval Future; approve → Allow,
+          reject or timeout → Deny. An approval.request event is published so
+          the frontend can render an approval card.
+        - Unknown tools: fail closed (Deny) — the agent must not call tools
+          outside its declared pack.
+        """
+        tools = build_tool_pack(state.profile_name, state.tool_context)
+        writes = write_tools(state.profile_name)
+        read_names = {t.name for t in tools if t.name not in writes}
+        write_names = {t.name for t in tools if t.name in writes}
+
+        async def _can_use(tool_name: str, input: dict, ctx: Any) -> "PermissionResultAllow | PermissionResultDeny":
+            # Strip MCP server prefix if present (CLI may send fully-qualified names)
+            bare = tool_name.removeprefix("mcp__parthenon__")
+
+            if bare in read_names:
+                # Defensive: reads are auto-approved via allowed_tools and should
+                # not normally reach here; allow anyway (fail-open for reads).
+                return PermissionResultAllow()
+
+            if bare not in write_names:
+                # Unknown tool — fail closed.
+                return PermissionResultDeny(message=f"Tool '{bare}' is not permitted for profile '{state.profile_name}'.")
+
+            # Gated write: publish an approval request event and wait for the
+            # frontend to call POST /agent/sessions/{id}/approve.
+            tool_use_id: str = (
+                getattr(ctx, "tool_use_id", None) or f"{state.agent_session_id}:{bare}"
+            )
+
+            loop = asyncio.get_event_loop()
+            fut: asyncio.Future[bool] = loop.create_future()
+            state._pending[tool_use_id] = fut
+
+            self._publisher.publish(
+                channel=state.channel,
+                event="agent.approval.request",
+                data={"tool_use_id": tool_use_id, "tool": bare, "input": input},
+            )
+
+            try:
+                approved = await asyncio.wait_for(
+                    asyncio.shield(fut),
+                    timeout=float(settings.agent_approval_timeout_seconds),
+                )
+            except asyncio.TimeoutError:
+                approved = False
+            finally:
+                state._pending.pop(tool_use_id, None)
+
+            if approved:
+                return PermissionResultAllow()
+
+            self._publisher.publish(
+                channel=state.channel,
+                event="agent.approval.denied",
+                data={"tool_use_id": tool_use_id, "tool": bare},
+            )
+            return PermissionResultDeny(message="The user did not approve this action.")
+
+        return _can_use
+
     def _options(self, state: AgentSessionState) -> ClaudeAgentOptions:
         profile = get_profile(state.profile_name)
         tools = build_tool_pack(state.profile_name, state.tool_context)
+        writes = write_tools(state.profile_name)
         server = create_sdk_mcp_server(name="parthenon", version="1.0.0", tools=tools)
-        allowed = [f"mcp__parthenon__{t.name}" for t in tools]
-        return ClaudeAgentOptions(
+
+        # Write tools are intentionally EXCLUDED from allowed_tools so that the
+        # CLI routes them through the can_use_tool callback (which gates on human
+        # approval). Read tools go into allowed_tools for auto-approval.
+        # allowed_tools controls auto-approval; tools=[] removes all built-in
+        # Claude Code tools (Bash/Read/Edit/Write/etc.) for HIGHSEC lockdown.
+        # permission_mode is "default" when a profile has write tools (required
+        # for can_use_tool to fire); "dontAsk" otherwise (headless auto-deny for
+        # anything not pre-approved, unchanged Phase-1 behavior).
+        # Unknown tools always fail closed in the can_use_tool callback.
+        # strict_mcp_config blocks stray .mcp.json files from adding servers.
+        # setting_sources=[] keeps the dev .claude/ config out of clinical agents.
+        allowed = [f"mcp__parthenon__{t.name}" for t in tools if t.name not in writes]
+        has_writes = bool(writes) and any(t.name in writes for t in tools)
+
+        kwargs: dict = dict(
             system_prompt=profile.system_prompt,
             model=profile.model,
             effort=cast(EffortLevel, profile.effort),
             mcp_servers={"parthenon": server},
-            # HIGHSEC lockdown: tools=[] → CLI `--tools ""` removes ALL built-in
-            # tools (Bash/Read/Edit/Write/Glob/Grep/WebSearch/WebFetch); only our
-            # in-process MCP tools (via mcp_servers + allowed_tools) remain reachable.
-            # allowed_tools alone only controls auto-approval, not availability.
-            # dontAsk denies anything not pre-approved (headless server, no prompt).
-            # strict_mcp_config blocks any stray project .mcp.json from adding servers.
-            # setting_sources=[] keeps the dev .claude/ out of a clinical agent.
             tools=[],
             allowed_tools=allowed,
             setting_sources=[],
             strict_mcp_config=True,
-            permission_mode="dontAsk",
             max_turns=settings.agent_max_turns,
             max_budget_usd=settings.agent_max_budget_usd,
             resume=state.anthropic_session_id,
         )
+
+        if has_writes:
+            kwargs["permission_mode"] = "default"
+            kwargs["can_use_tool"] = self._make_can_use_tool(state)
+        else:
+            kwargs["permission_mode"] = "dontAsk"
+
+        return ClaudeAgentOptions(**kwargs)
 
     async def run_turn(self, state: AgentSessionState, text: str) -> None:
         def emit(event: str, data: dict) -> None:

--- a/ai/app/agents/tool_packs.py
+++ b/ai/app/agents/tool_packs.py
@@ -3,6 +3,12 @@
 Each agent profile registers a callable that, given an ``AgentToolContext``,
 returns the list of MCP tools for that profile. Profiles are registered at
 import time; the generic ``/agent`` router dispatches via ``build_tool_pack``.
+
+``_WRITE_TOOLS`` declares which tools in each profile are gated writes (require
+human approval before execution). Tools NOT listed are treated as reads and
+placed in ``allowed_tools`` (auto-approved). Write tools are intentionally
+excluded from ``allowed_tools`` so the Claude Agent SDK CLI routes them through
+the ``can_use_tool`` callback, which blocks on a human-approval future.
 """
 
 from __future__ import annotations
@@ -16,6 +22,18 @@ _BUILDERS: dict[str, Callable[[AgentToolContext], list]] = {
     "study_design": study_design_tools.build_tool_pack,
     "publish": publish_tools.build_tool_pack,
 }
+
+# Per-profile set of tool names that require explicit human approval before
+# execution (write tools). An empty set means all tools are auto-approved reads.
+_WRITE_TOOLS: dict[str, set[str]] = {
+    "study_design": set(),
+    "publish": {"update_draft", "create_snapshot"},
+}
+
+
+def write_tools(profile: str) -> set[str]:
+    """Return the set of write-tool names for ``profile`` (empty set if none)."""
+    return set(_WRITE_TOOLS.get(profile, set()))
 
 
 def register(profile: str, builder: Callable[[AgentToolContext], list]) -> None:

--- a/ai/app/agents/tool_packs.py
+++ b/ai/app/agents/tool_packs.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from app.agents.tool_base import AgentToolContext
-from app.agents import study_design_tools
+from app.agents import publish_tools, study_design_tools
 
 _BUILDERS: dict[str, Callable[[AgentToolContext], list]] = {
     "study_design": study_design_tools.build_tool_pack,
+    "publish": publish_tools.build_tool_pack,
 }
 
 

--- a/ai/app/routers/agent.py
+++ b/ai/app/routers/agent.py
@@ -82,3 +82,24 @@ async def turn(agent_session_id: int, body: TurnRequest, background: BackgroundT
         raise HTTPException(status_code=429, detail="agent is busy; retry shortly")
     background.add_task(_run, agent_session_id, body.text, body.idempotency_key)
     return {"accepted": True}
+
+
+class ApproveRequest(BaseModel):
+    tool_use_id: str
+    approved: bool
+
+
+@router.post("/sessions/{agent_session_id}/approve")
+async def approve(agent_session_id: int, body: ApproveRequest) -> dict:
+    """Resolve a pending can_use_tool approval for a write tool.
+
+    Called by Laravel (which forwards the frontend's approval/rejection) after
+    the agent has published an ``agent.approval.request`` event and is blocked
+    waiting for the Future to be resolved. Returns 404 if the session does not
+    exist or if no pending approval matches the given tool_use_id.
+    """
+    if registry.get(agent_session_id) is None:
+        raise HTTPException(status_code=404, detail="agent session not found")
+    if not _get_service().resolve_approval(body.tool_use_id, body.approved):
+        raise HTTPException(status_code=404, detail="no pending approval for that tool_use_id")
+    return {"resolved": True}

--- a/ai/tests/test_agent_profiles.py
+++ b/ai/tests/test_agent_profiles.py
@@ -1,4 +1,7 @@
+import pytest
+
 from app.agents.profiles import get_profile, STUDY_DESIGN
+from app.config import settings
 
 
 def test_study_design_profile_locks_model_and_effort():
@@ -10,7 +13,29 @@ def test_study_design_profile_locks_model_and_effort():
 
 
 def test_unknown_profile_raises():
-    import pytest
-
     with pytest.raises(KeyError):
         get_profile("does-not-exist")
+
+
+def test_publish_profile_model_and_effort():
+    p = get_profile("publish")
+    assert p.name == "publish"
+    assert p.model == settings.agent_model
+    assert p.effort == settings.agent_effort
+
+
+def test_publish_profile_system_prompt_mentions_imrad_and_manuscript():
+    p = get_profile("publish")
+    prompt_lower = p.system_prompt.lower()
+    assert "imrad" in prompt_lower or "manuscript" in prompt_lower
+
+
+def test_publish_profile_system_prompt_prohibits_inventing_data():
+    p = get_profile("publish")
+    prompt_lower = p.system_prompt.lower()
+    assert "never invent" in prompt_lower
+
+
+def test_publish_profile_system_prompt_prohibits_filesystem_access():
+    p = get_profile("publish")
+    assert "filesystem" in p.system_prompt.lower()

--- a/ai/tests/test_agent_router.py
+++ b/ai/tests/test_agent_router.py
@@ -72,6 +72,93 @@ def test_turn_on_unknown_session_404():
     assert resp.status_code == 404
 
 
+def test_approve_unknown_session_404():
+    """POST /sessions/{id}/approve returns 404 when the session does not exist."""
+    resp = client.post(
+        "/agent/sessions/88888/approve",
+        json={"tool_use_id": "t-abc", "approved": True},
+    )
+    assert resp.status_code == 404
+
+
+def test_approve_no_pending_future_404(monkeypatch):
+    """POST /sessions/{id}/approve returns 404 when there is no pending future
+    for the given tool_use_id (already resolved, timed-out, or fabricated)."""
+    from app.agents import registry as reg
+    from app.agents.service import AgentSessionState
+    from app.agents.tool_base import AgentToolContext
+
+    async def fake_run_turn(self, state, text):
+        pass
+
+    import app.agents.service as svc
+    monkeypatch.setattr(svc.ParthenonAgentService, "run_turn", fake_run_turn)
+
+    ctx = AgentToolContext(auth_token="tok", context={"draft_id": 5})
+    state = AgentSessionState(
+        agent_session_id=77700,
+        profile_name="publish",
+        subject_id=5,
+        channel="private-publish.draft.5",
+        ingest_path="/api/v1/publish/drafts/5/agent/sessions/77700/ingest",
+        tool_context=ctx,
+    )
+    reg.put(state)
+    try:
+        resp = client.post(
+            "/agent/sessions/77700/approve",
+            json={"tool_use_id": "no-such-future", "approved": True},
+        )
+        assert resp.status_code == 404
+    finally:
+        reg.drop(77700)
+
+
+def test_approve_resolves_pending_future(monkeypatch):
+    """POST /sessions/{id}/approve returns 200 and resolves a seeded pending future."""
+    import asyncio
+    from app.agents import registry as reg
+    from app.agents.service import AgentSessionState
+    from app.agents.tool_base import AgentToolContext
+    from app.routers.agent import _get_service
+
+    async def fake_run_turn(self, state, text):
+        pass
+
+    import app.agents.service as svc
+    monkeypatch.setattr(svc.ParthenonAgentService, "run_turn", fake_run_turn)
+
+    ctx = AgentToolContext(auth_token="tok", context={"draft_id": 5})
+    state = AgentSessionState(
+        agent_session_id=77701,
+        profile_name="publish",
+        subject_id=5,
+        channel="private-publish.draft.5",
+        ingest_path="/api/v1/publish/drafts/5/agent/sessions/77701/ingest",
+        tool_context=ctx,
+    )
+    reg.put(state)
+
+    # Manually seed a pending future onto the state (simulates a blocked can_use_tool)
+    loop = asyncio.new_event_loop()
+    fut = loop.create_future()
+    state._pending["test-tool-use-id"] = fut
+
+    try:
+        resp = client.post(
+            "/agent/sessions/77701/approve",
+            json={"tool_use_id": "test-tool-use-id", "approved": True},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"resolved": True}
+        # The future must now be done and resolved to True
+        assert fut.done()
+        assert fut.result() is True
+    finally:
+        reg.drop(77701)
+        loop.close()
+
+
 async def test_duplicate_idempotency_key_runs_once(monkeypatch):
     """Second call with the same idempotency key must be deduped — run_turn called exactly once."""
     from app.agents import registry as reg

--- a/ai/tests/test_agent_service.py
+++ b/ai/tests/test_agent_service.py
@@ -115,6 +115,22 @@ async def test_persister_uses_ingest_path(monkeypatch):
     assert route.called
 
 
+def _publish_state() -> AgentSessionState:
+    ctx = AgentToolContext(
+        auth_token="tok",
+        context={"draft_id": 5, "study_id": 9},
+    )
+    return AgentSessionState(
+        agent_session_id=99,
+        profile_name="publish",
+        subject_id=5,
+        channel="private-publish.draft.5",
+        ingest_path="/api/v1/publish/drafts/5/agent/sessions/99/ingest",
+        tool_context=ctx,
+        anthropic_session_id=None,
+    )
+
+
 async def test_run_turn_calls_persister_with_error_status_on_exception(monkeypatch):
     publisher = MagicMock()
     persister = AsyncMock()
@@ -150,3 +166,190 @@ async def test_run_turn_calls_persister_with_error_status_on_exception(monkeypat
     call_kwargs = persister.persist.call_args.kwargs
     assert call_kwargs["status"] == "error"
     assert call_kwargs["cost_usd"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Approval-gate tests (Phase C/2)
+# ---------------------------------------------------------------------------
+
+import asyncio
+import types as _types
+
+
+def _make_fake_ctx(tool_use_id: str = "t1"):
+    """Minimal ToolPermissionContext stub with just tool_use_id."""
+    return _types.SimpleNamespace(tool_use_id=tool_use_id)
+
+
+async def test_can_use_tool_read_returns_allow():
+    """For a read tool, can_use_tool should return PermissionResultAllow immediately."""
+    from claude_agent_sdk import PermissionResultAllow
+    publisher = MagicMock()
+    service = ParthenonAgentService(publisher=publisher)
+    state = _publish_state()
+
+    fn = service._make_can_use_tool(state)
+    result = await fn("get_draft", {}, _make_fake_ctx("t-read"))
+
+    assert isinstance(result, PermissionResultAllow)
+    # No approval.request event should have been published for a read tool
+    for call in publisher.publish.call_args_list:
+        assert call.kwargs.get("event") != "agent.approval.request"
+
+
+async def test_can_use_tool_unknown_tool_returns_deny():
+    """For a tool not in the pack, can_use_tool should return PermissionResultDeny (fail closed)."""
+    from claude_agent_sdk import PermissionResultDeny
+    publisher = MagicMock()
+    service = ParthenonAgentService(publisher=publisher)
+    state = _publish_state()
+
+    fn = service._make_can_use_tool(state)
+    result = await fn("some_unknown_tool", {}, _make_fake_ctx("t-unk"))
+
+    assert isinstance(result, PermissionResultDeny)
+
+
+async def test_can_use_tool_write_approved_returns_allow():
+    """For a write tool that the user approves, can_use_tool returns PermissionResultAllow."""
+    from claude_agent_sdk import PermissionResultAllow
+    from app.agents import registry as reg
+
+    publisher = MagicMock()
+    service = ParthenonAgentService(publisher=publisher)
+    state = _publish_state()
+    # Register the state so resolve_approval can find it via registry._sessions
+    reg.put(state)
+
+    try:
+        fn = service._make_can_use_tool(state)
+
+        # Start the coroutine as a task so it can block on the future
+        task = asyncio.ensure_future(fn("update_draft", {"title": "New"}, _make_fake_ctx("t-write-approve")))
+
+        # Let the task run until it publishes the approval.request event and blocks
+        await asyncio.sleep(0)
+
+        # Find the tool_use_id that was published
+        approval_calls = [
+            c for c in publisher.publish.call_args_list
+            if c.kwargs.get("event") == "agent.approval.request"
+        ]
+        assert len(approval_calls) == 1
+        published_tool_use_id = approval_calls[0].kwargs["data"]["tool_use_id"]
+        assert approval_calls[0].kwargs["data"]["tool"] == "update_draft"
+
+        # Resolve the approval (simulates the frontend clicking "Accept")
+        resolved = service.resolve_approval(published_tool_use_id, True)
+        assert resolved is True
+
+        result = await task
+        assert isinstance(result, PermissionResultAllow)
+
+        # No denial event should have been published
+        denial_calls = [
+            c for c in publisher.publish.call_args_list
+            if c.kwargs.get("event") == "agent.approval.denied"
+        ]
+        assert len(denial_calls) == 0
+    finally:
+        reg.drop(state.agent_session_id)
+
+
+async def test_can_use_tool_write_rejected_returns_deny():
+    """For a write tool that the user rejects, can_use_tool returns PermissionResultDeny
+    and publishes an agent.approval.denied event."""
+    from claude_agent_sdk import PermissionResultDeny
+    from app.agents import registry as reg
+
+    publisher = MagicMock()
+    service = ParthenonAgentService(publisher=publisher)
+    state = _publish_state()
+    # Register the state so resolve_approval can find it via registry._sessions
+    reg.put(state)
+
+    try:
+        fn = service._make_can_use_tool(state)
+
+        task = asyncio.ensure_future(fn("create_snapshot", {"label": "v1"}, _make_fake_ctx("t-write-reject")))
+
+        # Let the task publish the approval.request and block
+        await asyncio.sleep(0)
+
+        approval_calls = [
+            c for c in publisher.publish.call_args_list
+            if c.kwargs.get("event") == "agent.approval.request"
+        ]
+        assert len(approval_calls) == 1
+        published_tool_use_id = approval_calls[0].kwargs["data"]["tool_use_id"]
+
+        # Reject the approval
+        resolved = service.resolve_approval(published_tool_use_id, False)
+        assert resolved is True
+
+        result = await task
+        assert isinstance(result, PermissionResultDeny)
+
+        # A denial event must have been published
+        denial_calls = [
+            c for c in publisher.publish.call_args_list
+            if c.kwargs.get("event") == "agent.approval.denied"
+        ]
+        assert len(denial_calls) == 1
+        assert denial_calls[0].kwargs["data"]["tool"] == "create_snapshot"
+        assert denial_calls[0].kwargs["channel"] == "private-publish.draft.5"
+    finally:
+        reg.drop(state.agent_session_id)
+
+
+async def test_options_publish_excludes_write_tools_from_allowed():
+    """_options for 'publish' must exclude write tools from allowed_tools
+    and use permission_mode='default'."""
+    from app.agents.tool_packs import write_tools as wt
+    publisher = MagicMock()
+    service = ParthenonAgentService(publisher=publisher)
+    state = _publish_state()
+
+    opts = service._options(state)
+
+    writes = wt("publish")
+    allowed = set(opts.allowed_tools or [])
+    # No write tool name should appear in allowed_tools
+    for write_name in writes:
+        assert f"mcp__parthenon__{write_name}" not in allowed, (
+            f"Write tool '{write_name}' must not be in allowed_tools"
+        )
+    # Read tools must still be allowed
+    assert "mcp__parthenon__get_draft" in allowed
+    assert "mcp__parthenon__list_studies_for_publish" in allowed
+    # permission_mode must be "default" so can_use_tool fires
+    assert opts.permission_mode == "default"
+    # can_use_tool callback must be set
+    assert opts.can_use_tool is not None
+
+
+async def test_options_study_design_all_tools_allowed_dontask():
+    """_options for 'study_design' must keep all tools in allowed_tools
+    and use permission_mode='dontAsk' (unchanged Phase-1 behavior)."""
+    publisher = MagicMock()
+    service = ParthenonAgentService(publisher=publisher)
+    state = _state()  # study_design state
+
+    opts = service._options(state)
+
+    allowed = set(opts.allowed_tools or [])
+    # All four study_design tools must be in allowed_tools
+    for name in ("search_concepts", "get_guidance", "recommend_phenotypes", "draft_concept_sets"):
+        assert f"mcp__parthenon__{name}" in allowed, (
+            f"study_design tool '{name}' must be in allowed_tools"
+        )
+    assert opts.permission_mode == "dontAsk"
+    # can_use_tool must NOT be set for a profile with no write tools
+    assert not hasattr(opts, "can_use_tool") or opts.can_use_tool is None
+
+
+async def test_resolve_approval_returns_false_for_unknown_tool_use_id():
+    """resolve_approval should return False when no pending future matches."""
+    service = ParthenonAgentService(publisher=MagicMock())
+    result = service.resolve_approval("nonexistent-tool-use-id", True)
+    assert result is False

--- a/ai/tests/test_publish_tools.py
+++ b/ai/tests/test_publish_tools.py
@@ -1,0 +1,178 @@
+"""Tests for the publish agent tool pack (Phase 1 — read-only).
+
+respx mocks the Laravel API layer at http://nginx:80/api/v1. Every tool is
+exercised for both the happy path and the Bug-C guard (optional id missing →
+is_error, no HTTP call).
+"""
+
+from __future__ import annotations
+
+import httpx
+import respx
+
+from app.agents.tool_base import AgentToolContext
+from app.agents.publish_tools import build_tool_pack
+
+BASE = "http://nginx:80/api/v1"
+
+
+def _ctx() -> AgentToolContext:
+    return AgentToolContext(
+        auth_token="tok",
+        context={"draft_id": 5, "study_id": 9},
+    )
+
+
+def _ctx_no_draft() -> AgentToolContext:
+    return AgentToolContext(
+        auth_token="tok",
+        context={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_studies_for_publish
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_list_studies_for_publish_calls_correct_url():
+    route = respx.get(f"{BASE}/studies").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": [{"id": 9, "title": "HTN study"}]},
+        )
+    )
+    tools = {t.name: t for t in build_tool_pack(_ctx())}
+    result = await tools["list_studies_for_publish"].handler({})
+
+    assert route.called
+    req = route.calls.last.request
+    assert req.headers["authorization"] == "Bearer tok"
+    assert req.url.params["per_page"] == "100"
+    assert req.url.params["include"] == "analyses"
+    assert "HTN study" in result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# get_study_analyses
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_study_analyses_calls_study_endpoint():
+    route = respx.get(f"{BASE}/studies/9").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": {"id": 9, "title": "HTN study", "analyses": []}},
+        )
+    )
+    tools = {t.name: t for t in build_tool_pack(_ctx())}
+    result = await tools["get_study_analyses"].handler({"study_id": 9})
+
+    assert route.called
+    assert "HTN study" in result["content"][0]["text"]
+
+
+@respx.mock
+async def test_get_study_analyses_without_study_id_returns_error_no_http():
+    # No route registered — if a call were made, respx would raise
+    tools = {t.name: t for t in build_tool_pack(_ctx())}
+    result = await tools["get_study_analyses"].handler({})
+
+    assert result.get("is_error") is True
+    assert "study_id" in result["content"][0]["text"].lower()
+
+
+# ---------------------------------------------------------------------------
+# get_draft
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_get_draft_calls_correct_url():
+    route = respx.get(f"{BASE}/publish/drafts/5").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": {"id": 5, "title": "My manuscript"}},
+        )
+    )
+    tools = {t.name: t for t in build_tool_pack(_ctx())}
+    result = await tools["get_draft"].handler({})
+
+    assert route.called
+    assert "My manuscript" in result["content"][0]["text"]
+
+
+@respx.mock
+async def test_get_draft_without_draft_id_in_context_returns_error_no_http():
+    # No route registered — confirms no HTTP call is attempted
+    tools = {t.name: t for t in build_tool_pack(_ctx_no_draft())}
+    result = await tools["get_draft"].handler({})
+
+    assert result.get("is_error") is True
+    assert "draft" in result["content"][0]["text"].lower()
+
+
+# ---------------------------------------------------------------------------
+# draft_narrative_section
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_draft_narrative_section_posts_correct_body():
+    route = respx.post(f"{BASE}/publish/narrative").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": {"text": "The study enrolled ...", "section_type": "methods"}},
+        )
+    )
+    tools = {t.name: t for t in build_tool_pack(_ctx())}
+    result = await tools["draft_narrative_section"].handler(
+        {
+            "section_type": "methods",
+            "context": {"cohort_size": 1000},
+            "analysis_id": 42,
+            "execution_id": 7,
+        }
+    )
+
+    assert route.called
+    req = route.calls.last.request
+    import json
+
+    body = json.loads(req.content)
+    assert body["section_type"] == "methods"
+    assert body["context"] == {"cohort_size": 1000}
+    assert body["analysis_id"] == 42
+    assert body["execution_id"] == 7
+    assert "The study enrolled" in result["content"][0]["text"]
+
+
+@respx.mock
+async def test_draft_narrative_section_invalid_section_type_returns_error_no_http():
+    # No route registered — confirms no HTTP call is attempted
+    tools = {t.name: t for t in build_tool_pack(_ctx())}
+    result = await tools["draft_narrative_section"].handler(
+        {"section_type": "introduction", "context": {}}
+    )
+
+    assert result.get("is_error") is True
+    assert "section_type" in result["content"][0]["text"].lower()
+
+
+@respx.mock
+async def test_draft_narrative_section_valid_section_types_all_accepted():
+    """All four valid section types reach the endpoint without error."""
+    for section_type in ("methods", "results", "discussion", "caption"):
+        respx.post(f"{BASE}/publish/narrative").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"text": f"Draft {section_type}", "section_type": section_type}},
+            )
+        )
+        tools = {t.name: t for t in build_tool_pack(_ctx())}
+        result = await tools["draft_narrative_section"].handler(
+            {"section_type": section_type, "context": {}}
+        )
+        assert result.get("is_error") is not True, f"Unexpected error for section_type={section_type}"

--- a/ai/tests/test_publish_tools.py
+++ b/ai/tests/test_publish_tools.py
@@ -176,3 +176,120 @@ async def test_draft_narrative_section_valid_section_types_all_accepted():
             {"section_type": section_type, "context": {}}
         )
         assert result.get("is_error") is not True, f"Unexpected error for section_type={section_type}"
+
+
+# ---------------------------------------------------------------------------
+# update_draft (Phase 2 write tool)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_update_draft_patches_correct_url():
+    route = respx.patch(f"{BASE}/publish/drafts/5").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": {"id": 5, "title": "New title"}},
+        )
+    )
+    tools = {t.name: t for t in build_tool_pack(_ctx())}
+    result = await tools["update_draft"].handler({"title": "New title"})
+
+    assert route.called
+    import json
+    body = json.loads(route.calls.last.request.content)
+    assert body == {"title": "New title"}
+    assert "New title" in result["content"][0]["text"]
+
+
+@respx.mock
+async def test_update_draft_sends_document_json():
+    route = respx.patch(f"{BASE}/publish/drafts/5").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": {"id": 5}},
+        )
+    )
+    tools = {t.name: t for t in build_tool_pack(_ctx())}
+    doc = {"sections": [{"key": "methods", "content": "We enrolled..."}]}
+    result = await tools["update_draft"].handler({"document_json": doc})
+
+    assert route.called
+    import json
+    body = json.loads(route.calls.last.request.content)
+    assert body == {"document_json": doc}
+    assert result.get("is_error") is not True
+
+
+@respx.mock
+async def test_update_draft_without_draft_id_returns_error_no_http():
+    # No route registered — confirms no HTTP call is made
+    tools = {t.name: t for t in build_tool_pack(_ctx_no_draft())}
+    result = await tools["update_draft"].handler({"title": "anything"})
+
+    assert result.get("is_error") is True
+    assert "draft" in result["content"][0]["text"].lower()
+
+
+@respx.mock
+async def test_update_draft_no_fields_returns_error_no_http():
+    # No route registered — empty body is rejected before any HTTP call
+    tools = {t.name: t for t in build_tool_pack(_ctx())}
+    result = await tools["update_draft"].handler({})
+
+    assert result.get("is_error") is True
+
+
+# ---------------------------------------------------------------------------
+# create_snapshot (Phase 2 write tool)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_create_snapshot_posts_correct_url():
+    route = respx.post(f"{BASE}/publish/drafts/5/snapshots").mock(
+        return_value=httpx.Response(
+            201,
+            json={"data": {"id": 12, "label": "v1.0"}},
+        )
+    )
+    tools = {t.name: t for t in build_tool_pack(_ctx())}
+    result = await tools["create_snapshot"].handler({"label": "v1.0", "comment": "Initial draft"})
+
+    assert route.called
+    import json
+    body = json.loads(route.calls.last.request.content)
+    assert body["label"] == "v1.0"
+    assert body["comment"] == "Initial draft"
+    assert "idempotency_key" in body
+    # idempotency_key must be a non-empty string (UUID)
+    assert isinstance(body["idempotency_key"], str)
+    assert len(body["idempotency_key"]) > 0
+    assert "v1.0" in result["content"][0]["text"]
+
+
+@respx.mock
+async def test_create_snapshot_without_draft_id_returns_error_no_http():
+    # No route registered — confirms no HTTP call is made
+    tools = {t.name: t for t in build_tool_pack(_ctx_no_draft())}
+    result = await tools["create_snapshot"].handler({"label": "v1.0"})
+
+    assert result.get("is_error") is True
+    assert "draft" in result["content"][0]["text"].lower()
+
+
+@respx.mock
+async def test_create_snapshot_empty_label_returns_error_no_http():
+    # No route registered — empty label is rejected before any HTTP call
+    tools = {t.name: t for t in build_tool_pack(_ctx())}
+    result = await tools["create_snapshot"].handler({"label": ""})
+
+    assert result.get("is_error") is True
+    assert "label" in result["content"][0]["text"].lower()
+
+
+@respx.mock
+async def test_create_snapshot_missing_label_returns_error_no_http():
+    tools = {t.name: t for t in build_tool_pack(_ctx())}
+    result = await tools["create_snapshot"].handler({})
+
+    assert result.get("is_error") is True

--- a/ai/tests/test_tool_packs.py
+++ b/ai/tests/test_tool_packs.py
@@ -5,13 +5,20 @@ from __future__ import annotations
 import pytest
 
 from app.agents.tool_base import AgentToolContext
-from app.agents.tool_packs import build_tool_pack, register
+from app.agents.tool_packs import build_tool_pack, register, write_tools
 
 
 def _ctx() -> AgentToolContext:
     return AgentToolContext(
         auth_token="tok",
         context={"study_slug": "t2dm", "design_session_id": 7, "version_id": 3},
+    )
+
+
+def _publish_ctx() -> AgentToolContext:
+    return AgentToolContext(
+        auth_token="tok",
+        context={"draft_id": 5, "study_id": 9},
     )
 
 
@@ -34,3 +41,52 @@ def test_register_adds_custom_profile():
     register("fake_profile", _fake_builder)
     result = build_tool_pack("fake_profile", _ctx())
     assert result == ["tool_a", "tool_b"]
+
+
+# ---------------------------------------------------------------------------
+# write_tools()
+# ---------------------------------------------------------------------------
+
+
+def test_write_tools_publish_returns_correct_set():
+    assert write_tools("publish") == {"update_draft", "create_snapshot"}
+
+
+def test_write_tools_study_design_returns_empty_set():
+    assert write_tools("study_design") == set()
+
+
+def test_write_tools_unknown_profile_returns_empty_set():
+    assert write_tools("completely_unknown_profile") == set()
+
+
+# ---------------------------------------------------------------------------
+# build_tool_pack for publish returns 6 tools (4 reads + 2 writes)
+# ---------------------------------------------------------------------------
+
+
+def test_publish_returns_six_tools():
+    tools = build_tool_pack("publish", _publish_ctx())
+    assert len(tools) == 6
+    names = {t.name for t in tools}
+    assert names == {
+        "list_studies_for_publish",
+        "get_study_analyses",
+        "get_draft",
+        "draft_narrative_section",
+        "update_draft",
+        "create_snapshot",
+    }
+
+
+def test_publish_read_tools_not_in_write_set():
+    """The four read tools must NOT appear in write_tools("publish")."""
+    reads = {"list_studies_for_publish", "get_study_analyses", "get_draft", "draft_narrative_section"}
+    assert reads.isdisjoint(write_tools("publish"))
+
+
+def test_publish_write_tools_in_pack():
+    """The two write tools must be present in the full publish tool pack."""
+    tools = build_tool_pack("publish", _publish_ctx())
+    names = {t.name for t in tools}
+    assert write_tools("publish").issubset(names)

--- a/backend/app/Http/Controllers/Api/V1/PublishAgentController.php
+++ b/backend/app/Http/Controllers/Api/V1/PublishAgentController.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\App\AgentSession;
+use App\Models\App\PublicationDraft;
+use App\Models\User;
+use App\Policies\PublicationDraftPolicy;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+class PublishAgentController extends Controller
+{
+    // NOTE (review C3 — known Phase-1 gap): these abilities scope the minted
+    // Sanctum token, but the publish routes the agent calls are gated only by
+    // auth:sanctum + PublicationDraftPolicy (not Sanctum `abilities:` middleware).
+    // So the agent currently acts with the user's FULL permission set, not this
+    // subset — "cannot exceed the user" holds, but "scoped to publications.view+update"
+    // does NOT. Phase 2 must add `abilities:publications.view` / `abilities:publications.update`
+    // (or `$token->can(...)` checks) to the agent-reachable routes to enforce this.
+    private const AGENT_ABILITIES = ['publications.view', 'publications.update'];
+
+    private function aiBaseUrl(): string
+    {
+        return rtrim((string) config('services.ai.url', 'http://python-ai:8000'), '/');
+    }
+
+    /**
+     * Verify the authenticated user may access the given draft.
+     * Aborts with 401 if unauthenticated or 404 if the policy rejects access.
+     */
+    private function authorizeAccess(Request $request, PublicationDraft $draft): void
+    {
+        abort_unless($request->user() !== null, 401);
+        abort_unless((new PublicationDraftPolicy)->view($request->user(), $draft), 404);
+    }
+
+    /**
+     * Create a new agent session for a publication draft.
+     *
+     * POST /api/v1/publish/drafts/{draft}/agent/sessions
+     */
+    public function start(Request $request, PublicationDraft $draft): JsonResponse
+    {
+        $this->authorizeAccess($request, $draft);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        $agentSession = AgentSession::create([
+            'profile' => 'publish',
+            'subject_type' => 'publication_draft',
+            'subject_id' => $draft->id,
+            'user_id' => $user->id,
+            'status' => 'active',
+            'context_json' => [
+                'draft_id' => $draft->id,
+                'study_id' => $draft->study_id,
+            ],
+            'last_active_at' => now(),
+        ]);
+
+        $newToken = $user->createToken('publish-agent', self::AGENT_ABILITIES);
+        $agentSession->update(['token_id' => $newToken->accessToken->id]);
+
+        $channel = "private-publish.draft.{$draft->id}";
+
+        // Internal call to python-ai (internal-only network, unauthenticated).
+        // The scoped token travels in the body so the agent can call back to Laravel.
+        $resp = Http::acceptJson()->post($this->aiBaseUrl().'/agent/sessions', [
+            'profile' => 'publish',
+            'agent_session_id' => $agentSession->id,
+            'subject_id' => $draft->id,
+            'channel' => $channel,
+            'ingest_path' => "/api/v1/publish/drafts/{$draft->id}/agent/sessions/{$agentSession->id}/ingest",
+            'scoped_token' => $newToken->plainTextToken,
+            'context' => [
+                'draft_id' => $draft->id,
+                'study_id' => $draft->study_id,
+            ],
+        ]);
+
+        if ($resp->failed()) {
+            // Revoke the just-minted scoped token — no agent process will consume it.
+            $newToken->accessToken->delete();
+            $agentSession->update(['status' => 'error', 'token_id' => null]);
+
+            return response()->json(['message' => 'Agent service unavailable'], 503);
+        }
+
+        return response()->json([
+            'data' => [
+                'agent_session_id' => $agentSession->id,
+                'channel_name' => $channel,
+            ],
+        ], 201);
+    }
+
+    /**
+     * Forward a user message to the agent's turn endpoint.
+     *
+     * POST /api/v1/publish/drafts/{draft}/agent/sessions/{agentSession}/messages
+     */
+    public function message(Request $request, PublicationDraft $draft, AgentSession $agentSession): JsonResponse
+    {
+        $this->authorizeAccess($request, $draft);
+        abort_unless(
+            (int) $agentSession->subject_id === (int) $draft->id && $agentSession->profile === 'publish',
+            404,
+        );
+
+        $validated = $request->validate([
+            'text' => ['required', 'string', 'max:8000'],
+            'idempotency_key' => ['required', 'string', 'max:128'],
+        ]);
+
+        $agentSession->update(['last_active_at' => now()]);
+
+        $resp = Http::acceptJson()->post($this->aiBaseUrl()."/agent/sessions/{$agentSession->id}/turn", [
+            'text' => $validated['text'],
+            'idempotency_key' => $validated['idempotency_key'],
+        ]);
+
+        if ($resp->failed()) {
+            return response()->json(['message' => 'Agent service unavailable'], 503);
+        }
+
+        return response()->json(['data' => ['accepted' => true]], 202);
+    }
+
+    /**
+     * Return a cost/token snapshot for an agent session.
+     *
+     * GET /api/v1/publish/drafts/{draft}/agent/sessions/{agentSession}/snapshot
+     */
+    public function snapshot(Request $request, PublicationDraft $draft, AgentSession $agentSession): JsonResponse
+    {
+        $this->authorizeAccess($request, $draft);
+        abort_unless(
+            (int) $agentSession->subject_id === (int) $draft->id && $agentSession->profile === 'publish',
+            404,
+        );
+
+        return response()->json(['data' => [
+            'agent_session_id' => $agentSession->id,
+            'status' => $agentSession->status,
+            'cost_usd' => $agentSession->cost_usd,
+            'tokens_in' => $agentSession->tokens_in,
+            'tokens_out' => $agentSession->tokens_out,
+            'channel_name' => "private-publish.draft.{$draft->id}",
+        ]]);
+    }
+
+    /**
+     * Ingest cost/token telemetry from the python-ai agent (increments running totals).
+     *
+     * POST /api/v1/publish/drafts/{draft}/agent/sessions/{agentSession}/ingest
+     */
+    public function ingest(Request $request, PublicationDraft $draft, AgentSession $agentSession): JsonResponse
+    {
+        $this->authorizeAccess($request, $draft);
+        abort_unless(
+            (int) $agentSession->subject_id === (int) $draft->id && $agentSession->profile === 'publish',
+            404,
+        );
+
+        $validated = $request->validate([
+            'anthropic_session_id' => ['nullable', 'string', 'max:255'],
+            'cost_usd' => ['required', 'numeric', 'min:0'],
+            'tokens_in' => ['required', 'integer', 'min:0'],
+            'tokens_out' => ['required', 'integer', 'min:0'],
+            'status' => ['required', 'string', 'in:active,closed,error'],
+        ]);
+
+        $agentSession->update([
+            'anthropic_session_id' => $validated['anthropic_session_id'] ?? $agentSession->anthropic_session_id,
+            'cost_usd' => (float) $agentSession->cost_usd + (float) $validated['cost_usd'],
+            'tokens_in' => (int) $agentSession->tokens_in + (int) $validated['tokens_in'],
+            'tokens_out' => (int) $agentSession->tokens_out + (int) $validated['tokens_out'],
+            'status' => $validated['status'],
+            'last_active_at' => now(),
+        ]);
+
+        return response()->json(['data' => ['ok' => true]]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/V1/PublishAgentController.php
+++ b/backend/app/Http/Controllers/Api/V1/PublishAgentController.php
@@ -13,13 +13,13 @@ use Illuminate\Support\Facades\Http;
 
 class PublishAgentController extends Controller
 {
-    // NOTE (review C3 — known Phase-1 gap): these abilities scope the minted
-    // Sanctum token, but the publish routes the agent calls are gated only by
-    // auth:sanctum + PublicationDraftPolicy (not Sanctum `abilities:` middleware).
-    // So the agent currently acts with the user's FULL permission set, not this
-    // subset — "cannot exceed the user" holds, but "scoped to publications.view+update"
-    // does NOT. Phase 2 must add `abilities:publications.view` / `abilities:publications.update`
-    // (or `$token->can(...)` checks) to the agent-reachable routes to enforce this.
+    // NOTE (C3 — closed in Phase 2): these abilities scope the minted Sanctum
+    // token. As of Phase 2, the agent-reachable WRITE routes
+    // (PATCH publish/drafts/{draft} and POST publish/drafts/{draft}/snapshots)
+    // carry `abilities:publications.update` middleware, so the scoped token IS
+    // enforced on writes — C3 is closed for the write path. Regular SPA users
+    // are unaffected because their login tokens carry ['*'], which satisfies any
+    // `abilities:` check.
     private const AGENT_ABILITIES = ['publications.view', 'publications.update'];
 
     private function aiBaseUrl(): string
@@ -128,6 +128,36 @@ class PublishAgentController extends Controller
         }
 
         return response()->json(['data' => ['accepted' => true]], 202);
+    }
+
+    /**
+     * Forward a human-approval decision to the agent (tool-use gate).
+     *
+     * POST /api/v1/publish/drafts/{draft}/agent/sessions/{agentSession}/approve
+     */
+    public function approve(Request $request, PublicationDraft $draft, AgentSession $agentSession): JsonResponse
+    {
+        $this->authorizeAccess($request, $draft);
+        abort_unless(
+            (int) $agentSession->subject_id === (int) $draft->id && $agentSession->profile === 'publish',
+            404,
+        );
+
+        $validated = $request->validate([
+            'tool_use_id' => ['required', 'string', 'max:255'],
+            'approved' => ['required', 'boolean'],
+        ]);
+
+        $resp = Http::acceptJson()->post($this->aiBaseUrl()."/agent/sessions/{$agentSession->id}/approve", [
+            'tool_use_id' => $validated['tool_use_id'],
+            'approved' => $validated['approved'],
+        ]);
+
+        if ($resp->failed()) {
+            return response()->json(['message' => 'Agent service unavailable'], 503);
+        }
+
+        return response()->json(['data' => ['resolved' => true]], 200);
     }
 
     /**

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -21,6 +21,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Validation\ValidationException;
+use Laravel\Sanctum\Http\Middleware\CheckAbilities;
 use Spatie\Permission\Middleware\PermissionMiddleware;
 use Spatie\Permission\Middleware\RoleMiddleware;
 use Spatie\Permission\Middleware\RoleOrPermissionMiddleware;
@@ -52,6 +53,7 @@ return Application::configure(basePath: dirname(__DIR__))
             RecordUserActivity::class,
         ]);
         $middleware->alias([
+            'abilities' => CheckAbilities::class,
             'role' => RoleMiddleware::class,
             'permission' => PermissionMiddleware::class,
             'role_or_permission' => RoleOrPermissionMiddleware::class,

--- a/backend/config/feature-flags.php
+++ b/backend/config/feature-flags.php
@@ -18,11 +18,13 @@ return [
     | is installed.
     */
     'flags' => [
-        // Example (commented):
-        // 'audit.signed' => [
-        //     'enabled' => false,
-        //     'source'  => 'ce',
-        //     'description' => 'Signed (HMAC) audit chain shipped to WORM storage.',
-        // ],
+        // AI publication copilot (Claude Agent SDK) on the Publish page. Ships
+        // dark: default OFF. Enable per-deployment with PUBLISH_AGENT_ENABLED=true
+        // once the Anthropic account behind ANTHROPIC_API_KEY is credited.
+        'publish.agent' => [
+            'enabled' => (bool) env('PUBLISH_AGENT_ENABLED', false),
+            'source' => 'config',
+            'description' => 'AI publication copilot (Claude Agent SDK) on the Publish page.',
+        ],
     ],
 ];

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -123,6 +123,7 @@ use App\Http\Controllers\Api\V1\PoseidonController;
 use App\Http\Controllers\Api\V1\PredictionController;
 use App\Http\Controllers\Api\V1\PublicationController;
 use App\Http\Controllers\Api\V1\PublicSurveyController;
+use App\Http\Controllers\Api\V1\PublishAgentController;
 use App\Http\Controllers\Api\V1\QueryLibraryController;
 use App\Http\Controllers\Api\V1\RadiogenomicsController;
 use App\Http\Controllers\Api\V1\RiskScoreAnalysisController;
@@ -1327,6 +1328,12 @@ Route::prefix('v1')->group(function () {
         Route::post('publish/export', [PublicationController::class, 'export']);
         Route::post('publish/report-bundles/export', [PublicationController::class, 'exportReportBundle']);
         Route::post('publish/report-bundles/import', [PublicationController::class, 'importReportBundle']);
+
+        // Publish Agent (C.1 — Phase 1: auth:sanctum only; no permission: middleware — see C3 Phase 2)
+        Route::post('publish/drafts/{draft}/agent/sessions', [PublishAgentController::class, 'start'])->middleware('throttle:20,1');
+        Route::post('publish/drafts/{draft}/agent/sessions/{agentSession}/messages', [PublishAgentController::class, 'message'])->middleware('throttle:30,1');
+        Route::get('publish/drafts/{draft}/agent/sessions/{agentSession}/snapshot', [PublishAgentController::class, 'snapshot']);
+        Route::post('publish/drafts/{draft}/agent/sessions/{agentSession}/ingest', [PublishAgentController::class, 'ingest'])->middleware('throttle:120,1');
 
         // ETL Tools
         Route::prefix('etl')->group(function () {

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1319,10 +1319,10 @@ Route::prefix('v1')->group(function () {
         Route::get('publish/drafts', [PublicationController::class, 'listDrafts']);
         Route::post('publish/drafts', [PublicationController::class, 'createDraft']);
         Route::get('publish/drafts/{draft}', [PublicationController::class, 'showDraft']);
-        Route::patch('publish/drafts/{draft}', [PublicationController::class, 'updateDraft']);
+        Route::patch('publish/drafts/{draft}', [PublicationController::class, 'updateDraft'])->middleware('abilities:publications.update');
         Route::delete('publish/drafts/{draft}', [PublicationController::class, 'deleteDraft']);
         Route::get('publish/drafts/{draft}/snapshots', [PublicationController::class, 'listSnapshots']);
-        Route::post('publish/drafts/{draft}/snapshots', [PublicationController::class, 'createSnapshot']);
+        Route::post('publish/drafts/{draft}/snapshots', [PublicationController::class, 'createSnapshot'])->middleware('abilities:publications.update');
         Route::post('publish/drafts/{draft}/snapshots/{snapshot}/revert', [PublicationController::class, 'revertSnapshot']);
         Route::post('publish/narrative', [PublicationController::class, 'narrative']);
         Route::post('publish/export', [PublicationController::class, 'export']);
@@ -1334,6 +1334,7 @@ Route::prefix('v1')->group(function () {
         Route::post('publish/drafts/{draft}/agent/sessions/{agentSession}/messages', [PublishAgentController::class, 'message'])->middleware('throttle:30,1');
         Route::get('publish/drafts/{draft}/agent/sessions/{agentSession}/snapshot', [PublishAgentController::class, 'snapshot']);
         Route::post('publish/drafts/{draft}/agent/sessions/{agentSession}/ingest', [PublishAgentController::class, 'ingest'])->middleware('throttle:120,1');
+        Route::post('publish/drafts/{draft}/agent/sessions/{agentSession}/approve', [PublishAgentController::class, 'approve'])->middleware('throttle:60,1');
 
         // ETL Tools
         Route::prefix('etl')->group(function () {

--- a/backend/routes/channels.php
+++ b/backend/routes/channels.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Models\App\PublicationDraft;
 use App\Models\App\Study;
 use App\Models\App\StudyDesignSession;
 use App\Models\Commons\ChannelMember;
+use App\Policies\PublicationDraftPolicy;
 use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\Str;
 
@@ -36,4 +38,10 @@ Broadcast::channel('study-design.session.{session}', function ($user, int $sessi
     }
 
     return Study::accessibleBy($user->id)->whereKey($design->study_id)->exists();
+});
+
+Broadcast::channel('publish.draft.{draft}', function ($user, int $draft) {
+    $d = PublicationDraft::find($draft);
+
+    return $d !== null && (new PublicationDraftPolicy)->view($user, $d);
 });

--- a/backend/tests/Feature/Api/V1/PublishAgentSessionTest.php
+++ b/backend/tests/Feature/Api/V1/PublishAgentSessionTest.php
@@ -237,6 +237,173 @@ it('ingest persists cost tokens and anthropic_session_id and returns 200', funct
 });
 
 // ---------------------------------------------------------------------------
+// approve — forwards decision to python-ai and returns 200
+// ---------------------------------------------------------------------------
+
+it('approve forwards tool_use_id and approved flag to python-ai and returns 200', function () {
+    $agentSession = AgentSession::create([
+        'profile' => 'publish',
+        'subject_type' => 'publication_draft',
+        'subject_id' => $this->draft->id,
+        'user_id' => $this->user->id,
+        'status' => 'active',
+        'last_active_at' => now(),
+    ]);
+
+    Http::fake([
+        '*/agent/sessions/*/approve' => Http::response(['ok' => true], 200),
+    ]);
+
+    Sanctum::actingAs($this->user, ['*']);
+
+    $response = $this->postJson(
+        "/api/v1/publish/drafts/{$this->draft->id}/agent/sessions/{$agentSession->id}/approve",
+        ['tool_use_id' => 'toolu_abc123', 'approved' => true],
+    );
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.resolved', true);
+
+    Http::assertSent(function ($request) use ($agentSession) {
+        $body = $request->data();
+
+        return str_ends_with($request->url(), "/agent/sessions/{$agentSession->id}/approve")
+            && $body['tool_use_id'] === 'toolu_abc123'
+            && $body['approved'] === true;
+    });
+});
+
+it('approve returns 503 when python-ai is unavailable', function () {
+    $agentSession = AgentSession::create([
+        'profile' => 'publish',
+        'subject_type' => 'publication_draft',
+        'subject_id' => $this->draft->id,
+        'user_id' => $this->user->id,
+        'status' => 'active',
+        'last_active_at' => now(),
+    ]);
+
+    Http::fake(['*' => Http::response([], 503)]);
+
+    Sanctum::actingAs($this->user, ['*']);
+
+    $this->postJson(
+        "/api/v1/publish/drafts/{$this->draft->id}/agent/sessions/{$agentSession->id}/approve",
+        ['tool_use_id' => 'toolu_abc123', 'approved' => false],
+    )->assertStatus(503);
+});
+
+it('approve returns 404 for a non-owner of the draft', function () {
+    $agentSession = AgentSession::create([
+        'profile' => 'publish',
+        'subject_type' => 'publication_draft',
+        'subject_id' => $this->draft->id,
+        'user_id' => $this->user->id,
+        'status' => 'active',
+        'last_active_at' => now(),
+    ]);
+
+    Http::fake(['*/agent/sessions/*/approve' => Http::response(['ok' => true], 200)]);
+
+    $stranger = User::factory()->create();
+    $stranger->assignRole('researcher');
+    Sanctum::actingAs($stranger, ['*']);
+
+    $this->postJson(
+        "/api/v1/publish/drafts/{$this->draft->id}/agent/sessions/{$agentSession->id}/approve",
+        ['tool_use_id' => 'toolu_abc123', 'approved' => true],
+    )->assertStatus(404);
+});
+
+it('approve returns 404 when agentSession profile or draft does not match', function () {
+    $otherDraft = PublicationDraft::create([
+        'user_id' => $this->user->id,
+        'study_id' => null,
+        'title' => 'Other draft',
+        'template' => 'standard',
+        'document_json' => [],
+        'status' => 'draft',
+        'visibility' => 'private',
+    ]);
+
+    // Session belongs to otherDraft, not $this->draft
+    $agentSession = AgentSession::create([
+        'profile' => 'publish',
+        'subject_type' => 'publication_draft',
+        'subject_id' => $otherDraft->id,
+        'user_id' => $this->user->id,
+        'status' => 'active',
+        'last_active_at' => now(),
+    ]);
+
+    Http::fake(['*/agent/sessions/*/approve' => Http::response(['ok' => true], 200)]);
+
+    Sanctum::actingAs($this->user, ['*']);
+
+    // Passing $this->draft id but session belongs to $otherDraft — must 404
+    $this->postJson(
+        "/api/v1/publish/drafts/{$this->draft->id}/agent/sessions/{$agentSession->id}/approve",
+        ['tool_use_id' => 'toolu_abc123', 'approved' => true],
+    )->assertStatus(404);
+});
+
+// ---------------------------------------------------------------------------
+// abilities enforcement — PATCH publish/drafts/{draft} (updateDraft)
+// ---------------------------------------------------------------------------
+
+it('updateDraft is accessible with a wildcard token', function () {
+    // Real login tokens are minted with createToken() → Sanctum default ['*'].
+    // (Sanctum::actingAs with no abilities arg defaults to [] — not a wildcard.)
+    Sanctum::actingAs($this->user, ['*']);
+
+    $this->patchJson("/api/v1/publish/drafts/{$this->draft->id}", ['title' => 'Updated title'])
+        ->assertStatus(200);
+});
+
+it('updateDraft is accessible with a publications.update scoped token', function () {
+    Sanctum::actingAs($this->user, ['publications.update']);
+
+    $this->patchJson("/api/v1/publish/drafts/{$this->draft->id}", ['title' => 'Updated title'])
+        ->assertStatus(200);
+});
+
+it('updateDraft returns 403 with a publications.view-only scoped token', function () {
+    Sanctum::actingAs($this->user, ['publications.view']);
+
+    $this->patchJson("/api/v1/publish/drafts/{$this->draft->id}", ['title' => 'Blocked'])
+        ->assertStatus(403);
+});
+
+// ---------------------------------------------------------------------------
+// abilities enforcement — POST publish/drafts/{draft}/snapshots (createSnapshot)
+// ---------------------------------------------------------------------------
+
+it('createSnapshot is accessible with a wildcard token', function () {
+    // Real login tokens carry ['*'] (createToken default); replicate that here.
+    Sanctum::actingAs($this->user, ['*']);
+
+    $this->postJson("/api/v1/publish/drafts/{$this->draft->id}/snapshots", [
+        'label' => 'v1',
+    ])->assertStatus(201);
+});
+
+it('createSnapshot is accessible with a publications.update scoped token', function () {
+    Sanctum::actingAs($this->user, ['publications.update']);
+
+    $this->postJson("/api/v1/publish/drafts/{$this->draft->id}/snapshots", [
+        'label' => 'v1',
+    ])->assertStatus(201);
+});
+
+it('createSnapshot returns 403 with a publications.view-only scoped token', function () {
+    Sanctum::actingAs($this->user, ['publications.view']);
+
+    $this->postJson("/api/v1/publish/drafts/{$this->draft->id}/snapshots", [
+        'label' => 'blocked',
+    ])->assertStatus(403);
+});
+
+// ---------------------------------------------------------------------------
 // ingest — increments cost and tokens on a second call
 // ---------------------------------------------------------------------------
 

--- a/backend/tests/Feature/Api/V1/PublishAgentSessionTest.php
+++ b/backend/tests/Feature/Api/V1/PublishAgentSessionTest.php
@@ -1,0 +1,275 @@
+<?php
+
+use App\Models\App\AgentSession;
+use App\Models\App\PublicationDraft;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(RolePermissionSeeder::class);
+
+    $this->user = User::factory()->create();
+    $this->user->assignRole('researcher');
+
+    $this->draft = PublicationDraft::create([
+        'user_id' => $this->user->id,
+        'study_id' => null,
+        'title' => 'Agent test draft',
+        'template' => 'standard',
+        'document_json' => [],
+        'status' => 'draft',
+        'visibility' => 'private',
+    ]);
+});
+
+// ---------------------------------------------------------------------------
+// start — 201, DB row, correct channel name
+// ---------------------------------------------------------------------------
+
+it('start creates an agent session and returns 201 with channel name', function () {
+    Http::fake([
+        '*/agent/sessions' => Http::response(['ok' => true], 200),
+    ]);
+
+    Sanctum::actingAs($this->user, ['*']);
+
+    $response = $this->postJson("/api/v1/publish/drafts/{$this->draft->id}/agent/sessions");
+
+    $response->assertStatus(201)
+        ->assertJsonPath('data.channel_name', "private-publish.draft.{$this->draft->id}");
+
+    $agentSessionId = $response->json('data.agent_session_id');
+    expect($agentSessionId)->toBeInt();
+
+    $this->assertDatabaseHas('agent_sessions', [
+        'id' => $agentSessionId,
+        'profile' => 'publish',
+        'subject_type' => 'publication_draft',
+        'subject_id' => $this->draft->id,
+        'user_id' => $this->user->id,
+        'status' => 'active',
+    ]);
+});
+
+// ---------------------------------------------------------------------------
+// start — minted token has correct name and abilities
+// ---------------------------------------------------------------------------
+
+it('start mints a scoped token with publish-agent name and correct abilities', function () {
+    Http::fake([
+        '*/agent/sessions' => Http::response(['ok' => true], 200),
+    ]);
+
+    Sanctum::actingAs($this->user, ['*']);
+
+    $response = $this->postJson("/api/v1/publish/drafts/{$this->draft->id}/agent/sessions");
+
+    $response->assertStatus(201);
+
+    $agentSessionId = $response->json('data.agent_session_id');
+    $agentSession = AgentSession::findOrFail($agentSessionId);
+
+    // token_id must be recorded on the agent session row
+    expect($agentSession->token_id)->not->toBeNull();
+
+    $token = $this->user->tokens()->where('id', $agentSession->token_id)->firstOrFail();
+
+    expect($token->name)->toBe('publish-agent');
+    expect($token->abilities)->toBe(['publications.view', 'publications.update']);
+});
+
+// ---------------------------------------------------------------------------
+// start — python-ai receives correct generic /agent/sessions body
+// ---------------------------------------------------------------------------
+
+it('start posts correct profile/subject_id/channel/ingest_path/context to python-ai', function () {
+    Http::fake([
+        '*/agent/sessions' => Http::response(['ok' => true], 200),
+    ]);
+
+    Sanctum::actingAs($this->user, ['*']);
+
+    $this->postJson("/api/v1/publish/drafts/{$this->draft->id}/agent/sessions")
+        ->assertStatus(201);
+
+    Http::assertSent(function ($request) {
+        $body = $request->data();
+
+        return str_ends_with($request->url(), '/agent/sessions')
+            && $body['profile'] === 'publish'
+            && (int) $body['subject_id'] === (int) $this->draft->id
+            && $body['channel'] === "private-publish.draft.{$this->draft->id}"
+            && str_contains($body['ingest_path'], '/agent/sessions/')
+            && str_contains($body['ingest_path'], '/ingest')
+            && isset($body['context']['draft_id'])
+            && (int) $body['context']['draft_id'] === (int) $this->draft->id;
+    });
+});
+
+// ---------------------------------------------------------------------------
+// start — python-ai failure revokes token and sets status=error
+// ---------------------------------------------------------------------------
+
+it('start revokes scoped token and sets status error when python-ai fails', function () {
+    Http::fake(['*' => Http::response([], 500)]);
+
+    Sanctum::actingAs($this->user, ['*']);
+
+    $response = $this->postJson("/api/v1/publish/drafts/{$this->draft->id}/agent/sessions");
+
+    $response->assertStatus(503);
+
+    // No publish-agent token must remain for the user
+    expect($this->user->tokens()->where('name', 'publish-agent')->count())->toBe(0);
+
+    // The agent session row must exist with status=error and token_id=null
+    $this->assertDatabaseHas('agent_sessions', [
+        'profile' => 'publish',
+        'subject_type' => 'publication_draft',
+        'subject_id' => $this->draft->id,
+        'user_id' => $this->user->id,
+        'status' => 'error',
+        'token_id' => null,
+    ]);
+});
+
+// ---------------------------------------------------------------------------
+// start — non-owner (policy rejects) gets 404
+// ---------------------------------------------------------------------------
+
+it('start returns 404 for a user who does not own the draft and has no study access', function () {
+    Http::fake([
+        '*/agent/sessions' => Http::response(['ok' => true], 200),
+    ]);
+
+    $stranger = User::factory()->create();
+    $stranger->assignRole('researcher');
+
+    Sanctum::actingAs($stranger, ['*']);
+
+    $response = $this->postJson("/api/v1/publish/drafts/{$this->draft->id}/agent/sessions");
+
+    $response->assertStatus(404);
+});
+
+// ---------------------------------------------------------------------------
+// message — 202 and python-ai /agent/sessions/{id}/turn endpoint is called
+// ---------------------------------------------------------------------------
+
+it('message forwards to python-ai turn endpoint and returns 202', function () {
+    Http::fake([
+        '*/agent/sessions' => Http::response(['ok' => true], 200),
+        '*/agent/sessions/*/turn' => Http::response(['ok' => true], 200),
+    ]);
+
+    Sanctum::actingAs($this->user, ['*']);
+
+    // Create an agent session via start
+    $startResponse = $this->postJson("/api/v1/publish/drafts/{$this->draft->id}/agent/sessions");
+    $startResponse->assertStatus(201);
+    $agentSessionId = $startResponse->json('data.agent_session_id');
+
+    // Send a message
+    $response = $this->postJson(
+        "/api/v1/publish/drafts/{$this->draft->id}/agent/sessions/{$agentSessionId}/messages",
+        [
+            'text' => 'Help me write the methods section for this publication.',
+            'idempotency_key' => 'test-key-'.uniqid(),
+        ],
+    );
+
+    $response->assertStatus(202)
+        ->assertJsonPath('data.accepted', true);
+
+    Http::assertSent(function ($request) use ($agentSessionId) {
+        return str_ends_with($request->url(), "/agent/sessions/{$agentSessionId}/turn");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ingest — persists cost/tokens/session_id and returns 200
+// ---------------------------------------------------------------------------
+
+it('ingest persists cost tokens and anthropic_session_id and returns 200', function () {
+    Sanctum::actingAs($this->user, ['*']);
+
+    $agentSession = AgentSession::create([
+        'profile' => 'publish',
+        'subject_type' => 'publication_draft',
+        'subject_id' => $this->draft->id,
+        'user_id' => $this->user->id,
+        'status' => 'active',
+        'cost_usd' => 0,
+        'tokens_in' => 0,
+        'tokens_out' => 0,
+        'last_active_at' => now(),
+    ]);
+
+    $response = $this->postJson(
+        "/api/v1/publish/drafts/{$this->draft->id}/agent/sessions/{$agentSession->id}/ingest",
+        [
+            'anthropic_session_id' => 'sess-pub-abc',
+            'cost_usd' => 0.05,
+            'tokens_in' => 200,
+            'tokens_out' => 80,
+            'status' => 'active',
+        ],
+    );
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.ok', true);
+
+    $this->assertDatabaseHas('agent_sessions', [
+        'id' => $agentSession->id,
+        'anthropic_session_id' => 'sess-pub-abc',
+        'tokens_in' => 200,
+        'tokens_out' => 80,
+        'status' => 'active',
+    ]);
+
+    $agentSession->refresh();
+    expect((float) $agentSession->cost_usd)->toBe(0.05);
+});
+
+// ---------------------------------------------------------------------------
+// ingest — increments cost and tokens on a second call
+// ---------------------------------------------------------------------------
+
+it('ingest increments cost and tokens on a second call', function () {
+    Sanctum::actingAs($this->user, ['*']);
+
+    $agentSession = AgentSession::create([
+        'profile' => 'publish',
+        'subject_type' => 'publication_draft',
+        'subject_id' => $this->draft->id,
+        'user_id' => $this->user->id,
+        'status' => 'active',
+        'cost_usd' => 0,
+        'tokens_in' => 0,
+        'tokens_out' => 0,
+        'last_active_at' => now(),
+    ]);
+
+    $payload = [
+        'anthropic_session_id' => 'sess-pub-abc',
+        'cost_usd' => 0.05,
+        'tokens_in' => 200,
+        'tokens_out' => 80,
+        'status' => 'active',
+    ];
+
+    $url = "/api/v1/publish/drafts/{$this->draft->id}/agent/sessions/{$agentSession->id}/ingest";
+
+    $this->postJson($url, $payload)->assertStatus(200);
+    $this->postJson($url, $payload)->assertStatus(200);
+
+    $agentSession->refresh();
+    expect((float) $agentSession->cost_usd)->toBe(0.10);
+    expect($agentSession->tokens_in)->toBe(400);
+    expect($agentSession->tokens_out)->toBe(160);
+});

--- a/backend/tests/Feature/Broadcasting/PublishChannelAuthTest.php
+++ b/backend/tests/Feature/Broadcasting/PublishChannelAuthTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\App\PublicationDraft;
+use App\Models\User;
+use App\Policies\PublicationDraftPolicy;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('publish draft channel authorizes the owner and rejects a stranger', function () {
+    $this->seed(RolePermissionSeeder::class);
+
+    $owner = User::factory()->create();
+    $owner->assignRole('researcher');
+
+    $draft = PublicationDraft::create([
+        'user_id' => $owner->id,
+        'study_id' => null,
+        'title' => 'Channel auth test draft',
+        'template' => 'standard',
+        'document_json' => [],
+        'status' => 'draft',
+        'visibility' => 'private',
+    ]);
+
+    $stranger = User::factory()->create();
+    $stranger->assignRole('researcher');
+
+    // routes/channels.php authorizes `publish.draft.{draft}` iff the policy
+    // view() method approves. We assert the predicate directly rather than
+    // POSTing to /api/broadcasting/auth: the default `null` broadcaster does not
+    // enforce channel callbacks (returns 200 for anyone), and forcing a real
+    // driver makes the HTTP result depend on signature/auth state that is not
+    // deterministic across the full suite. The end-to-end auth path is covered
+    // by PublishAgentSessionTest (controller authorizeAccess → 201 owner / 404 stranger).
+    $policy = new PublicationDraftPolicy;
+
+    expect($policy->view($owner, $draft))->toBeTrue();
+    expect($policy->view($stranger, $draft))->toBeFalse();
+
+    // Guard the find()===null branch: a non-existent draft id authorizes no one.
+    $missingDraft = PublicationDraft::find($draft->id + 999_999);
+    expect($missingDraft)->toBeNull();
+});

--- a/frontend/src/features/publish/api/publishAgentApi.ts
+++ b/frontend/src/features/publish/api/publishAgentApi.ts
@@ -38,8 +38,32 @@ export const agentTurnDone = z.object({
 });
 export const agentError = z.object({ message: z.string() });
 
+export const agentApprovalRequest = z.object({
+  tool_use_id: z.string(),
+  tool: z.string(),
+  input: z.unknown(),
+});
+export const agentApprovalDenied = z.object({
+  tool_use_id: z.string(),
+  tool: z.string(),
+});
+
 export type AgentEvent =
   | { type: "text"; text: string }
   | { type: "tool"; name: string; input: unknown }
   | { type: "done"; costUsd: number }
-  | { type: "error"; message: string };
+  | { type: "error"; message: string }
+  | { type: "approval-request"; toolUseId: string; tool: string; input: unknown }
+  | { type: "approval-denied"; toolUseId: string };
+
+export async function approveTool(
+  draftId: number,
+  agentSessionId: number,
+  toolUseId: string,
+  approved: boolean,
+): Promise<void> {
+  await apiClient.post(`${base(draftId)}/${agentSessionId}/approve`, {
+    tool_use_id: toolUseId,
+    approved,
+  });
+}

--- a/frontend/src/features/publish/api/publishAgentApi.ts
+++ b/frontend/src/features/publish/api/publishAgentApi.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import apiClient from "@/lib/api-client";
+
+const base = (draftId: number) => `/publish/drafts/${draftId}/agent/sessions`;
+
+export const startAgentSessionResponse = z.object({
+  agent_session_id: z.number(),
+  channel_name: z.string(),
+});
+export type StartAgentSessionResponse = z.infer<typeof startAgentSessionResponse>;
+
+export async function startAgentSession(
+  draftId: number,
+): Promise<StartAgentSessionResponse> {
+  const { data } = await apiClient.post(base(draftId), {});
+  return startAgentSessionResponse.parse(data.data ?? data);
+}
+
+export async function sendAgentMessage(
+  draftId: number,
+  agentSessionId: number,
+  text: string,
+): Promise<void> {
+  await apiClient.post(`${base(draftId)}/${agentSessionId}/messages`, {
+    text,
+    idempotency_key: crypto.randomUUID(),
+  });
+}
+
+// ── Reverb event payloads ────────────────────────────────────────────────────
+export const agentTextDelta = z.object({ text: z.string() });
+export const agentToolStart = z.object({ name: z.string(), input: z.unknown() });
+export const agentTurnDone = z.object({
+  cost_usd: z.number(),
+  tokens_in: z.number(),
+  tokens_out: z.number(),
+  anthropic_session_id: z.string().nullable(),
+});
+export const agentError = z.object({ message: z.string() });
+
+export type AgentEvent =
+  | { type: "text"; text: string }
+  | { type: "tool"; name: string; input: unknown }
+  | { type: "done"; costUsd: number }
+  | { type: "error"; message: string };

--- a/frontend/src/features/publish/components/agent/AgentCopilotPanel.test.tsx
+++ b/frontend/src/features/publish/components/agent/AgentCopilotPanel.test.tsx
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AgentCopilotPanel } from "./AgentCopilotPanel";
+import { usePublishAgentStore } from "../../stores/publishAgentStore";
+
+vi.mock("@/lib/echo", () => ({ getEcho: () => null }));
+vi.mock("../../api/publishAgentApi", async (orig) => {
+  const actual = await orig<typeof import("../../api/publishAgentApi")>();
+  return {
+    ...actual,
+    startAgentSession: vi.fn().mockResolvedValue({ agent_session_id: 1, channel_name: "private-publish.draft.5" }),
+    sendAgentMessage: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+async function getMocks() {
+  const mod = await import("../../api/publishAgentApi");
+  return mod as typeof mod & {
+    startAgentSession: ReturnType<typeof vi.fn>;
+    sendAgentMessage: ReturnType<typeof vi.fn>;
+  };
+}
+
+function renderPanel() {
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <AgentCopilotPanel draftId={5} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(async () => {
+  const mocks = await getMocks();
+  mocks.startAgentSession.mockClear();
+  mocks.sendAgentMessage.mockClear();
+});
+
+afterEach(() => usePublishAgentStore.getState().reset());
+
+describe("AgentCopilotPanel", () => {
+  it("renders the panel and an empty transcript", () => {
+    renderPanel();
+    expect(screen.getByTestId("agent-copilot-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-transcript")).toBeInTheDocument();
+  });
+
+  it("renders streamed assistant text from the store", () => {
+    renderPanel();
+    act(() => {
+      usePublishAgentStore.getState().pushUserMessage("improve introduction");
+      usePublishAgentStore.getState().applyEvent({ type: "text", text: "Revising the introduction." });
+    });
+    expect(screen.getByText("Revising the introduction.")).toBeInTheDocument();
+  });
+
+  it("auto-start fires exactly once even under React-19 strict double-invoke", async () => {
+    const mocks = await getMocks();
+    renderPanel();
+    // Allow microtasks / mutation effects to settle
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mocks.startAgentSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("input is disabled while streaming", () => {
+    renderPanel();
+    act(() => {
+      usePublishAgentStore.getState().setSession(1, "private-publish.draft.5");
+      usePublishAgentStore.getState().pushUserMessage("test");
+    });
+    const input = screen.getByRole("textbox");
+    expect(input).toBeDisabled();
+  });
+});

--- a/frontend/src/features/publish/components/agent/AgentCopilotPanel.test.tsx
+++ b/frontend/src/features/publish/components/agent/AgentCopilotPanel.test.tsx
@@ -11,6 +11,7 @@ vi.mock("../../api/publishAgentApi", async (orig) => {
     ...actual,
     startAgentSession: vi.fn().mockResolvedValue({ agent_session_id: 1, channel_name: "private-publish.draft.5" }),
     sendAgentMessage: vi.fn().mockResolvedValue(undefined),
+    approveTool: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -19,6 +20,7 @@ async function getMocks() {
   return mod as typeof mod & {
     startAgentSession: ReturnType<typeof vi.fn>;
     sendAgentMessage: ReturnType<typeof vi.fn>;
+    approveTool: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -35,6 +37,7 @@ beforeEach(async () => {
   const mocks = await getMocks();
   mocks.startAgentSession.mockClear();
   mocks.sendAgentMessage.mockClear();
+  mocks.approveTool.mockClear();
 });
 
 afterEach(() => usePublishAgentStore.getState().reset());
@@ -73,5 +76,62 @@ describe("AgentCopilotPanel", () => {
     });
     const input = screen.getByRole("textbox");
     expect(input).toBeDisabled();
+  });
+
+  describe("approval cards", () => {
+    it("renders an approval card when the store has a pendingApproval", () => {
+      renderPanel();
+      act(() => {
+        usePublishAgentStore.getState().setSession(1, "private-publish.draft.5");
+        usePublishAgentStore.getState().applyEvent({
+          type: "approval-request",
+          toolUseId: "tu-1",
+          tool: "write_file",
+          input: { path: "output.md" },
+        });
+      });
+      expect(screen.getByTestId("approval-card")).toBeInTheDocument();
+      expect(screen.getByText("write_file")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /approve/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /reject/i })).toBeInTheDocument();
+    });
+
+    it("clicking Approve calls approveTool with (toolUseId, true)", async () => {
+      const mocks = await getMocks();
+      renderPanel();
+      act(() => {
+        usePublishAgentStore.getState().setSession(1, "private-publish.draft.5");
+        usePublishAgentStore.getState().applyEvent({
+          type: "approval-request",
+          toolUseId: "tu-1",
+          tool: "write_file",
+          input: { path: "output.md" },
+        });
+      });
+      await act(async () => {
+        screen.getByRole("button", { name: /approve/i }).click();
+        await Promise.resolve();
+      });
+      expect(mocks.approveTool).toHaveBeenCalledWith(5, 1, "tu-1", true);
+    });
+
+    it("clicking Reject calls approveTool with (toolUseId, false)", async () => {
+      const mocks = await getMocks();
+      renderPanel();
+      act(() => {
+        usePublishAgentStore.getState().setSession(1, "private-publish.draft.5");
+        usePublishAgentStore.getState().applyEvent({
+          type: "approval-request",
+          toolUseId: "tu-1",
+          tool: "write_file",
+          input: { path: "output.md" },
+        });
+      });
+      await act(async () => {
+        screen.getByRole("button", { name: /reject/i }).click();
+        await Promise.resolve();
+      });
+      expect(mocks.approveTool).toHaveBeenCalledWith(5, 1, "tu-1", false);
+    });
   });
 });

--- a/frontend/src/features/publish/components/agent/AgentCopilotPanel.tsx
+++ b/frontend/src/features/publish/components/agent/AgentCopilotPanel.tsx
@@ -10,8 +10,9 @@ interface Props {
 
 export function AgentCopilotPanel({ draftId }: Props) {
   const { t } = useTranslation();
-  const { start, starting, send } = usePublishAgent({ draftId });
-  const { transcript, isStreaming, agentSessionId, errorMessage } = usePublishAgentStore();
+  const { start, starting, send, approve } = usePublishAgent({ draftId });
+  const { transcript, isStreaming, agentSessionId, errorMessage, pendingApprovals } =
+    usePublishAgentStore();
   const [draft, setDraft] = useState("");
   const startAttemptedRef = useRef(false);
 
@@ -34,6 +35,38 @@ export function AgentCopilotPanel({ draftId }: Props) {
     <aside data-testid="agent-copilot-panel" className="flex h-full w-[360px] flex-col border-l border-white/10 bg-[#0E0E11] p-4">
       <h2 className="mb-2 text-sm font-semibold text-slate-200">{t("publish.agent.title", "Publication Assistant")}</h2>
       {errorMessage && <div className="mb-2 rounded bg-[#9B1B30]/20 p-2 text-xs text-[#9B1B30]">{errorMessage}</div>}
+      {pendingApprovals.length > 0 && (
+        <div className="mb-2 flex flex-col gap-2">
+          {pendingApprovals.map((approval) => (
+            <div
+              key={approval.toolUseId}
+              data-testid="approval-card"
+              className="rounded border border-white/10 bg-white/5 p-2 text-xs text-slate-200"
+            >
+              <p className="mb-1 font-semibold text-[#C9A227]">{approval.tool}</p>
+              <p className="mb-2 break-all text-slate-400">
+                {JSON.stringify(approval.input).slice(0, 160)}
+              </p>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => void approve(approval.toolUseId, true)}
+                  className="rounded bg-[#2DD4BF] px-2 py-0.5 text-black"
+                >
+                  {t("publish.agent.approve", "Approve")}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void approve(approval.toolUseId, false)}
+                  className="rounded bg-[#9B1B30] px-2 py-0.5 text-white"
+                >
+                  {t("publish.agent.reject", "Reject")}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
       <div className="flex-1 overflow-y-auto">
         <AgentTranscript transcript={transcript} isStreaming={isStreaming} />
       </div>

--- a/frontend/src/features/publish/components/agent/AgentCopilotPanel.tsx
+++ b/frontend/src/features/publish/components/agent/AgentCopilotPanel.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { usePublishAgent } from "../../hooks/usePublishAgent";
+import { usePublishAgentStore } from "../../stores/publishAgentStore";
+import { AgentTranscript } from "./AgentTranscript";
+
+interface Props {
+  draftId: number | null;
+}
+
+export function AgentCopilotPanel({ draftId }: Props) {
+  const { t } = useTranslation();
+  const { start, starting, send } = usePublishAgent({ draftId });
+  const { transcript, isStreaming, agentSessionId, errorMessage } = usePublishAgentStore();
+  const [draft, setDraft] = useState("");
+  const startAttemptedRef = useRef(false);
+
+  // Reset the one-shot start guard when the draft context changes.
+  useEffect(() => {
+    startAttemptedRef.current = false;
+  }, [draftId]);
+
+  // Auto-start exactly once per draft context. The ref survives React 19
+  // strict-mode double-invoke and in-flight re-renders, preventing duplicate
+  // agent sessions + scoped tokens.
+  useEffect(() => {
+    if (agentSessionId == null && !startAttemptedRef.current && draftId != null) {
+      startAttemptedRef.current = true;
+      start();
+    }
+  }, [agentSessionId, draftId, start]);
+
+  return (
+    <aside data-testid="agent-copilot-panel" className="flex h-full w-[360px] flex-col border-l border-white/10 bg-[#0E0E11] p-4">
+      <h2 className="mb-2 text-sm font-semibold text-slate-200">{t("publish.agent.title", "Publication Assistant")}</h2>
+      {errorMessage && <div className="mb-2 rounded bg-[#9B1B30]/20 p-2 text-xs text-[#9B1B30]">{errorMessage}</div>}
+      <div className="flex-1 overflow-y-auto">
+        <AgentTranscript transcript={transcript} isStreaming={isStreaming} />
+      </div>
+      <form
+        className="mt-2 flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (draft.trim() && !isStreaming) {
+            void send(draft.trim());
+            setDraft("");
+          }
+        }}
+      >
+        <input
+          aria-label={t("publish.agent.input", "Message the assistant")}
+          className="flex-1 rounded bg-white/5 px-2 py-1 text-sm text-slate-100"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          disabled={starting || agentSessionId == null}
+        />
+        <button type="submit" disabled={isStreaming || agentSessionId == null} className="rounded bg-[#2DD4BF] px-3 py-1 text-sm text-black disabled:opacity-40">
+          {t("common.send", "Send")}
+        </button>
+      </form>
+    </aside>
+  );
+}

--- a/frontend/src/features/publish/components/agent/AgentTranscript.tsx
+++ b/frontend/src/features/publish/components/agent/AgentTranscript.tsx
@@ -1,0 +1,27 @@
+import type { TranscriptTurn } from "../../stores/publishAgentStore";
+
+interface Props {
+  transcript: TranscriptTurn[];
+  isStreaming: boolean;
+}
+
+export function AgentTranscript({ transcript, isStreaming }: Props) {
+  return (
+    <div data-testid="agent-transcript" className="flex flex-col gap-3">
+      {transcript.map((turn, i) => (
+        <div key={i} className={turn.role === "user" ? "text-[#C9A227]" : "text-slate-100"}>
+          <div className="text-xs uppercase tracking-wide opacity-60">{turn.role}</div>
+          <div className="whitespace-pre-wrap">{turn.text}</div>
+          {turn.tools && turn.tools.length > 0 && (
+            <ul className="mt-1 text-xs text-[#2DD4BF]">
+              {turn.tools.map((t, j) => (
+                <li key={j}>&#9881; {t.name}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ))}
+      {isStreaming && <div className="text-xs text-slate-400">…thinking</div>}
+    </div>
+  );
+}

--- a/frontend/src/features/publish/hooks/usePublishAgent.ts
+++ b/frontend/src/features/publish/hooks/usePublishAgent.ts
@@ -2,10 +2,13 @@ import { useCallback, useEffect, useRef } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { getEcho } from "@/lib/echo";
 import {
+  agentApprovalDenied,
+  agentApprovalRequest,
   agentError,
   agentTextDelta,
   agentToolStart,
   agentTurnDone,
+  approveTool,
   sendAgentMessage,
   startAgentSession,
 } from "../api/publishAgentApi";
@@ -61,7 +64,15 @@ export function usePublishAgent({ draftId }: Params) {
       })
       .listen(".agent.error", (e: unknown) =>
         applyEvent({ type: "error", ...agentError.parse(e) }),
-      );
+      )
+      .listen(".agent.approval.request", (e: unknown) => {
+        const p = agentApprovalRequest.parse(e);
+        applyEvent({ type: "approval-request", toolUseId: p.tool_use_id, tool: p.tool, input: p.input });
+      })
+      .listen(".agent.approval.denied", (e: unknown) => {
+        const p = agentApprovalDenied.parse(e);
+        applyEvent({ type: "approval-denied", toolUseId: p.tool_use_id });
+      });
 
     subscribedRef.current = name;
     return () => {
@@ -80,5 +91,14 @@ export function usePublishAgent({ draftId }: Params) {
     [draftId],
   );
 
-  return { start: startMutation.mutate, starting: startMutation.isPending, send };
+  const approve = useCallback(
+    async (toolUseId: string, approved: boolean) => {
+      const { agentSessionId } = usePublishAgentStore.getState();
+      if (draftId == null || agentSessionId == null) return;
+      await approveTool(draftId, agentSessionId, toolUseId, approved);
+    },
+    [draftId],
+  );
+
+  return { start: startMutation.mutate, starting: startMutation.isPending, send, approve };
 }

--- a/frontend/src/features/publish/hooks/usePublishAgent.ts
+++ b/frontend/src/features/publish/hooks/usePublishAgent.ts
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getEcho } from "@/lib/echo";
+import {
+  agentError,
+  agentTextDelta,
+  agentToolStart,
+  agentTurnDone,
+  sendAgentMessage,
+  startAgentSession,
+} from "../api/publishAgentApi";
+import { usePublishAgentStore } from "../stores/publishAgentStore";
+import { PUBLISH_DRAFT_KEYS } from "./usePublicationDrafts";
+
+interface Params {
+  draftId: number | null;
+}
+
+export function usePublishAgent({ draftId }: Params) {
+  const qc = useQueryClient();
+  // Select only the primitive channel name + the (stable) setter. Subscribing to
+  // the whole store here would re-run the effect below on every streamed event,
+  // churning the Echo subscription (leave + re-subscribe per event).
+  const channelName = usePublishAgentStore((s) => s.channelName);
+  const setSession = usePublishAgentStore((s) => s.setSession);
+  const subscribedRef = useRef<string | null>(null);
+
+  const startMutation = useMutation({
+    mutationFn: () => startAgentSession(draftId!),
+    onSuccess: (data) => setSession(data.agent_session_id, data.channel_name),
+  });
+
+  // Subscribe to the private Reverb channel once a session exists. Depends only
+  // on the channel name (primitive) + route params, so streamed events do NOT
+  // re-run it. Store actions are read via getState() (stable) inside listeners.
+  useEffect(() => {
+    if (!channelName) return;
+    const echo = getEcho();
+    if (!echo) return;
+
+    const name = channelName.replace(/^private-/, "");
+    if (subscribedRef.current === name) return;
+    if (subscribedRef.current) echo.leave(subscribedRef.current);
+
+    const { applyEvent } = usePublishAgentStore.getState();
+    echo
+      .private(name)
+      .listen(".agent.text.delta", (e: unknown) =>
+        applyEvent({ type: "text", ...agentTextDelta.parse(e) }),
+      )
+      .listen(".agent.tool.start", (e: unknown) => {
+        const p = agentToolStart.parse(e);
+        applyEvent({ type: "tool", name: p.name, input: p.input });
+      })
+      .listen(".agent.turn.done", (e: unknown) => {
+        applyEvent({ type: "done", costUsd: agentTurnDone.parse(e).cost_usd });
+        if (draftId != null) {
+          qc.invalidateQueries({ queryKey: ["publish", "study"] });
+          qc.invalidateQueries({ queryKey: PUBLISH_DRAFT_KEYS.detail(draftId) });
+        }
+      })
+      .listen(".agent.error", (e: unknown) =>
+        applyEvent({ type: "error", ...agentError.parse(e) }),
+      );
+
+    subscribedRef.current = name;
+    return () => {
+      echo.leave(name);
+      subscribedRef.current = null;
+    };
+  }, [channelName, draftId, qc]);
+
+  const send = useCallback(
+    async (text: string) => {
+      const { agentSessionId, pushUserMessage } = usePublishAgentStore.getState();
+      if (draftId == null || agentSessionId == null) return;
+      pushUserMessage(text);
+      await sendAgentMessage(draftId, agentSessionId, text);
+    },
+    [draftId],
+  );
+
+  return { start: startMutation.mutate, starting: startMutation.isPending, send };
+}

--- a/frontend/src/features/publish/pages/PublishPage.tsx
+++ b/frontend/src/features/publish/pages/PublishPage.tsx
@@ -22,6 +22,7 @@ import { useAutosave } from "../hooks/useAutosave";
 import { useGenerateNarrative } from "../hooks/useNarrativeGeneration";
 import { useDraft, useCreateDraft, useUpdateDraftById } from "../hooks/useDrafts";
 import { useAuthStore } from "@/stores/authStore";
+import { useFlag } from "@/stores/featureFlagsStore";
 import { buildTableFromResults } from "../lib/tableBuilders";
 import { buildDiagramData } from "../lib/diagramBuilders";
 import { getDiagramSvgMarkup } from "../lib/svgExport";
@@ -320,6 +321,9 @@ export default function PublishPage() {
   const { draftId: draftIdParam } = useParams<{ draftId: string }>();
   const draftId =
     draftIdParam && /^\d+$/.test(draftIdParam) ? Number(draftIdParam) : null;
+  // Ships dark: the AI publication copilot only renders when the deployment flag
+  // is enabled (PUBLISH_AGENT_ENABLED) — keeps it off prod until credit is added.
+  const publishAgentEnabled = useFlag("publish.agent");
 
   const [searchParams] = useSearchParams();
   const initialStudyId = searchParams.get("studyId")
@@ -894,7 +898,7 @@ export default function PublishPage() {
         onContinueWithoutSaving={() => setPromptOpen(false)}
       />
       </div>
-      {draftId !== null && <AgentCopilotPanel draftId={draftId} />}
+      {publishAgentEnabled && draftId !== null && <AgentCopilotPanel draftId={draftId} />}
     </div>
   );
 }

--- a/frontend/src/features/publish/pages/PublishPage.tsx
+++ b/frontend/src/features/publish/pages/PublishPage.tsx
@@ -13,6 +13,7 @@ import DocumentConfigurator from "../components/DocumentConfigurator";
 import DocumentPreview from "../components/DocumentPreview";
 import ExportPanel from "../components/ExportPanel";
 import { HybridPromptModal } from "../components/PublishPage/HybridPromptModal";
+import { AgentCopilotPanel } from "../components/agent/AgentCopilotPanel";
 import { ShareDropdown } from "../components/PublishPage/ShareDropdown";
 import { SaveDraftButton } from "../components/library/SaveDraftButton";
 import { SaveStatusIndicator } from "../components/PublishPage/SaveStatusIndicator";
@@ -684,7 +685,8 @@ export default function PublishPage() {
   ]);
 
   return (
-    <div className="space-y-6">
+    <div className="flex gap-0">
+      <div className="min-w-0 flex-1 space-y-6">
       {/* Page header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -891,6 +893,8 @@ export default function PublishPage() {
         onSave={handlePromptSave}
         onContinueWithoutSaving={() => setPromptOpen(false)}
       />
+      </div>
+      {draftId !== null && <AgentCopilotPanel draftId={draftId} />}
     </div>
   );
 }

--- a/frontend/src/features/publish/stores/publishAgentStore.test.ts
+++ b/frontend/src/features/publish/stores/publishAgentStore.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { usePublishAgentStore } from "./publishAgentStore";
+
+afterEach(() => {
+  usePublishAgentStore.getState().reset();
+});
+
+describe("publishAgentStore", () => {
+  it("starts empty and not streaming", () => {
+    const s = usePublishAgentStore.getState();
+    expect(s.transcript).toEqual([]);
+    expect(s.isStreaming).toBe(false);
+  });
+
+  it("appends user + assistant turns and accumulates text deltas", () => {
+    const st = usePublishAgentStore.getState();
+    st.pushUserMessage("find diabetes concepts");
+    st.applyEvent({ type: "text", text: "Searching " });
+    st.applyEvent({ type: "text", text: "the vocabulary." });
+
+    const s = usePublishAgentStore.getState();
+    expect(s.transcript[0]).toEqual({ role: "user", text: "find diabetes concepts" });
+    expect(s.transcript[1]).toEqual({ role: "assistant", text: "Searching the vocabulary.", tools: [] });
+  });
+
+  it("records tool calls on the active assistant turn", () => {
+    const st = usePublishAgentStore.getState();
+    st.pushUserMessage("hi");
+    st.applyEvent({ type: "tool", name: "search_concepts", input: { query: "t2dm" } });
+    const s = usePublishAgentStore.getState();
+    expect(s.transcript[1].tools).toEqual([{ name: "search_concepts", input: { query: "t2dm" } }]);
+  });
+
+  it("marks streaming done and stores cost", () => {
+    const st = usePublishAgentStore.getState();
+    st.pushUserMessage("hi");
+    st.setStreaming(true);
+    st.applyEvent({ type: "done", costUsd: 0.2 });
+    const s = usePublishAgentStore.getState();
+    expect(s.isStreaming).toBe(false);
+    expect(s.lastCostUsd).toBe(0.2);
+  });
+
+  it("sets error message on error event", () => {
+    const st = usePublishAgentStore.getState();
+    st.pushUserMessage("hi");
+    st.applyEvent({ type: "error", message: "Something went wrong" });
+    const s = usePublishAgentStore.getState();
+    expect(s.isStreaming).toBe(false);
+    expect(s.errorMessage).toBe("Something went wrong");
+  });
+
+  it("reset clears all state", () => {
+    const st = usePublishAgentStore.getState();
+    st.setSession(42, "private-publish.draft.42");
+    st.pushUserMessage("test");
+    st.reset();
+    const s = usePublishAgentStore.getState();
+    expect(s.agentSessionId).toBeNull();
+    expect(s.channelName).toBeNull();
+    expect(s.transcript).toEqual([]);
+    expect(s.isStreaming).toBe(false);
+    expect(s.lastCostUsd).toBeNull();
+    expect(s.errorMessage).toBeNull();
+  });
+});

--- a/frontend/src/features/publish/stores/publishAgentStore.test.ts
+++ b/frontend/src/features/publish/stores/publishAgentStore.test.ts
@@ -62,5 +62,49 @@ describe("publishAgentStore", () => {
     expect(s.isStreaming).toBe(false);
     expect(s.lastCostUsd).toBeNull();
     expect(s.errorMessage).toBeNull();
+    expect(s.pendingApprovals).toEqual([]);
+  });
+
+  describe("pendingApprovals", () => {
+    it("approval-request appends a pending item", () => {
+      usePublishAgentStore
+        .getState()
+        .applyEvent({ type: "approval-request", toolUseId: "tu-1", tool: "write_file", input: { path: "out.md" } });
+      expect(usePublishAgentStore.getState().pendingApprovals).toEqual([
+        { toolUseId: "tu-1", tool: "write_file", input: { path: "out.md" } },
+      ]);
+    });
+
+    it("a second identical toolUseId does not duplicate", () => {
+      const st = usePublishAgentStore.getState();
+      st.applyEvent({ type: "approval-request", toolUseId: "tu-1", tool: "write_file", input: { path: "out.md" } });
+      st.applyEvent({ type: "approval-request", toolUseId: "tu-1", tool: "write_file", input: { path: "out.md" } });
+      expect(usePublishAgentStore.getState().pendingApprovals).toHaveLength(1);
+    });
+
+    it("approval-denied removes the matching toolUseId", () => {
+      const st = usePublishAgentStore.getState();
+      st.applyEvent({ type: "approval-request", toolUseId: "tu-1", tool: "write_file", input: {} });
+      st.applyEvent({ type: "approval-request", toolUseId: "tu-2", tool: "read_file", input: {} });
+      st.applyEvent({ type: "approval-denied", toolUseId: "tu-1" });
+      const approvals = usePublishAgentStore.getState().pendingApprovals;
+      expect(approvals).toHaveLength(1);
+      expect(approvals[0].toolUseId).toBe("tu-2");
+    });
+
+    it("done clears all pending approvals", () => {
+      const st = usePublishAgentStore.getState();
+      st.applyEvent({ type: "approval-request", toolUseId: "tu-1", tool: "write_file", input: {} });
+      st.applyEvent({ type: "done", costUsd: 0.1 });
+      expect(usePublishAgentStore.getState().pendingApprovals).toEqual([]);
+    });
+
+    it("reset clears pending approvals", () => {
+      usePublishAgentStore
+        .getState()
+        .applyEvent({ type: "approval-request", toolUseId: "tu-1", tool: "write_file", input: {} });
+      usePublishAgentStore.getState().reset();
+      expect(usePublishAgentStore.getState().pendingApprovals).toEqual([]);
+    });
   });
 });

--- a/frontend/src/features/publish/stores/publishAgentStore.ts
+++ b/frontend/src/features/publish/stores/publishAgentStore.ts
@@ -1,0 +1,88 @@
+import { create } from "zustand";
+import type { AgentEvent } from "../api/publishAgentApi";
+
+export interface ToolCall {
+  name: string;
+  input: unknown;
+}
+
+export interface TranscriptTurn {
+  role: "user" | "assistant";
+  text: string;
+  tools?: ToolCall[];
+}
+
+interface AgentState {
+  agentSessionId: number | null;
+  channelName: string | null;
+  transcript: TranscriptTurn[];
+  isStreaming: boolean;
+  lastCostUsd: number | null;
+  errorMessage: string | null;
+  setSession: (id: number, channel: string) => void;
+  pushUserMessage: (text: string) => void;
+  setStreaming: (v: boolean) => void;
+  applyEvent: (event: AgentEvent) => void;
+  reset: () => void;
+}
+
+function ensureAssistantTurn(transcript: TranscriptTurn[]): TranscriptTurn[] {
+  const last = transcript[transcript.length - 1];
+  if (last && last.role === "assistant") {
+    return transcript;
+  }
+  return [...transcript, { role: "assistant", text: "", tools: [] }];
+}
+
+export const usePublishAgentStore = create<AgentState>((set) => ({
+  agentSessionId: null,
+  channelName: null,
+  transcript: [],
+  isStreaming: false,
+  lastCostUsd: null,
+  errorMessage: null,
+
+  setSession: (id, channel) => set({ agentSessionId: id, channelName: channel }),
+
+  pushUserMessage: (text) =>
+    set((s) => ({
+      transcript: [...s.transcript, { role: "user", text }],
+      isStreaming: true,
+      errorMessage: null,
+    })),
+
+  setStreaming: (v) => set({ isStreaming: v }),
+
+  applyEvent: (event) =>
+    set((s) => {
+      if (event.type === "text") {
+        const t = ensureAssistantTurn(s.transcript);
+        const last = t[t.length - 1];
+        const updated: TranscriptTurn = { ...last, text: last.text + event.text };
+        return { transcript: [...t.slice(0, -1), updated] };
+      }
+      if (event.type === "tool") {
+        const t = ensureAssistantTurn(s.transcript);
+        const last = t[t.length - 1];
+        const updated: TranscriptTurn = {
+          ...last,
+          tools: [...(last.tools ?? []), { name: event.name, input: event.input }],
+        };
+        return { transcript: [...t.slice(0, -1), updated] };
+      }
+      if (event.type === "done") {
+        return { isStreaming: false, lastCostUsd: event.costUsd };
+      }
+      return { isStreaming: false, errorMessage: event.message };
+    }),
+
+  reset: () =>
+    set({
+      agentSessionId: null,
+      channelName: null,
+      transcript: [],
+      isStreaming: false,
+      lastCostUsd: null,
+      errorMessage: null,
+    }),
+}));

--- a/frontend/src/features/publish/stores/publishAgentStore.ts
+++ b/frontend/src/features/publish/stores/publishAgentStore.ts
@@ -12,6 +12,12 @@ export interface TranscriptTurn {
   tools?: ToolCall[];
 }
 
+export interface PendingApproval {
+  toolUseId: string;
+  tool: string;
+  input: unknown;
+}
+
 interface AgentState {
   agentSessionId: number | null;
   channelName: string | null;
@@ -19,6 +25,7 @@ interface AgentState {
   isStreaming: boolean;
   lastCostUsd: number | null;
   errorMessage: string | null;
+  pendingApprovals: PendingApproval[];
   setSession: (id: number, channel: string) => void;
   pushUserMessage: (text: string) => void;
   setStreaming: (v: boolean) => void;
@@ -41,6 +48,7 @@ export const usePublishAgentStore = create<AgentState>((set) => ({
   isStreaming: false,
   lastCostUsd: null,
   errorMessage: null,
+  pendingApprovals: [],
 
   setSession: (id, channel) => set({ agentSessionId: id, channelName: channel }),
 
@@ -70,8 +78,24 @@ export const usePublishAgentStore = create<AgentState>((set) => ({
         };
         return { transcript: [...t.slice(0, -1), updated] };
       }
+      if (event.type === "approval-request") {
+        // Dedupe: ignore if toolUseId already present
+        const already = s.pendingApprovals.some((p) => p.toolUseId === event.toolUseId);
+        if (already) return {};
+        return {
+          pendingApprovals: [
+            ...s.pendingApprovals,
+            { toolUseId: event.toolUseId, tool: event.tool, input: event.input },
+          ],
+        };
+      }
+      if (event.type === "approval-denied") {
+        return {
+          pendingApprovals: s.pendingApprovals.filter((p) => p.toolUseId !== event.toolUseId),
+        };
+      }
       if (event.type === "done") {
-        return { isStreaming: false, lastCostUsd: event.costUsd };
+        return { isStreaming: false, lastCostUsd: event.costUsd, pendingApprovals: [] };
       }
       return { isStreaming: false, errorMessage: event.message };
     }),
@@ -84,5 +108,6 @@ export const usePublishAgentStore = create<AgentState>((set) => ({
       isStreaming: false,
       lastCostUsd: null,
       errorMessage: null,
+      pendingApprovals: [],
     }),
 }));

--- a/frontend/src/types/featureFlags.ts
+++ b/frontend/src/types/featureFlags.ts
@@ -27,6 +27,7 @@ export interface FlagNameRegistry {
   "observability.opentelemetry": true;
   "crypto.fips": true;
   "operator.k8s": true;
+  "publish.agent": true;
 }
 
 export type FlagName = keyof FlagNameRegistry;


### PR DESCRIPTION
## What

An autonomous Claude Agent SDK copilot in the Publish page, built on the generalized agent core (PR #346). **Ships dark** behind the `publish.agent` feature flag (`PUBLISH_AGENT_ENABLED`, default OFF) so it's merge-safe.

### Phase 1 — read-only
Research a study and draft IMRAD manuscript sections grounded in real analysis results, streamed into a copilot panel. Backend `PublishAgentController` on the generic `AgentSession` (profile=`publish`); channel `private-publish.draft.{id}` (auth via `PublicationDraftPolicy`); Python `publish_tools` (4 read tools) + `publish` profile.

### Phase 2 — write + approval
- **Approval gate:** write tools are excluded from `allowed_tools` and routed through a `can_use_tool` callback that emits `agent.approval.request`, blocks on a per-session `asyncio.Future` (timeout `agent_approval_timeout_seconds`), and returns Allow/Deny. `permission_mode="default"` only for profiles with write tools; **study_design is unchanged** (`dontAsk`). New `POST /agent/sessions/{id}/approve` resolves it. Unknown tools fail closed.
- **Write tools:** `update_draft`, `create_snapshot` (gated). (Export stays a UI action.)
- **Frontend:** Approve/Reject cards in the copilot panel.
- **C3 closed:** `abilities:publications.update` on the agent-reachable write routes (`PATCH publish/drafts/{draft}`, `POST .../snapshots`). Real users unaffected (login tokens carry `['*']`); the agent's scoped token is now enforced. Registered the Sanctum `abilities` middleware alias.

## Tests
- Python: **480 pytest pass**, mypy clean (gate, write tools, approve endpoint, profile-isolation).
- Laravel: **44 Pest pass** (publish agent + abilities enforcement + existing publication suites).
- Frontend: tsc + vite build + eslint clean, **vitest 78 pass**.

## ⚠️ Live verification pending Anthropic credit
The account behind `ANTHROPIC_API_KEY` is out of credit, so the agent can't *generate* and the `can_use_tool`/`permission_mode` interaction (the one piece that can't be unit-tested against the real SDK) is **not yet live-verified**. The flag keeps it off prod until credit is added and the flag is flipped. Everything else (routing, transport, auth, gate mechanism) is tested with mocks.

## Deploy note
On merge: no new migrations beyond #346. Frontend rebuild via `./deploy.sh --frontend`. The copilot stays hidden until `PUBLISH_AGENT_ENABLED=true`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
