### PR TITLE
feat(admin): runtime AI Agents toggle (replaces publish.agent flag, gates both copilots)

### DIFF
--- a/backend/app/FeatureFlags/FeatureFlagResolver.php
+++ b/backend/app/FeatureFlags/FeatureFlagResolver.php
@@ -6,6 +6,7 @@ namespace App\FeatureFlags;
 
 use App\Auth\AuthDriverRegistry;
 use App\Contracts\TenantResolverInterface;
+use App\Models\App\SystemSetting;
 use App\Tenancy\SingleTenantResolver;
 
 /**
@@ -80,6 +81,14 @@ class FeatureFlagResolver
             enabled: $isMulti,
             source: $isMulti ? 'ee' : 'ce',
             description: 'Multi-tenant request routing.',
+        );
+
+        $agentsEnabled = SystemSetting::getValue('agents.enabled', '0') === '1';
+        $flags[] = new FeatureFlag(
+            name: 'ai.agents',
+            enabled: $agentsEnabled,
+            source: 'config',
+            description: 'AI agent copilots (Claude Agent SDK) across Study Designer and Publish.',
         );
 
         return $flags;

--- a/backend/app/Http/Controllers/Api/V1/Admin/AgentSettingsController.php
+++ b/backend/app/Http/Controllers/Api/V1/Admin/AgentSettingsController.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\App\AiProviderSetting;
+use App\Models\App\SystemSetting;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * @group Administration
+ *
+ * Runtime toggle for the AI agent copilots (Claude Agent SDK).
+ * Persisted in `system_settings` under key `agents.enabled`.
+ * Only super-admins may read or write this setting.
+ */
+class AgentSettingsController extends Controller
+{
+    /**
+     * GET /api/v1/admin/ai-agents
+     *
+     * Returns the current agent toggle state and whether an Anthropic-capable
+     * provider is configured and enabled (the prerequisite for Claude agents).
+     */
+    public function show(): JsonResponse
+    {
+        return response()->json($this->payload());
+    }
+
+    /**
+     * PUT /api/v1/admin/ai-agents
+     *
+     * Toggles the `agents.enabled` system setting.
+     *
+     * Body: { "enabled": true|false }
+     */
+    public function update(Request $request): JsonResponse
+    {
+        $request->validate([
+            'enabled' => ['required', 'boolean'],
+        ]);
+
+        SystemSetting::setValue(
+            'agents.enabled',
+            $request->boolean('enabled') ? '1' : '0',
+            'agents',
+        );
+
+        return response()->json($this->payload());
+    }
+
+    /**
+     * Build the response payload shared by show() and update().
+     *
+     * `anthropic_ready` is true when the `anthropic` AiProviderSetting row
+     * exists and is_enabled=true (meaning the super-admin has explicitly
+     * enabled it, which requires a valid api_key to have been saved).  If no
+     * row exists yet we fall back to checking the ANTHROPIC_API_KEY env var so
+     * fresh installs that set the key in .env before seeding still report
+     * ready=true.
+     *
+     * @return array{enabled: bool, anthropic_ready: bool}
+     */
+    private function payload(): array
+    {
+        $enabled = SystemSetting::getValue('agents.enabled', '0') === '1';
+
+        $anthropicReady = AiProviderSetting::where('provider_type', 'anthropic')
+            ->where('is_enabled', true)
+            ->exists();
+
+        // Env-key fallback for installs that haven't seeded the provider table yet.
+        if (! $anthropicReady) {
+            $anthropicReady = (bool) env('ANTHROPIC_API_KEY');
+        }
+
+        return [
+            'enabled' => $enabled,
+            'anthropic_ready' => $anthropicReady,
+        ];
+    }
+}

--- a/backend/config/feature-flags.php
+++ b/backend/config/feature-flags.php
@@ -18,13 +18,10 @@ return [
     | is installed.
     */
     'flags' => [
-        // AI publication copilot (Claude Agent SDK) on the Publish page. Ships
-        // dark: default OFF. Enable per-deployment with PUBLISH_AGENT_ENABLED=true
-        // once the Anthropic account behind ANTHROPIC_API_KEY is credited.
-        'publish.agent' => [
-            'enabled' => (bool) env('PUBLISH_AGENT_ENABLED', false),
-            'source' => 'config',
-            'description' => 'AI publication copilot (Claude Agent SDK) on the Publish page.',
-        ],
+        // CE ships zero static entries here. The runtime `ai.agents` flag is
+        // emitted by FeatureFlagResolver directly from the `system_settings` DB
+        // row (key: agents.enabled) so super-admins can toggle it without a
+        // redeploy. EE bundles may append entries via their own published
+        // config or by binding their own FeatureFlagResolver subclass.
     ],
 ];

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\V1\AbbyAiController;
 use App\Http\Controllers\Api\V1\AbbyConversationController;
 use App\Http\Controllers\Api\V1\AbbyProfileController;
 use App\Http\Controllers\Api\V1\AchillesController;
+use App\Http\Controllers\Api\V1\Admin\AgentSettingsController;
 use App\Http\Controllers\Api\V1\Admin\AiProviderController;
 use App\Http\Controllers\Api\V1\Admin\AppSettingsController;
 use App\Http\Controllers\Api\V1\Admin\AtlasMigrationController;
@@ -1504,6 +1505,12 @@ Route::prefix('v1')->group(function () {
                 Route::post('/{type}/disable', [AiProviderController::class, 'disable']);
                 Route::post('/{type}/activate', [AiProviderController::class, 'activate']);
                 Route::post('/{type}/test', [AiProviderController::class, 'test']);
+            });
+
+            // ── AI agent toggle (super-admin only) ───────────────────────
+            Route::middleware('role:super-admin')->prefix('ai-agents')->group(function () {
+                Route::get('/', [AgentSettingsController::class, 'show']);
+                Route::put('/', [AgentSettingsController::class, 'update']);
             });
 
             // ── WebAPI registry (admin+) ──────────────────────────────────

--- a/backend/tests/Feature/Api/V1/Admin/AgentSettingsControllerTest.php
+++ b/backend/tests/Feature/Api/V1/Admin/AgentSettingsControllerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1\Admin;
+
+use App\Models\App\SystemSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class AgentSettingsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Minimal role bootstrap — mirror LibraryControllerTest pattern.
+        Role::firstOrCreate(['name' => 'super-admin', 'guard_name' => 'web']);
+        Role::firstOrCreate(['name' => 'admin', 'guard_name' => 'web']);
+    }
+
+    // ── GET /api/v1/admin/ai-agents ───────────────────────────────────────────
+
+    public function test_unauthenticated_get_returns_401(): void
+    {
+        $this->getJson('/api/v1/admin/ai-agents')->assertUnauthorized();
+    }
+
+    public function test_non_super_admin_get_returns_403(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+        Sanctum::actingAs($user);
+
+        $this->getJson('/api/v1/admin/ai-agents')->assertForbidden();
+    }
+
+    public function test_super_admin_get_returns_shape(): void
+    {
+        $super = User::factory()->create();
+        $super->assignRole('super-admin');
+        Sanctum::actingAs($super);
+
+        $res = $this->getJson('/api/v1/admin/ai-agents');
+
+        $res->assertOk()
+            ->assertJsonStructure(['enabled', 'anthropic_ready'])
+            ->assertJsonPath('enabled', false);  // default: no DB row → '0'
+    }
+
+    // ── PUT /api/v1/admin/ai-agents ───────────────────────────────────────────
+
+    public function test_unauthenticated_put_returns_401(): void
+    {
+        $this->putJson('/api/v1/admin/ai-agents', ['enabled' => true])->assertUnauthorized();
+    }
+
+    public function test_non_super_admin_put_returns_403(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('admin');
+        Sanctum::actingAs($user);
+
+        $this->putJson('/api/v1/admin/ai-agents', ['enabled' => true])->assertForbidden();
+    }
+
+    public function test_put_enabled_true_persists_and_get_reflects_it(): void
+    {
+        $super = User::factory()->create();
+        $super->assignRole('super-admin');
+        Sanctum::actingAs($super);
+
+        $put = $this->putJson('/api/v1/admin/ai-agents', ['enabled' => true]);
+
+        $put->assertOk()
+            ->assertJsonPath('enabled', true);
+
+        // DB row must be set.
+        $this->assertSame('1', SystemSetting::getValue('agents.enabled', '0'));
+
+        // Subsequent GET also reflects the new state.
+        $this->getJson('/api/v1/admin/ai-agents')
+            ->assertOk()
+            ->assertJsonPath('enabled', true);
+    }
+
+    public function test_put_enabled_false_flips_back(): void
+    {
+        // Pre-seed an enabled state.
+        SystemSetting::setValue('agents.enabled', '1', 'agents');
+
+        $super = User::factory()->create();
+        $super->assignRole('super-admin');
+        Sanctum::actingAs($super);
+
+        $put = $this->putJson('/api/v1/admin/ai-agents', ['enabled' => false]);
+
+        $put->assertOk()
+            ->assertJsonPath('enabled', false);
+
+        $this->assertSame('0', SystemSetting::getValue('agents.enabled', '0'));
+    }
+
+    public function test_put_missing_enabled_field_returns_422(): void
+    {
+        $super = User::factory()->create();
+        $super->assignRole('super-admin');
+        Sanctum::actingAs($super);
+
+        $this->putJson('/api/v1/admin/ai-agents', [])->assertUnprocessable();
+    }
+}

--- a/backend/tests/Feature/Api/V1/System/FeatureFlagsControllerTest.php
+++ b/backend/tests/Feature/Api/V1/System/FeatureFlagsControllerTest.php
@@ -2,9 +2,15 @@
 
 declare(strict_types=1);
 
+use App\Models\App\SystemSetting;
 use App\Tenancy\SingleTenantResolver;
 
-it('returns 200 + a tenancy.multi flag without authentication on a fresh CE install', function () {
+beforeEach(function () {
+    // Ensure the ai.agents DB setting is absent so each test starts clean.
+    SystemSetting::where('key', 'agents.enabled')->delete();
+});
+
+it('returns 200 + tenancy.multi and ai.agents flags without authentication on a fresh CE install', function () {
     config(['tenancy.resolver' => SingleTenantResolver::class]);
     config(['feature-flags.flags' => []]);
 
@@ -18,8 +24,13 @@ it('returns 200 + a tenancy.multi flag without authentication on a fresh CE inst
     $names = collect($body['data'])->pluck('name')->all();
     expect($names)
         ->toContain('tenancy.multi')
+        ->toContain('ai.agents')
         ->and($names)->not->toContain('auth.saml')
         ->and($names)->not->toContain('auth.keycloak');
+
+    // ai.agents defaults disabled when no DB row is present.
+    $agents = collect($body['data'])->firstWhere('name', 'ai.agents');
+    expect($agents['enabled'])->toBeFalse();
 });
 
 it('reports tenancy.multi=false / source=ce on the CE single-tenant default', function () {

--- a/backend/tests/Feature/FeatureFlags/FeatureFlagResolverTest.php
+++ b/backend/tests/Feature/FeatureFlags/FeatureFlagResolverTest.php
@@ -8,13 +8,14 @@ use App\Contracts\AuthDriverInterface;
 use App\Contracts\TenantResolverInterface;
 use App\FeatureFlags\FeatureFlag;
 use App\FeatureFlags\FeatureFlagResolver;
+use App\Models\App\SystemSetting;
 use App\Tenancy\SingleTenantResolver;
 
 beforeEach(function () {
     config(['feature-flags.flags' => []]);
 });
 
-it('returns only the tenancy.multi flag on a fresh CE single-tenant install', function () {
+it('returns tenancy.multi and ai.agents on a fresh CE single-tenant install', function () {
     config(['tenancy.resolver' => SingleTenantResolver::class]);
 
     $resolver = new FeatureFlagResolver(
@@ -27,6 +28,7 @@ it('returns only the tenancy.multi flag on a fresh CE single-tenant install', fu
     $names = array_map(fn (FeatureFlag $f) => $f->name, $flags);
     expect($names)
         ->toContain('tenancy.multi')
+        ->toContain('ai.agents')
         ->and($names)->not->toContain('auth.saml')
         ->and($names)->not->toContain('auth.keycloak');
 
@@ -35,6 +37,13 @@ it('returns only the tenancy.multi flag on a fresh CE single-tenant install', fu
         ->not->toBeNull()
         ->and($tenancy->enabled)->toBeFalse()
         ->and($tenancy->source)->toBe('ce');
+
+    // ai.agents defaults to disabled when no DB row exists.
+    $agents = collect($flags)->firstWhere('name', 'ai.agents');
+    expect($agents)
+        ->not->toBeNull()
+        ->and($agents->enabled)->toBeFalse()
+        ->and($agents->source)->toBe('config');
 });
 
 it('flips tenancy.multi=true when a non-CE resolver is configured', function () {
@@ -150,4 +159,17 @@ it('every flag toArray() round-trips with stable shape', function () {
             ->and($row['enabled'])->toBeBool()
             ->and(in_array($row['source'], ['ce', 'ee', 'config', 'license'], true))->toBeTrue();
     }
+});
+
+it('ai.agents flips to enabled=true when agents.enabled system setting is 1', function () {
+    SystemSetting::setValue('agents.enabled', '1', 'agents');
+
+    $resolver = new FeatureFlagResolver(authDrivers: null, tenants: null);
+    $flags = $resolver->resolve();
+
+    $agents = collect($flags)->firstWhere('name', 'ai.agents');
+    expect($agents)
+        ->not->toBeNull()
+        ->and($agents->enabled)->toBeTrue()
+        ->and($agents->source)->toBe('config');
 });

--- a/frontend/src/features/administration/__tests__/AiAgentsToggle.test.tsx
+++ b/frontend/src/features/administration/__tests__/AiAgentsToggle.test.tsx
@@ -1,0 +1,224 @@
+// ---------------------------------------------------------------------------
+// AI Agents toggle — AiProvidersPage integration test
+//
+// Covers:
+//   - AgentsToggleCard renders with the toggle
+//   - Flipping the toggle calls setAgentSettings(true/false)
+//   - On success, both ["ai-agents"] and ["system","feature-flags"] are invalidated
+// ---------------------------------------------------------------------------
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import MockAdapter from "axios-mock-adapter";
+import type { PropsWithChildren } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import apiClient from "@/lib/api-client";
+import AiProvidersPage from "../pages/AiProvidersPage";
+
+let mock: MockAdapter;
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function Wrapper({ client, children }: PropsWithChildren<{ client: QueryClient }>) {
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  mock = new MockAdapter(apiClient);
+  // Provider list — empty so ProviderCard noise doesn't interfere
+  mock.onGet("/api/v1/admin/ai-providers").reply(200, []);
+});
+
+afterEach(() => {
+  mock.restore();
+  vi.restoreAllMocks();
+});
+
+describe("AI Agents toggle card", () => {
+  it("renders the toggle in disabled state when enabled=false", async () => {
+    mock.onGet("/api/v1/admin/ai-agents").reply(200, {
+      enabled: false,
+      anthropic_ready: false,
+    });
+
+    const client = makeClient();
+    render(
+      <Wrapper client={client}>
+        <AiProvidersPage />
+      </Wrapper>,
+    );
+
+    // Card title uses the fallback string since no i18n resources are loaded
+    await waitFor(() =>
+      expect(screen.getByText("AI Agents")).toBeInTheDocument(),
+    );
+
+    // Wait for the query to resolve so the checkbox reflects the server value
+    const toggle = await waitFor(() =>
+      screen.getByRole("checkbox", {
+        name: /Toggle AI Agents/i,
+      }) as HTMLInputElement,
+    );
+    expect(toggle.checked).toBe(false);
+  });
+
+  it("renders the toggle in enabled state when enabled=true", async () => {
+    mock.onGet("/api/v1/admin/ai-agents").reply(200, {
+      enabled: true,
+      anthropic_ready: true,
+    });
+
+    const client = makeClient();
+    render(
+      <Wrapper client={client}>
+        <AiProvidersPage />
+      </Wrapper>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("AI Agents")).toBeInTheDocument(),
+    );
+
+    // Wait until the checkbox reflects the resolved value (enabled=true)
+    await waitFor(() => {
+      const toggle = screen.getByRole("checkbox", {
+        name: /Toggle AI Agents/i,
+      }) as HTMLInputElement;
+      expect(toggle.checked).toBe(true);
+    });
+  });
+
+  it("shows the Anthropic-not-ready hint when enabled but anthropic_ready=false", async () => {
+    mock.onGet("/api/v1/admin/ai-agents").reply(200, {
+      enabled: true,
+      anthropic_ready: false,
+    });
+
+    const client = makeClient();
+    render(
+      <Wrapper client={client}>
+        <AiProvidersPage />
+      </Wrapper>,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Anthropic provider not configured/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("does not show the Anthropic hint when anthropic_ready=true", async () => {
+    mock.onGet("/api/v1/admin/ai-agents").reply(200, {
+      enabled: true,
+      anthropic_ready: true,
+    });
+
+    const client = makeClient();
+    render(
+      <Wrapper client={client}>
+        <AiProvidersPage />
+      </Wrapper>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("AI Agents")).toBeInTheDocument(),
+    );
+
+    expect(
+      screen.queryByText(/Anthropic provider not configured/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls PUT /ai-agents with enabled=true when toggle is flipped on", async () => {
+    mock.onGet("/api/v1/admin/ai-agents").reply(200, {
+      enabled: false,
+      anthropic_ready: false,
+    });
+    mock.onPut("/api/v1/admin/ai-agents").reply(200, {
+      enabled: true,
+      anthropic_ready: false,
+    });
+
+    const client = makeClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    render(
+      <Wrapper client={client}>
+        <AiProvidersPage />
+      </Wrapper>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("AI Agents")).toBeInTheDocument(),
+    );
+
+    const toggle = screen.getByRole("checkbox", { name: /Toggle AI Agents/i });
+    fireEvent.click(toggle);
+
+    // Wait for the PUT to complete and verify its payload
+    await waitFor(() => {
+      const putHistory = mock.history["put"] ?? [];
+      expect(putHistory.length).toBeGreaterThan(0);
+    });
+
+    const putHistory = mock.history["put"] ?? [];
+    const body = JSON.parse(putHistory[0]?.data as string) as { enabled: boolean };
+    expect(body.enabled).toBe(true);
+
+    // Both caches must be invalidated so useFlag("ai.agents") refreshes
+    await waitFor(() => {
+      const calls = invalidateSpy.mock.calls.map((c) =>
+        (c[0] as { queryKey?: unknown }).queryKey,
+      );
+      expect(calls).toContainEqual(["ai-agents"]);
+      expect(calls).toContainEqual(["system", "feature-flags"]);
+    });
+  });
+
+  it("calls PUT /ai-agents with enabled=false when toggle is flipped off", async () => {
+    mock.onGet("/api/v1/admin/ai-agents").reply(200, {
+      enabled: true,
+      anthropic_ready: true,
+    });
+    mock.onPut("/api/v1/admin/ai-agents").reply(200, {
+      enabled: false,
+      anthropic_ready: true,
+    });
+
+    const client = makeClient();
+    render(
+      <Wrapper client={client}>
+        <AiProvidersPage />
+      </Wrapper>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("AI Agents")).toBeInTheDocument(),
+    );
+
+    // Wait for the checkbox to reflect the resolved enabled=true value before clicking
+    await waitFor(() => {
+      const toggle = screen.getByRole("checkbox", { name: /Toggle AI Agents/i }) as HTMLInputElement;
+      expect(toggle.checked).toBe(true);
+    });
+
+    const toggle = screen.getByRole("checkbox", { name: /Toggle AI Agents/i });
+    fireEvent.click(toggle);
+
+    // Wait for the PUT and verify payload is enabled=false
+    await waitFor(() => {
+      const putHistory = mock.history["put"] ?? [];
+      expect(putHistory.length).toBeGreaterThan(0);
+    });
+
+    const putHistory = mock.history["put"] ?? [];
+    const body = JSON.parse(putHistory[0]?.data as string) as { enabled: boolean };
+    expect(body.enabled).toBe(false);
+  });
+});

--- a/frontend/src/features/administration/api/adminApi.ts
+++ b/frontend/src/features/administration/api/adminApi.ts
@@ -129,6 +129,19 @@ export const disableAiProvider = (type: string) =>
 export const testAiProvider = (type: string) =>
   apiClient.post<TestResult>(`/admin/ai-providers/${type}/test`).then((r) => r.data);
 
+// ── AI Agents Feature Flag ────────────────────────────────────────────────────
+
+export interface AgentSettings {
+  enabled: boolean;
+  anthropic_ready: boolean;
+}
+
+export const fetchAgentSettings = (): Promise<AgentSettings> =>
+  apiClient.get<AgentSettings>("/admin/ai-agents").then((r) => r.data);
+
+export const setAgentSettings = (enabled: boolean): Promise<AgentSettings> =>
+  apiClient.put<AgentSettings>("/admin/ai-agents", { enabled }).then((r) => r.data);
+
 // ── System Health ─────────────────────────────────────────────────────────────
 
 export const fetchSystemHealth = () =>

--- a/frontend/src/features/administration/hooks/useAiProviders.ts
+++ b/frontend/src/features/administration/hooks/useAiProviders.ts
@@ -3,17 +3,23 @@ import {
   activateAiProvider,
   disableAiProvider,
   enableAiProvider,
+  fetchAgentSettings,
   fetchAiProvider,
   fetchAiProviders,
   fetchHadesPackageInventory,
   fetchLiveKitConfig,
   fetchServiceDetail,
   fetchSystemHealth,
+  setAgentSettings,
   testAiProvider,
   testLiveKitConnection,
   updateAiProvider,
   updateLiveKitConfig,
 } from "../api/adminApi";
+
+// Feature-flags query key — must match the key used in useFeatureFlagsQuery
+// (frontend/src/features/system/api.ts) so invalidation refreshes useFlag().
+const FEATURE_FLAGS_KEY = ["system", "feature-flags"] as const;
 
 const QUERY_KEY = "ai-providers";
 const HEALTH_KEY = "system-health";
@@ -109,4 +115,31 @@ export function useUpdateLiveKitConfig() {
 
 export function useTestLiveKitConnection() {
   return useMutation({ mutationFn: testLiveKitConnection });
+}
+
+// ── AI Agents Feature Flag ────────────────────────────────────────────────────
+
+const AGENT_SETTINGS_KEY = "ai-agents";
+
+export function useAgentSettings() {
+  return useQuery({
+    queryKey: [AGENT_SETTINGS_KEY],
+    queryFn: fetchAgentSettings,
+  });
+}
+
+export function useSetAgentSettings() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (enabled: boolean) => setAgentSettings(enabled),
+    onSuccess: () => {
+      // Invalidate the agent settings cache so the toggle reflects the new state.
+      void qc.invalidateQueries({ queryKey: [AGENT_SETTINGS_KEY] });
+      // Invalidate the feature-flags query so useFlag("ai.agents") refreshes
+      // app-wide. FlagsLoader calls useFeatureFlagsQuery which uses this key;
+      // the refetch re-runs setFlags() on the store, updating every subscriber.
+      void qc.invalidateQueries({ queryKey: [...FEATURE_FLAGS_KEY] });
+    },
+  });
 }

--- a/frontend/src/features/administration/pages/AiProvidersPage.tsx
+++ b/frontend/src/features/administration/pages/AiProvidersPage.tsx
@@ -6,7 +6,9 @@ import { Panel, Badge, Button } from "@/components/ui";
 import type { AiProviderSetting } from "@/types/models";
 import {
   useActivateAiProvider,
+  useAgentSettings,
   useAiProviders,
+  useSetAgentSettings,
   useTestAiProvider,
   useToggleAiProvider,
   useUpdateAiProvider,
@@ -80,6 +82,72 @@ const PROVIDER_META: Record<string, ProviderMeta> = {
     hasBaseUrl: false,
   },
 };
+
+// ── AI Agents toggle card ─────────────────────────────────────────────────────
+
+function AgentsToggleCard() {
+  const { t } = useTranslation("app");
+  const { data, isLoading } = useAgentSettings();
+  const setAgents = useSetAgentSettings();
+
+  const enabled = data?.enabled ?? false;
+  const anthropicReady = data?.anthropic_ready ?? false;
+
+  return (
+    <Panel>
+      <div className="flex items-center gap-4">
+        <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
+          <Bot className="h-5 w-5 text-muted-foreground" />
+        </div>
+
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-foreground">
+              {t("admin.agents.title", "AI Agents")}
+            </span>
+            {enabled && <Badge variant="primary">{t("administration.aiProviders.values.enabled", "Enabled")}</Badge>}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {t(
+              "admin.agents.description",
+              "Enables the Claude Agent SDK copilots in Study Designer and Publish.",
+            )}
+          </p>
+          {enabled && !anthropicReady && (
+            <p className="mt-1 text-xs text-amber-500">
+              {t(
+                "admin.agents.notReady",
+                "Anthropic provider not configured — agents won't run until a credited Anthropic key is set.",
+              )}
+            </p>
+          )}
+        </div>
+
+        {/* Enable toggle */}
+        <label
+          className="relative inline-flex cursor-pointer items-center"
+          aria-label={t("admin.agents.toggleLabel", "Toggle AI Agents")}
+        >
+          <input
+            type="checkbox"
+            className="peer sr-only"
+            checked={enabled}
+            disabled={isLoading || setAgents.isPending}
+            onChange={(e) => setAgents.mutate(e.target.checked)}
+          />
+          <div className="peer h-5 w-9 rounded-full bg-muted after:absolute after:left-[2px] after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all after:content-[''] peer-checked:bg-primary peer-checked:after:translate-x-4" />
+          <span className="ml-2 text-sm text-muted-foreground">
+            {enabled
+              ? t("administration.aiProviders.values.enabled", "Enabled")
+              : t("administration.aiProviders.values.disabled", "Disabled")}
+          </span>
+        </label>
+
+        {setAgents.isPending && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+      </div>
+    </Panel>
+  );
+}
 
 // ── Provider card ─────────────────────────────────────────────────────────────
 
@@ -365,6 +433,9 @@ export default function AiProvidersPage() {
         </div>
         <HelpButton helpKey="admin.ai-providers" />
       </div>
+
+      {/* AI Agents global toggle */}
+      <AgentsToggleCard />
 
       {/* Active provider banner */}
       {activeProvider && (

--- a/frontend/src/features/publish/pages/PublishPage.tsx
+++ b/frontend/src/features/publish/pages/PublishPage.tsx
@@ -323,7 +323,7 @@ export default function PublishPage() {
     draftIdParam && /^\d+$/.test(draftIdParam) ? Number(draftIdParam) : null;
   // Ships dark: the AI publication copilot only renders when the deployment flag
   // is enabled (PUBLISH_AGENT_ENABLED) — keeps it off prod until credit is added.
-  const publishAgentEnabled = useFlag("publish.agent");
+  const publishAgentEnabled = useFlag("ai.agents");
 
   const [searchParams] = useSearchParams();
   const initialStudyId = searchParams.get("studyId")

--- a/frontend/src/features/studies/components/v2/StudyDesignerWizard.tsx
+++ b/frontend/src/features/studies/components/v2/StudyDesignerWizard.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { tAuto } from "@/i18n/autoUserFacing";
+import { useFlag } from "@/stores/featureFlagsStore";
 import type { Study } from "../../types/study";
 import { useStudyDesignWorkbench } from "../../hooks/useStudyDesignWorkbench";
 import { useStudyDesignerWizardStore } from "../../stores/studyDesignerWizardStore";
@@ -89,6 +90,7 @@ export function StudyDesignerWizard({ study }: StudyDesignerWizardProps) {
   const { currentStep, slideDir, visited, setStep, goNext, goBack } =
     useStudyDesignerWizardStore();
   const [animKey, setAnimKey] = useState(0);
+  const agentsEnabled = useFlag("ai.agents");
 
   // One-shot auto-jump to the user's last-active stage on first guidance
   // arrival — mirrors v1's `useState(defaultActive)` resume behavior. Uses
@@ -264,11 +266,13 @@ export function StudyDesignerWizard({ study }: StudyDesignerWizardProps) {
         />
       </div>
 
-      <AgentCopilotPanel
-        slug={wb.slug}
-        sessionId={wb.selectedSession?.id ?? null}
-        versionId={wb.selectedVersion?.id ?? null}
-      />
+      {agentsEnabled && (
+        <AgentCopilotPanel
+          slug={wb.slug}
+          sessionId={wb.selectedSession?.id ?? null}
+          versionId={wb.selectedVersion?.id ?? null}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/types/featureFlags.ts
+++ b/frontend/src/types/featureFlags.ts
@@ -27,7 +27,7 @@ export interface FlagNameRegistry {
   "observability.opentelemetry": true;
   "crypto.fips": true;
   "operator.k8s": true;
-  "publish.agent": true;
+  "ai.agents": true;
 }
 
 export type FlagName = keyof FlagNameRegistry;


### PR DESCRIPTION
## What

A super-admin runtime toggle to enable/disable the AI agent copilots, on the **AI Providers** admin page. Unifies the deploy-time `publish.agent` env flag into a single runtime **`ai.agents`** feature flag.

- **Runtime, DB-backed:** `FeatureFlagResolver` derives `ai.agents` from `SystemSetting('agents.enabled')` (default OFF). New super-admin `GET/PUT /api/v1/admin/ai-agents` (`AgentSettingsController`) reads/writes it and reports `anthropic_ready`. Flipping the toggle invalidates the feature-flags query so `useFlag("ai.agents")` updates app-wide with no reload — no redeploy/env-edit needed (the `PUBLISH_AGENT_ENABLED` stop-gap is retired).
- **Gates BOTH copilots:** `PublishPage` and `StudyDesignerWizard` now gate `<AgentCopilotPanel>` on `useFlag("ai.agents")`. **This also fixes the Study Designer copilot, which was previously ungated** — on prod today it auto-starts and surfaces a "Credit balance too low" error. After this, both copilots are dark until a super-admin flips the toggle.
- **Readiness hint:** the toggle card shows when no Anthropic provider is configured, so an admin knows agents won't run even when enabled.

## Non-destructive
Reuses `system_settings` (no new table/migration). Super-admin only; audited via the standard activity middleware.

## Tests
Backend **21 Pest** (resolver + super-admin endpoint + auth) · Pint · PHPStan clean. Frontend tsc + vite build + eslint clean · vitest green (incl. the toggle card + flag-refresh wiring). Caught + fixed a route-path mismatch (`/admin/ai-agents`) during review.

## Note
This is the control surface; the agent still needs Anthropic credit to actually generate (the `anthropic_ready` hint flags that). Merging this makes both copilots dark-by-default — including fixing the currently-live SD copilot.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)