### PR TITLE
feat: Clio orchestrator launch surface (ADR-0020 Phase 5b)

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/ClioAgentController.php
+++ b/backend/app/Http/Controllers/Api/V1/ClioAgentController.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\App\AgentSession;
+use App\Models\App\Study;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Launches and drives a Clio orchestrator agent session for a study
+ * (ADR-0020 Phase 5b). Mirrors the publish/study-design agent controllers:
+ * mints a scoped Sanctum token, registers a session with the generic python-ai
+ * harness under the `clio` profile, and relays turns / approvals.
+ *
+ * The scoped token only needs the abilities the clio tool pack uses: reading
+ * study + gate state, evaluating gates, and building a study package.
+ */
+class ClioAgentController extends Controller
+{
+    /** @var list<string> */
+    private const AGENT_ABILITIES = ['studies.view', 'studies.execute', 'studies.create'];
+
+    private function aiBaseUrl(): string
+    {
+        return rtrim((string) config('services.ai.url', 'http://python-ai:8000'), '/');
+    }
+
+    /**
+     * A study's orchestration is reachable by its collaborators (creator, PI,
+     * lead data scientist, lead statistician, team member) or an admin.
+     */
+    private function authorizeAccess(Request $request, Study $study): void
+    {
+        $user = $request->user();
+        abort_unless($user !== null, 401);
+
+        $isCollaborator = Study::query()
+            ->whereKey($study->id)
+            ->accessibleBy($user->id)
+            ->exists();
+
+        abort_unless($isCollaborator || $user->hasRole(['admin', 'super-admin']), 404);
+    }
+
+    private function assertSessionBelongs(Study $study, AgentSession $agentSession): void
+    {
+        abort_unless(
+            (int) $agentSession->subject_id === (int) $study->id && $agentSession->profile === 'clio',
+            404,
+        );
+    }
+
+    /**
+     * POST /api/v1/studies/{study}/agent/sessions
+     */
+    public function start(Request $request, Study $study): JsonResponse
+    {
+        $this->authorizeAccess($request, $study);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        $agentSession = AgentSession::create([
+            'profile' => 'clio',
+            'subject_type' => 'study',
+            'subject_id' => $study->id,
+            'user_id' => $user->id,
+            'status' => 'active',
+            'context_json' => [
+                'study_slug' => $study->slug,
+                'study_id' => $study->id,
+            ],
+            'last_active_at' => now(),
+        ]);
+
+        $newToken = $user->createToken('clio-agent', self::AGENT_ABILITIES);
+        $agentSession->update(['token_id' => $newToken->accessToken->id]);
+
+        $channel = "private-clio.study.{$study->id}";
+
+        $resp = Http::acceptJson()->post($this->aiBaseUrl().'/agent/sessions', [
+            'profile' => 'clio',
+            'agent_session_id' => $agentSession->id,
+            'subject_id' => $study->id,
+            'channel' => $channel,
+            'ingest_path' => "/api/v1/studies/{$study->slug}/agent/sessions/{$agentSession->id}/ingest",
+            'scoped_token' => $newToken->plainTextToken,
+            'context' => [
+                'study_slug' => $study->slug,
+                'study_id' => $study->id,
+            ],
+        ]);
+
+        if ($resp->failed()) {
+            $newToken->accessToken->delete();
+            $agentSession->update(['status' => 'error', 'token_id' => null]);
+
+            return response()->json(['message' => 'Agent service unavailable'], 503);
+        }
+
+        return response()->json([
+            'data' => [
+                'agent_session_id' => $agentSession->id,
+                'channel_name' => $channel,
+            ],
+        ], 201);
+    }
+
+    /**
+     * POST /api/v1/studies/{study}/agent/sessions/{agentSession}/messages
+     */
+    public function message(Request $request, Study $study, AgentSession $agentSession): JsonResponse
+    {
+        $this->authorizeAccess($request, $study);
+        $this->assertSessionBelongs($study, $agentSession);
+
+        $validated = $request->validate([
+            'text' => ['required', 'string', 'max:8000'],
+            'idempotency_key' => ['required', 'string', 'max:128'],
+        ]);
+
+        $agentSession->update(['last_active_at' => now()]);
+
+        $resp = Http::acceptJson()->post($this->aiBaseUrl()."/agent/sessions/{$agentSession->id}/turn", [
+            'text' => $validated['text'],
+            'idempotency_key' => $validated['idempotency_key'],
+        ]);
+
+        if ($resp->failed()) {
+            return response()->json(['message' => 'Agent service unavailable'], 503);
+        }
+
+        return response()->json(['data' => ['accepted' => true]], 202);
+    }
+
+    /**
+     * POST /api/v1/studies/{study}/agent/sessions/{agentSession}/approve
+     */
+    public function approve(Request $request, Study $study, AgentSession $agentSession): JsonResponse
+    {
+        $this->authorizeAccess($request, $study);
+        $this->assertSessionBelongs($study, $agentSession);
+
+        $validated = $request->validate([
+            'tool_use_id' => ['required', 'string', 'max:255'],
+            'approved' => ['required', 'boolean'],
+        ]);
+
+        $resp = Http::acceptJson()->post($this->aiBaseUrl()."/agent/sessions/{$agentSession->id}/approve", [
+            'tool_use_id' => $validated['tool_use_id'],
+            'approved' => $validated['approved'],
+        ]);
+
+        if ($resp->failed()) {
+            return response()->json(['message' => 'Agent service unavailable'], 503);
+        }
+
+        return response()->json(['data' => ['resolved' => true]], 200);
+    }
+
+    /**
+     * GET /api/v1/studies/{study}/agent/sessions/{agentSession}/snapshot
+     */
+    public function snapshot(Request $request, Study $study, AgentSession $agentSession): JsonResponse
+    {
+        $this->authorizeAccess($request, $study);
+        $this->assertSessionBelongs($study, $agentSession);
+
+        return response()->json(['data' => [
+            'agent_session_id' => $agentSession->id,
+            'status' => $agentSession->status,
+            'cost_usd' => $agentSession->cost_usd,
+            'tokens_in' => $agentSession->tokens_in,
+            'tokens_out' => $agentSession->tokens_out,
+            'channel_name' => "private-clio.study.{$study->id}",
+        ]]);
+    }
+
+    /**
+     * POST /api/v1/studies/{study}/agent/sessions/{agentSession}/ingest
+     *
+     * Telemetry callback from the python-ai agent (increments running totals).
+     */
+    public function ingest(Request $request, Study $study, AgentSession $agentSession): JsonResponse
+    {
+        $this->authorizeAccess($request, $study);
+        $this->assertSessionBelongs($study, $agentSession);
+
+        $validated = $request->validate([
+            'anthropic_session_id' => ['nullable', 'string', 'max:255'],
+            'cost_usd' => ['required', 'numeric', 'min:0'],
+            'tokens_in' => ['required', 'integer', 'min:0'],
+            'tokens_out' => ['required', 'integer', 'min:0'],
+            'status' => ['required', 'string', 'in:active,closed,error'],
+        ]);
+
+        $agentSession->update([
+            'anthropic_session_id' => $validated['anthropic_session_id'] ?? $agentSession->anthropic_session_id,
+            'cost_usd' => (float) $agentSession->cost_usd + (float) $validated['cost_usd'],
+            'tokens_in' => (int) $agentSession->tokens_in + (int) $validated['tokens_in'],
+            'tokens_out' => (int) $agentSession->tokens_out + (int) $validated['tokens_out'],
+            'status' => $validated['status'],
+            'last_active_at' => now(),
+        ]);
+
+        return response()->json(['data' => ['ok' => true]]);
+    }
+}

--- a/backend/database/fixtures/designs/cohort_definitions/all-cause-death.json
+++ b/backend/database/fixtures/designs/cohort_definitions/all-cause-death.json
@@ -50,5 +50,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/all-pdac-patients.json
+++ b/backend/database/fixtures/designs/cohort_definitions/all-pdac-patients.json
@@ -73,5 +73,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/atrial-fibrillation-cohort.json
+++ b/backend/database/fixtures/designs/cohort_definitions/atrial-fibrillation-cohort.json
@@ -87,5 +87,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/authenticated-cohort.json
+++ b/backend/database/fixtures/designs/cohort_definitions/authenticated-cohort.json
@@ -20,5 +20,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/c-v3-always-normotensive-comparator-pool-pre-psm.json
+++ b/backend/database/fixtures/designs/cohort_definitions/c-v3-always-normotensive-comparator-pool-pre-psm.json
@@ -20412,5 +20412,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/cardiometabolic-dyad-t2dmprediabetes-hypertension-no-hyperlipidemia.json
+++ b/backend/database/fixtures/designs/cohort_definitions/cardiometabolic-dyad-t2dmprediabetes-hypertension-no-hyperlipidemia.json
@@ -315,5 +315,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/cardiometabolic-triad-t2dmprediabetes-hypertension-hyperlipidemia.json
+++ b/backend/database/fixtures/designs/cohort_definitions/cardiometabolic-triad-t2dmprediabetes-hypertension-hyperlipidemia.json
@@ -316,5 +316,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/chronic-kidney-disease-stage-3-5-with-egfr-monitoring.json
+++ b/backend/database/fixtures/designs/cohort_definitions/chronic-kidney-disease-stage-3-5-with-egfr-monitoring.json
@@ -200,5 +200,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/ckd-1-3-new-user-acetaminophen-initiators.json
+++ b/backend/database/fixtures/designs/cohort_definitions/ckd-1-3-new-user-acetaminophen-initiators.json
@@ -500,5 +500,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/ckd-1-3-new-user-nsaid-initiators-ibuprofen-or-naproxen.json
+++ b/backend/database/fixtures/designs/cohort_definitions/ckd-1-3-new-user-nsaid-initiators-ibuprofen-or-naproxen.json
@@ -517,5 +517,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/ckd-advanced-progression-stages-4-5-or-dialysis-first-occurrence-study-3.json
+++ b/backend/database/fixtures/designs/cohort_definitions/ckd-advanced-progression-stages-4-5-or-dialysis-first-occurrence-study-3.json
@@ -118,5 +118,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/ckd-advanced-progression-stages-4-5-or-dialysis.json
+++ b/backend/database/fixtures/designs/cohort_definitions/ckd-advanced-progression-stages-4-5-or-dialysis.json
@@ -120,5 +120,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/colon-cancer.json
+++ b/backend/database/fixtures/designs/cohort_definitions/colon-cancer.json
@@ -87,5 +87,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/composite-mace-first-occurrence-with-chf.json
+++ b/backend/database/fixtures/designs/cohort_definitions/composite-mace-first-occurrence-with-chf.json
@@ -127,5 +127,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/composite-mace-mi-or-stroke-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/composite-mace-mi-or-stroke-first-occurrence.json
@@ -129,5 +129,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/coronary-artery-disease-with-statin-therapy.json
+++ b/backend/database/fixtures/designs/cohort_definitions/coronary-artery-disease-with-statin-therapy.json
@@ -198,5 +198,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/debug-dm-default.json
+++ b/backend/database/fixtures/designs/cohort_definitions/debug-dm-default.json
@@ -73,5 +73,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/debug-dm-primaryonly.json
+++ b/backend/database/fixtures/designs/cohort_definitions/debug-dm-primaryonly.json
@@ -73,5 +73,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/debug-dm-test.json
+++ b/backend/database/fixtures/designs/cohort_definitions/debug-dm-test.json
@@ -575,5 +575,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/debug-hiv-large.json
+++ b/backend/database/fixtures/designs/cohort_definitions/debug-hiv-large.json
@@ -1301,5 +1301,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/debug-ra-primaryonly.json
+++ b/backend/database/fixtures/designs/cohort_definitions/debug-ra-primaryonly.json
@@ -87,5 +87,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/debug-ra-test.json
+++ b/backend/database/fixtures/designs/cohort_definitions/debug-ra-test.json
@@ -953,5 +953,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/dolorum-officia.json
+++ b/backend/database/fixtures/designs/cohort_definitions/dolorum-officia.json
@@ -38,5 +38,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/e2e-final-test.json
+++ b/backend/database/fixtures/designs/cohort_definitions/e2e-final-test.json
@@ -82,5 +82,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/e2e-wizard-test.json
+++ b/backend/database/fixtures/designs/cohort_definitions/e2e-wizard-test.json
@@ -82,5 +82,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/eos-a-ea.json
+++ b/backend/database/fixtures/designs/cohort_definitions/eos-a-ea.json
@@ -38,5 +38,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/essential-hypertension-with-antihypertensive-therapy.json
+++ b/backend/database/fixtures/designs/cohort_definitions/essential-hypertension-with-antihypertensive-therapy.json
@@ -220,5 +220,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/folfirinox-recipients.json
+++ b/backend/database/fixtures/designs/cohort_definitions/folfirinox-recipients.json
@@ -152,5 +152,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/gi-bleed-new-users.json
+++ b/backend/database/fixtures/designs/cohort_definitions/gi-bleed-new-users.json
@@ -38,5 +38,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/headaches.json
+++ b/backend/database/fixtures/designs/cohort_definitions/headaches.json
@@ -98,5 +98,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/heart-failure-with-bnp-monitoring.json
+++ b/backend/database/fixtures/designs/cohort_definitions/heart-failure-with-bnp-monitoring.json
@@ -256,5 +256,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/high-ca-19-9-at-diagnosis.json
+++ b/backend/database/fixtures/designs/cohort_definitions/high-ca-19-9-at-diagnosis.json
@@ -128,5 +128,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/hypertension-cohort.json
+++ b/backend/database/fixtures/designs/cohort_definitions/hypertension-cohort.json
@@ -87,5 +87,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/hypertensive-ckd-1-3-new-user-amlodipine-initiators.json
+++ b/backend/database/fixtures/designs/cohort_definitions/hypertensive-ckd-1-3-new-user-amlodipine-initiators.json
@@ -634,5 +634,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/hypertensive-ckd-1-3-new-user-lisinopril-initiators.json
+++ b/backend/database/fixtures/designs/cohort_definitions/hypertensive-ckd-1-3-new-user-lisinopril-initiators.json
@@ -634,5 +634,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-e-01-keppra-levetiracetam-exposure.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-e-01-keppra-levetiracetam-exposure.json
@@ -79,5 +79,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-e-02-diastat-diazepam-rectal-exposure.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-e-02-diastat-diazepam-rectal-exposure.json
@@ -79,5 +79,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-e-03-lamictal-lamotrigine-exposure.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-e-03-lamictal-lamotrigine-exposure.json
@@ -79,5 +79,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-e-04-trileptal-oxcarbazepine-exposure.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-e-04-trileptal-oxcarbazepine-exposure.json
@@ -79,5 +79,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-e-05-clonazepam-exposure.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-e-05-clonazepam-exposure.json
@@ -79,5 +79,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-e-06-depakote-valproic-acid-exposure.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-e-06-depakote-valproic-acid-exposure.json
@@ -79,5 +79,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-e-07-topamax-topiramate-exposure.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-e-07-topamax-topiramate-exposure.json
@@ -79,5 +79,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-o-01-first-seizure-onset.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-o-01-first-seizure-onset.json
@@ -82,5 +82,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-o-02-all-cause-mortality.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-o-02-all-cause-mortality.json
@@ -54,5 +54,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-o-03-severe-functional-impairment-css-30.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-o-03-severe-functional-impairment-css-30.json
@@ -83,5 +83,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-t1-01-severe-mecp2-mutations-r168xr255xr270x.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-t1-01-severe-mecp2-mutations-r168xr255xr270x.json
@@ -152,5 +152,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-t1-02-mild-mecp2-mutations-r294xr133c.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-t1-02-mild-mecp2-mutations-r294xr133c.json
@@ -135,5 +135,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-t1-03-aed-treated-seizure-patients-with-longitudinal-css.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-t1-03-aed-treated-seizure-patients-with-longitudinal-css.json
@@ -269,5 +269,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-t2-01-progression-cohort-genotyped-4-css.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-t2-01-progression-cohort-genotyped-4-css.json
@@ -74,5 +74,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-t2-02-css-progressors-5pt-decline.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-t2-02-css-progressors-5pt-decline.json
@@ -74,5 +74,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-t2-03-growth-failure.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-t2-03-growth-failure.json
@@ -55,5 +55,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-t3-01-cdkl5-deficiency-disorder.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-t3-01-cdkl5-deficiency-disorder.json
@@ -139,5 +139,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-t3-02-foxg1-syndrome.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-t3-02-foxg1-syndrome.json
@@ -126,5 +126,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-t3-03-mecp2-duplication-syndrome.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-t3-03-mecp2-duplication-syndrome.json
@@ -100,5 +100,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-t3-04-seizure-free-rett-patients.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-t3-04-seizure-free-rett-patients.json
@@ -111,5 +111,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-t4-01-aed-polypharmacy-3-anticonvulsants.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-t4-01-aed-polypharmacy-3-anticonvulsants.json
@@ -85,5 +85,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/irsf-t4-02-aed-switchers-2-medication-changes.json
+++ b/backend/database/fixtures/designs/cohort_definitions/irsf-t4-02-aed-switchers-2-medication-changes.json
@@ -50,5 +50,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/kras-mutant-pdac.json
+++ b/backend/database/fixtures/designs/cohort_definitions/kras-mutant-pdac.json
@@ -130,5 +130,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/metabolic-syndrome-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/metabolic-syndrome-first-occurrence.json
@@ -76,5 +76,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/nc-acne-vulgaris.json
+++ b/backend/database/fixtures/designs/cohort_definitions/nc-acne-vulgaris.json
@@ -104,5 +104,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/nc-acute-upper-respiratory-infection.json
+++ b/backend/database/fixtures/designs/cohort_definitions/nc-acute-upper-respiratory-infection.json
@@ -434,5 +434,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/nc-allergic-rhinitis.json
+++ b/backend/database/fixtures/designs/cohort_definitions/nc-allergic-rhinitis.json
@@ -412,5 +412,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/nc-atopic-dermatitis.json
+++ b/backend/database/fixtures/designs/cohort_definitions/nc-atopic-dermatitis.json
@@ -841,5 +841,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/nc-cellulitis.json
+++ b/backend/database/fixtures/designs/cohort_definitions/nc-cellulitis.json
@@ -2810,5 +2810,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/nc-hallux-valgus-bunion.json
+++ b/backend/database/fixtures/designs/cohort_definitions/nc-hallux-valgus-bunion.json
@@ -236,5 +236,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/nc-hemorrhoids.json
+++ b/backend/database/fixtures/designs/cohort_definitions/nc-hemorrhoids.json
@@ -522,5 +522,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/nc-onychomycosis.json
+++ b/backend/database/fixtures/designs/cohort_definitions/nc-onychomycosis.json
@@ -412,5 +412,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/nc-otitis-media.json
+++ b/backend/database/fixtures/designs/cohort_definitions/nc-otitis-media.json
@@ -2183,5 +2183,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/nc-plantar-fasciitis.json
+++ b/backend/database/fixtures/designs/cohort_definitions/nc-plantar-fasciitis.json
@@ -115,5 +115,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/nc-sciatica.json
+++ b/backend/database/fixtures/designs/cohort_definitions/nc-sciatica.json
@@ -236,5 +236,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/nc-verruca-vulgaris-wart.json
+++ b/backend/database/fixtures/designs/cohort_definitions/nc-verruca-vulgaris-wart.json
@@ -137,5 +137,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/neque-quas-sint-quisquam.json
+++ b/backend/database/fixtures/designs/cohort_definitions/neque-quas-sint-quisquam.json
@@ -38,5 +38,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/o1-v3-mace-composite-mi-stroke-inpatient-hf-death.json
+++ b/backend/database/fixtures/designs/cohort_definitions/o1-v3-mace-composite-mi-stroke-inpatient-hf-death.json
@@ -8081,5 +8081,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/o2-v3-incident-ckd.json
+++ b/backend/database/fixtures/designs/cohort_definitions/o2-v3-incident-ckd.json
@@ -1734,5 +1734,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/original-name.json
+++ b/backend/database/fixtures/designs/cohort_definitions/original-name.json
@@ -20,5 +20,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/pediatric-hypertension-and-diabetes-age-2-17.json
+++ b/backend/database/fixtures/designs/cohort_definitions/pediatric-hypertension-and-diabetes-age-2-17.json
@@ -625,5 +625,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/post-mi-new-user-aspirin-monotherapy-initiators-secondary-prevention.json
+++ b/backend/database/fixtures/designs/cohort_definitions/post-mi-new-user-aspirin-monotherapy-initiators-secondary-prevention.json
@@ -408,5 +408,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/post-mi-new-user-clopidogrel-initiators-secondary-prevention.json
+++ b/backend/database/fixtures/designs/cohort_definitions/post-mi-new-user-clopidogrel-initiators-secondary-prevention.json
@@ -351,5 +351,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/prediabetes-new-user-metformin-initiators.json
+++ b/backend/database/fixtures/designs/cohort_definitions/prediabetes-new-user-metformin-initiators.json
@@ -513,5 +513,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/prediabetes-new-user-watchful-waiting-no-drug.json
+++ b/backend/database/fixtures/designs/cohort_definitions/prediabetes-new-user-watchful-waiting-no-drug.json
@@ -492,5 +492,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/recurrent-mace-mi-or-stroke-first-occurrence-after-index-study-5.json
+++ b/backend/database/fixtures/designs/cohort_definitions/recurrent-mace-mi-or-stroke-first-occurrence-after-index-study-5.json
@@ -134,5 +134,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/resectable-pdac-with-surgical-intervention.json
+++ b/backend/database/fixtures/designs/cohort_definitions/resectable-pdac-with-surgical-intervention.json
@@ -138,5 +138,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s10-ckd-any-stage-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s10-ckd-any-stage-first-occurrence.json
@@ -114,5 +114,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s10-prediabetes-escapers-5yr-follow-up-no-t2dm.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s10-prediabetes-escapers-5yr-follow-up-no-t2dm.json
@@ -136,5 +136,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s10-prediabetes-first-occurrence-base-cohort.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s10-prediabetes-first-occurrence-base-cohort.json
@@ -81,5 +81,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s10-prediabetes-progressors-t2dm-within-5-years.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s10-prediabetes-progressors-t2dm-within-5-years.json
@@ -131,5 +131,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s10-type-2-diabetes-mellitus-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s10-type-2-diabetes-mellitus-first-occurrence.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s6-anemia-at-ckd-diagnosis-subgroup.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s6-anemia-at-ckd-diagnosis-subgroup.json
@@ -170,5 +170,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s6-ckd-stage-1-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s6-ckd-stage-1-first-occurrence.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s6-ckd-stage-2-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s6-ckd-stage-2-first-occurrence.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s6-ckd-stage-3-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s6-ckd-stage-3-first-occurrence.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s6-ckd-stage-4-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s6-ckd-stage-4-first-occurrence.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s6-composite-mace-first-occurrence-no-chf.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s6-composite-mace-first-occurrence-no-chf.json
@@ -114,5 +114,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s6-esrd-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s6-esrd-first-occurrence.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s6-essential-hypertension-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s6-essential-hypertension-first-occurrence.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s6-matched-controls-no-prediabetes-or-t2dm.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s6-matched-controls-no-prediabetes-or-t2dm.json
@@ -168,5 +168,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s6-metabolic-syndrome-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s6-metabolic-syndrome-first-occurrence.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s6-new-prediabetes-no-prior-ckd-htn-or-t2dm.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s6-new-prediabetes-no-prior-ckd-htn-or-t2dm.json
@@ -283,5 +283,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s7-new-atorvastatin-users.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s7-new-atorvastatin-users.json
@@ -175,5 +175,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s7-new-simvastatin-users.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s7-new-simvastatin-users.json
@@ -175,5 +175,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s7-statin-users-primary-prevention-no-ihd.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s7-statin-users-primary-prevention-no-ihd.json
@@ -225,5 +225,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s7-statin-users-secondary-prevention-ihd.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s7-statin-users-secondary-prevention-ihd.json
@@ -224,5 +224,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s7-stemi-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s7-stemi-first-occurrence.json
@@ -74,5 +74,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s7-stroke-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s7-stroke-first-occurrence.json
@@ -74,5 +74,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s8-all-cause-death.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s8-all-cause-death.json
@@ -50,5 +50,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s8-chronic-pain-nsaid-only-management-no-opioids.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s8-chronic-pain-nsaid-only-management-no-opioids.json
@@ -251,5 +251,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s8-drug-dependence-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s8-drug-dependence-first-occurrence.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s8-drug-misuse-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s8-drug-misuse-first-occurrence.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s8-mat-initiation-buprenorphine-or-methadone.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s8-mat-initiation-buprenorphine-or-methadone.json
@@ -88,5 +88,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s8-naloxone-administration-overdose-reversal-sentinel.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s8-naloxone-administration-overdose-reversal-sentinel.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s8-new-opioid-users-chronic-pain-no-prior-substance-abuse.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s8-new-opioid-users-chronic-pain-no-prior-substance-abuse.json
@@ -251,5 +251,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s9-all-cause-death.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s9-all-cause-death.json
@@ -50,5 +50,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s9-alzheimers-disease-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s9-alzheimers-disease-first-occurrence.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s9-colorectal-neoplasm-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s9-colorectal-neoplasm-first-occurrence.json
@@ -88,5 +88,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s9-composite-mace-first-occurrence-with-chf.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s9-composite-mace-first-occurrence-with-chf.json
@@ -127,5 +127,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s9-malignant-breast-tumor-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s9-malignant-breast-tumor-first-occurrence.json
@@ -75,5 +75,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s9-prediabetes-no-glucose-lowering-drugs.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s9-prediabetes-no-glucose-lowering-drugs.json
@@ -131,5 +131,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s9-t2dm-new-insulin-users-no-prior-metformin.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s9-t2dm-new-insulin-users-no-prior-metformin.json
@@ -238,5 +238,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/s9-t2dm-new-metformin-users.json
+++ b/backend/database/fixtures/designs/cohort_definitions/s9-t2dm-new-metformin-users.json
@@ -165,5 +165,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/seeded-cohort.json
+++ b/backend/database/fixtures/designs/cohort_definitions/seeded-cohort.json
@@ -20,5 +20,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/smoke-260416-owf-union-overwrite.json
+++ b/backend/database/fixtures/designs/cohort_definitions/smoke-260416-owf-union-overwrite.json
@@ -43,5 +43,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/smoke-260416-owf-union.json
+++ b/backend/database/fixtures/designs/cohort_definitions/smoke-260416-owf-union.json
@@ -43,5 +43,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/smoke-260416-postfix-union-222223-overwrite.json
+++ b/backend/database/fixtures/designs/cohort_definitions/smoke-260416-postfix-union-222223-overwrite.json
@@ -43,5 +43,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/t-v3-incident-essential-hypertension-treatment-naive.json
+++ b/backend/database/fixtures/designs/cohort_definitions/t-v3-incident-essential-hypertension-treatment-naive.json
@@ -20340,5 +20340,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/t2-dm.json
+++ b/backend/database/fixtures/designs/cohort_definitions/t2-dm.json
@@ -95,5 +95,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/t2dm-cohort.json
+++ b/backend/database/fixtures/designs/cohort_definitions/t2dm-cohort.json
@@ -22,5 +22,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/test-233.json
+++ b/backend/database/fixtures/designs/cohort_definitions/test-233.json
@@ -154,5 +154,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/test-234.json
+++ b/backend/database/fixtures/designs/cohort_definitions/test-234.json
@@ -92,5 +92,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/test-238.json
+++ b/backend/database/fixtures/designs/cohort_definitions/test-238.json
@@ -92,5 +92,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/test-239.json
+++ b/backend/database/fixtures/designs/cohort_definitions/test-239.json
@@ -92,5 +92,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/test.json
+++ b/backend/database/fixtures/designs/cohort_definitions/test.json
@@ -154,5 +154,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/to-delete.json
+++ b/backend/database/fixtures/designs/cohort_definitions/to-delete.json
@@ -20,5 +20,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/type-2-diabetes-mellitus-first-occurrence.json
+++ b/backend/database/fixtures/designs/cohort_definitions/type-2-diabetes-mellitus-first-occurrence.json
@@ -77,5 +77,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/type-2-diabetes-mellitus.json
+++ b/backend/database/fixtures/designs/cohort_definitions/type-2-diabetes-mellitus.json
@@ -178,5 +178,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/untitled-cohort-definition-226.json
+++ b/backend/database/fixtures/designs/cohort_definitions/untitled-cohort-definition-226.json
@@ -203,5 +203,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/untitled-cohort-definition-231.json
+++ b/backend/database/fixtures/designs/cohort_definitions/untitled-cohort-definition-231.json
@@ -39,5 +39,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/untitled-cohort-definition.json
+++ b/backend/database/fixtures/designs/cohort_definitions/untitled-cohort-definition.json
@@ -39,5 +39,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/untitled-cohort-definition2.json
+++ b/backend/database/fixtures/designs/cohort_definitions/untitled-cohort-definition2.json
@@ -213,5 +213,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/updated-name.json
+++ b/backend/database/fixtures/designs/cohort_definitions/updated-name.json
@@ -20,5 +20,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/verify-htn-01-uncontrolled-v2.json
+++ b/backend/database/fixtures/designs/cohort_definitions/verify-htn-01-uncontrolled-v2.json
@@ -32,5 +32,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/voluptatem-eum-soluta.json
+++ b/backend/database/fixtures/designs/cohort_definitions/voluptatem-eum-soluta.json
@@ -38,5 +38,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/cohort_definitions/wizard-debug-test-2.json
+++ b/backend/database/fixtures/designs/cohort_definitions/wizard-debug-test-2.json
@@ -82,5 +82,6 @@
     "status": "active",
     "archived_at": null,
     "archived_by": null,
-    "promoted_at": null
+    "promoted_at": null,
+    "expression_sha256": null
 }

--- a/backend/database/fixtures/designs/concept_sets/abnormal-kidney-function-ckd-aki.json
+++ b/backend/database/fixtures/designs/concept_sets/abnormal-kidney-function-ckd-aki.json
@@ -1704,6 +1704,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 3910,

--- a/backend/database/fixtures/designs/concept_sets/ace-inhibitors-and-arbs-atc-c09.json
+++ b/backend/database/fixtures/designs/concept_sets/ace-inhibitors-and-arbs-atc-c09.json
@@ -216,6 +216,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4128,

--- a/backend/database/fixtures/designs/concept_sets/acetaminophen-all-formulations-study-3-comparator-drug.json
+++ b/backend/database/fixtures/designs/concept_sets/acetaminophen-all-formulations-study-3-comparator-drug.json
@@ -22,6 +22,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 363,

--- a/backend/database/fixtures/designs/concept_sets/ad-numquam-quis-non.json
+++ b/backend/database/fixtures/designs/concept_sets/ad-numquam-quis-non.json
@@ -14,5 +14,6 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": []
 }

--- a/backend/database/fixtures/designs/concept_sets/aldosterone-and-plasma-renin-activity-loinc.json
+++ b/backend/database/fixtures/designs/concept_sets/aldosterone-and-plasma-renin-activity-loinc.json
@@ -40,6 +40,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1763,

--- a/backend/database/fixtures/designs/concept_sets/amlodipine-all-formulations.json
+++ b/backend/database/fixtures/designs/concept_sets/amlodipine-all-formulations.json
@@ -19,6 +19,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 364,

--- a/backend/database/fixtures/designs/concept_sets/analgesics-nsaids-and-acetaminophen-study-3-new-user-washout.json
+++ b/backend/database/fixtures/designs/concept_sets/analgesics-nsaids-and-acetaminophen-study-3-new-user-washout.json
@@ -22,6 +22,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 365,

--- a/backend/database/fixtures/designs/concept_sets/antihypertensive-drugs-all-classes-washout.json
+++ b/backend/database/fixtures/designs/concept_sets/antihypertensive-drugs-all-classes-washout.json
@@ -23,6 +23,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 378,

--- a/backend/database/fixtures/designs/concept_sets/antihypertensive-medications.json
+++ b/backend/database/fixtures/designs/concept_sets/antihypertensive-medications.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 396,

--- a/backend/database/fixtures/designs/concept_sets/antihypertensives-atc-c02-c09-broad.json
+++ b/backend/database/fixtures/designs/concept_sets/antihypertensives-atc-c02-c09-broad.json
@@ -1216,6 +1216,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4152,

--- a/backend/database/fixtures/designs/concept_sets/antiplatelet-agents-clopidogrel-and-aspirin-study-5-washout.json
+++ b/backend/database/fixtures/designs/concept_sets/antiplatelet-agents-clopidogrel-and-aspirin-study-5-washout.json
@@ -22,6 +22,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 403,

--- a/backend/database/fixtures/designs/concept_sets/aspirin-all-formulations-study-5-comparator-drug.json
+++ b/backend/database/fixtures/designs/concept_sets/aspirin-all-formulations-study-5-comparator-drug.json
@@ -22,6 +22,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 405,

--- a/backend/database/fixtures/designs/concept_sets/asthma.json
+++ b/backend/database/fixtures/designs/concept_sets/asthma.json
@@ -14,6 +14,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1443,

--- a/backend/database/fixtures/designs/concept_sets/at-neque.json
+++ b/backend/database/fixtures/designs/concept_sets/at-neque.json
@@ -14,5 +14,6 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": []
 }

--- a/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-2-conditions.json
+++ b/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-2-conditions.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1446,

--- a/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-2-drugs.json
+++ b/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-2-drugs.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1448,

--- a/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-2-measurements.json
+++ b/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-2-measurements.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1457,

--- a/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-2-observations.json
+++ b/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-2-observations.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1456,

--- a/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-conditions-159.json
+++ b/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-conditions-159.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1427,

--- a/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-conditions.json
+++ b/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-conditions.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1403,

--- a/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-drugs.json
+++ b/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-drugs.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1429,

--- a/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-measurements.json
+++ b/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-measurements.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1438,

--- a/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-observations.json
+++ b/backend/database/fixtures/designs/concept_sets/atrial-fibrillation-observations.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1437,

--- a/backend/database/fixtures/designs/concept_sets/beta-blockers-atc-c07.json
+++ b/backend/database/fixtures/designs/concept_sets/beta-blockers-atc-c07.json
@@ -232,6 +232,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1765,

--- a/backend/database/fixtures/designs/concept_sets/bipolar-disorder.json
+++ b/backend/database/fixtures/designs/concept_sets/bipolar-disorder.json
@@ -14,6 +14,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1426,

--- a/backend/database/fixtures/designs/concept_sets/bnpnt-probnp-lab-tests.json
+++ b/backend/database/fixtures/designs/concept_sets/bnpnt-probnp-lab-tests.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 406,

--- a/backend/database/fixtures/designs/concept_sets/cad-conditions.json
+++ b/backend/database/fixtures/designs/concept_sets/cad-conditions.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 408,

--- a/backend/database/fixtures/designs/concept_sets/calcium-channel-blockers-atc-c08.json
+++ b/backend/database/fixtures/designs/concept_sets/calcium-channel-blockers-atc-c08.json
@@ -208,6 +208,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1791,

--- a/backend/database/fixtures/designs/concept_sets/central-alpha-agonists-atc-c02a.json
+++ b/backend/database/fixtures/designs/concept_sets/central-alpha-agonists-atc-c02a.json
@@ -112,6 +112,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4309,

--- a/backend/database/fixtures/designs/concept_sets/chronic-kidney-disease-stages-1-3.json
+++ b/backend/database/fixtures/designs/concept_sets/chronic-kidney-disease-stages-1-3.json
@@ -19,6 +19,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 411,

--- a/backend/database/fixtures/designs/concept_sets/chronic-kidney-disease.json
+++ b/backend/database/fixtures/designs/concept_sets/chronic-kidney-disease.json
@@ -1240,6 +1240,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1462,

--- a/backend/database/fixtures/designs/concept_sets/ckd-advanced-progression-stages-4-5-and-dialysis-study-3-outcome.json
+++ b/backend/database/fixtures/designs/concept_sets/ckd-advanced-progression-stages-4-5-and-dialysis-study-3-outcome.json
@@ -23,6 +23,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 414,

--- a/backend/database/fixtures/designs/concept_sets/ckd-advanced-progression-stages-4-5-and-dialysis.json
+++ b/backend/database/fixtures/designs/concept_sets/ckd-advanced-progression-stages-4-5-and-dialysis.json
@@ -21,6 +21,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 417,

--- a/backend/database/fixtures/designs/concept_sets/ckd-conditions.json
+++ b/backend/database/fixtures/designs/concept_sets/ckd-conditions.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 420,

--- a/backend/database/fixtures/designs/concept_sets/ckd-stages-1-3-enrollment-criterion-study-3.json
+++ b/backend/database/fixtures/designs/concept_sets/ckd-stages-1-3-enrollment-criterion-study-3.json
@@ -21,6 +21,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 422,

--- a/backend/database/fixtures/designs/concept_sets/clopidogrel-all-formulations-study-5-target-drug.json
+++ b/backend/database/fixtures/designs/concept_sets/clopidogrel-all-formulations-study-5-target-drug.json
@@ -22,6 +22,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 425,

--- a/backend/database/fixtures/designs/concept_sets/colon-cancer.json
+++ b/backend/database/fixtures/designs/concept_sets/colon-cancer.json
@@ -14,6 +14,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1425,

--- a/backend/database/fixtures/designs/concept_sets/complete-blood-count-panel-loinc.json
+++ b/backend/database/fixtures/designs/concept_sets/complete-blood-count-panel-loinc.json
@@ -120,6 +120,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 3461,

--- a/backend/database/fixtures/designs/concept_sets/comprehensive-metabolic-panel-loinc.json
+++ b/backend/database/fixtures/designs/concept_sets/comprehensive-metabolic-panel-loinc.json
@@ -240,6 +240,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 3473,

--- a/backend/database/fixtures/designs/concept_sets/debug-pad-conditions.json
+++ b/backend/database/fixtures/designs/concept_sets/debug-pad-conditions.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1405,

--- a/backend/database/fixtures/designs/concept_sets/debug-pad-drugs.json
+++ b/backend/database/fixtures/designs/concept_sets/debug-pad-drugs.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1414,

--- a/backend/database/fixtures/designs/concept_sets/debug-pad-measurements.json
+++ b/backend/database/fixtures/designs/concept_sets/debug-pad-measurements.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1407,

--- a/backend/database/fixtures/designs/concept_sets/debug-pad-observations.json
+++ b/backend/database/fixtures/designs/concept_sets/debug-pad-observations.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1420,

--- a/backend/database/fixtures/designs/concept_sets/debug-pad-procedures.json
+++ b/backend/database/fixtures/designs/concept_sets/debug-pad-procedures.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1423,

--- a/backend/database/fixtures/designs/concept_sets/diabetes-conditions.json
+++ b/backend/database/fixtures/designs/concept_sets/diabetes-conditions.json
@@ -17,5 +17,6 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": []
 }

--- a/backend/database/fixtures/designs/concept_sets/dialysis-procedures.json
+++ b/backend/database/fixtures/designs/concept_sets/dialysis-procedures.json
@@ -456,6 +456,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4414,

--- a/backend/database/fixtures/designs/concept_sets/diastolic-blood-pressure-loinc.json
+++ b/backend/database/fixtures/designs/concept_sets/diastolic-blood-pressure-loinc.json
@@ -32,6 +32,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1761,

--- a/backend/database/fixtures/designs/concept_sets/diuretics-atc-c03.json
+++ b/backend/database/fixtures/designs/concept_sets/diuretics-atc-c03.json
@@ -304,6 +304,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 3501,

--- a/backend/database/fixtures/designs/concept_sets/egfr-estimated-glomerular-filtration-rate-loinc.json
+++ b/backend/database/fixtures/designs/concept_sets/egfr-estimated-glomerular-filtration-rate-loinc.json
@@ -152,6 +152,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4320,

--- a/backend/database/fixtures/designs/concept_sets/egfr-lab-tests.json
+++ b/backend/database/fixtures/designs/concept_sets/egfr-lab-tests.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 426,

--- a/backend/database/fixtures/designs/concept_sets/essential-hypertension-169.json
+++ b/backend/database/fixtures/designs/concept_sets/essential-hypertension-169.json
@@ -152,6 +152,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1614,

--- a/backend/database/fixtures/designs/concept_sets/essential-hypertension-study-4-component-2.json
+++ b/backend/database/fixtures/designs/concept_sets/essential-hypertension-study-4-component-2.json
@@ -20,6 +20,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 428,

--- a/backend/database/fixtures/designs/concept_sets/essential-hypertension.json
+++ b/backend/database/fixtures/designs/concept_sets/essential-hypertension.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 429,

--- a/backend/database/fixtures/designs/concept_sets/glucose-lowering-drugs-all-classes.json
+++ b/backend/database/fixtures/designs/concept_sets/glucose-lowering-drugs-all-classes.json
@@ -20,6 +20,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 430,

--- a/backend/database/fixtures/designs/concept_sets/hba1c-lab-tests.json
+++ b/backend/database/fixtures/designs/concept_sets/hba1c-lab-tests.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 452,

--- a/backend/database/fixtures/designs/concept_sets/heart-failure-conditions.json
+++ b/backend/database/fixtures/designs/concept_sets/heart-failure-conditions.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 455,

--- a/backend/database/fixtures/designs/concept_sets/heart-failure-medications.json
+++ b/backend/database/fixtures/designs/concept_sets/heart-failure-medications.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 457,

--- a/backend/database/fixtures/designs/concept_sets/heart-failure.json
+++ b/backend/database/fixtures/designs/concept_sets/heart-failure.json
@@ -1088,6 +1088,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1814,

--- a/backend/database/fixtures/designs/concept_sets/home-blood-pressure-monitor-hcpcs.json
+++ b/backend/database/fixtures/designs/concept_sets/home-blood-pressure-monitor-hcpcs.json
@@ -32,6 +32,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 2972,

--- a/backend/database/fixtures/designs/concept_sets/hyperlipidemia-all-types-study-4-component-3.json
+++ b/backend/database/fixtures/designs/concept_sets/hyperlipidemia-all-types-study-4-component-3.json
@@ -21,6 +21,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 462,

--- a/backend/database/fixtures/designs/concept_sets/hypertension-conditions.json
+++ b/backend/database/fixtures/designs/concept_sets/hypertension-conditions.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 463,

--- a/backend/database/fixtures/designs/concept_sets/lipid-panel-loinc.json
+++ b/backend/database/fixtures/designs/concept_sets/lipid-panel-loinc.json
@@ -88,6 +88,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4120,

--- a/backend/database/fixtures/designs/concept_sets/lisinopril-all-formulations.json
+++ b/backend/database/fixtures/designs/concept_sets/lisinopril-all-formulations.json
@@ -19,6 +19,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 465,

--- a/backend/database/fixtures/designs/concept_sets/major-adverse-cardiovascular-events-mi-and-stroke-study-4-outcome.json
+++ b/backend/database/fixtures/designs/concept_sets/major-adverse-cardiovascular-events-mi-and-stroke-study-4-outcome.json
@@ -23,6 +23,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 466,

--- a/backend/database/fixtures/designs/concept_sets/metformin-all-formulations.json
+++ b/backend/database/fixtures/designs/concept_sets/metformin-all-formulations.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 470,

--- a/backend/database/fixtures/designs/concept_sets/mineralocorticoid-receptor-antagonists-atc-c03da.json
+++ b/backend/database/fixtures/designs/concept_sets/mineralocorticoid-receptor-antagonists-atc-c03da.json
@@ -64,6 +64,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4301,

--- a/backend/database/fixtures/designs/concept_sets/myocardial-infarction-all-types-study-5-trigger-condition.json
+++ b/backend/database/fixtures/designs/concept_sets/myocardial-infarction-all-types-study-5-trigger-condition.json
@@ -22,6 +22,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 471,

--- a/backend/database/fixtures/designs/concept_sets/myocardial-infarction.json
+++ b/backend/database/fixtures/designs/concept_sets/myocardial-infarction.json
@@ -1072,6 +1072,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1630,

--- a/backend/database/fixtures/designs/concept_sets/natus-sequi-numquam.json
+++ b/backend/database/fixtures/designs/concept_sets/natus-sequi-numquam.json
@@ -14,5 +14,6 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": []
 }

--- a/backend/database/fixtures/designs/concept_sets/nc-acne-vulgaris.json
+++ b/backend/database/fixtures/designs/concept_sets/nc-acne-vulgaris.json
@@ -60,6 +60,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4468,

--- a/backend/database/fixtures/designs/concept_sets/nc-acute-upper-respiratory-infection.json
+++ b/backend/database/fixtures/designs/concept_sets/nc-acute-upper-respiratory-infection.json
@@ -360,6 +360,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4472,

--- a/backend/database/fixtures/designs/concept_sets/nc-allergic-rhinitis.json
+++ b/backend/database/fixtures/designs/concept_sets/nc-allergic-rhinitis.json
@@ -340,6 +340,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4506,

--- a/backend/database/fixtures/designs/concept_sets/nc-atopic-dermatitis.json
+++ b/backend/database/fixtures/designs/concept_sets/nc-atopic-dermatitis.json
@@ -730,6 +730,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4538,

--- a/backend/database/fixtures/designs/concept_sets/nc-cellulitis.json
+++ b/backend/database/fixtures/designs/concept_sets/nc-cellulitis.json
@@ -2520,6 +2520,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4609,

--- a/backend/database/fixtures/designs/concept_sets/nc-hallux-valgus-bunion.json
+++ b/backend/database/fixtures/designs/concept_sets/nc-hallux-valgus-bunion.json
@@ -180,6 +180,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4859,

--- a/backend/database/fixtures/designs/concept_sets/nc-hemorrhoids.json
+++ b/backend/database/fixtures/designs/concept_sets/nc-hemorrhoids.json
@@ -440,6 +440,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4875,

--- a/backend/database/fixtures/designs/concept_sets/nc-onychomycosis.json
+++ b/backend/database/fixtures/designs/concept_sets/nc-onychomycosis.json
@@ -340,6 +340,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4917,

--- a/backend/database/fixtures/designs/concept_sets/nc-otitis-media.json
+++ b/backend/database/fixtures/designs/concept_sets/nc-otitis-media.json
@@ -1950,6 +1950,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4949,

--- a/backend/database/fixtures/designs/concept_sets/nc-plantar-fasciitis.json
+++ b/backend/database/fixtures/designs/concept_sets/nc-plantar-fasciitis.json
@@ -70,6 +70,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 5142,

--- a/backend/database/fixtures/designs/concept_sets/nc-sciatica.json
+++ b/backend/database/fixtures/designs/concept_sets/nc-sciatica.json
@@ -180,6 +180,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 5147,

--- a/backend/database/fixtures/designs/concept_sets/nc-verruca-vulgaris-wart.json
+++ b/backend/database/fixtures/designs/concept_sets/nc-verruca-vulgaris-wart.json
@@ -90,6 +90,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 5163,

--- a/backend/database/fixtures/designs/concept_sets/non-ipsa-itaque.json
+++ b/backend/database/fixtures/designs/concept_sets/non-ipsa-itaque.json
@@ -14,5 +14,6 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": []
 }

--- a/backend/database/fixtures/designs/concept_sets/nsaids-ibuprofen-and-naproxen-study-3-index-drugs.json
+++ b/backend/database/fixtures/designs/concept_sets/nsaids-ibuprofen-and-naproxen-study-3-index-drugs.json
@@ -22,6 +22,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 474,

--- a/backend/database/fixtures/designs/concept_sets/pediatric-diabetes-and-metabolic-precursors.json
+++ b/backend/database/fixtures/designs/concept_sets/pediatric-diabetes-and-metabolic-precursors.json
@@ -20,6 +20,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1371,

--- a/backend/database/fixtures/designs/concept_sets/pediatric-hypertension.json
+++ b/backend/database/fixtures/designs/concept_sets/pediatric-hypertension.json
@@ -19,6 +19,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1364,

--- a/backend/database/fixtures/designs/concept_sets/pneumonia.json
+++ b/backend/database/fixtures/designs/concept_sets/pneumonia.json
@@ -14,6 +14,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 815,

--- a/backend/database/fixtures/designs/concept_sets/prediabetes-conditions.json
+++ b/backend/database/fixtures/designs/concept_sets/prediabetes-conditions.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 476,

--- a/backend/database/fixtures/designs/concept_sets/pregnancy-diagnosis.json
+++ b/backend/database/fixtures/designs/concept_sets/pregnancy-diagnosis.json
@@ -648,6 +648,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4336,

--- a/backend/database/fixtures/designs/concept_sets/primary-aldosteronism.json
+++ b/backend/database/fixtures/designs/concept_sets/primary-aldosteronism.json
@@ -48,6 +48,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 4306,

--- a/backend/database/fixtures/designs/concept_sets/prior-cardiovascular-disease-composite.json
+++ b/backend/database/fixtures/designs/concept_sets/prior-cardiovascular-disease-composite.json
@@ -8224,6 +8224,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1947,

--- a/backend/database/fixtures/designs/concept_sets/recurrent-mace-mi-or-stroke-study-5-outcome.json
+++ b/backend/database/fixtures/designs/concept_sets/recurrent-mace-mi-or-stroke-study-5-outcome.json
@@ -23,6 +23,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 477,

--- a/backend/database/fixtures/designs/concept_sets/secondary-hypertension.json
+++ b/backend/database/fixtures/designs/concept_sets/secondary-hypertension.json
@@ -248,6 +248,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 2973,

--- a/backend/database/fixtures/designs/concept_sets/statin-medications.json
+++ b/backend/database/fixtures/designs/concept_sets/statin-medications.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 481,

--- a/backend/database/fixtures/designs/concept_sets/statins-all-hmg-coa-reductase-inhibitors-study-4-covariate.json
+++ b/backend/database/fixtures/designs/concept_sets/statins-all-hmg-coa-reductase-inhibitors-study-4-covariate.json
@@ -21,6 +21,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 485,

--- a/backend/database/fixtures/designs/concept_sets/stroke-ischemic-and-hemorrhagic.json
+++ b/backend/database/fixtures/designs/concept_sets/stroke-ischemic-and-hemorrhagic.json
@@ -3704,6 +3704,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 3001,

--- a/backend/database/fixtures/designs/concept_sets/systolic-blood-pressure-loinc.json
+++ b/backend/database/fixtures/designs/concept_sets/systolic-blood-pressure-loinc.json
@@ -32,6 +32,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 1762,

--- a/backend/database/fixtures/designs/concept_sets/thyroid-disease-hyper-and-hypothyroidism.json
+++ b/backend/database/fixtures/designs/concept_sets/thyroid-disease-hyper-and-hypothyroidism.json
@@ -3016,6 +3016,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 3536,

--- a/backend/database/fixtures/designs/concept_sets/tsh-thyrotropin-loinc.json
+++ b/backend/database/fixtures/designs/concept_sets/tsh-thyrotropin-loinc.json
@@ -32,6 +32,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 3500,

--- a/backend/database/fixtures/designs/concept_sets/type-2-diabetes-and-prediabetes-study-4-component-1.json
+++ b/backend/database/fixtures/designs/concept_sets/type-2-diabetes-and-prediabetes-study-4-component-1.json
@@ -22,6 +22,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 491,

--- a/backend/database/fixtures/designs/concept_sets/type-2-diabetes-conditions.json
+++ b/backend/database/fixtures/designs/concept_sets/type-2-diabetes-conditions.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 493,

--- a/backend/database/fixtures/designs/concept_sets/type-2-diabetes-mellitus-new-diagnosis.json
+++ b/backend/database/fixtures/designs/concept_sets/type-2-diabetes-mellitus-new-diagnosis.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 496,

--- a/backend/database/fixtures/designs/concept_sets/untitled-concept-set-136.json
+++ b/backend/database/fixtures/designs/concept_sets/untitled-concept-set-136.json
@@ -14,5 +14,6 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": []
 }

--- a/backend/database/fixtures/designs/concept_sets/untitled-concept-set-137.json
+++ b/backend/database/fixtures/designs/concept_sets/untitled-concept-set-137.json
@@ -14,5 +14,6 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": []
 }

--- a/backend/database/fixtures/designs/concept_sets/untitled-concept-set-142.json
+++ b/backend/database/fixtures/designs/concept_sets/untitled-concept-set-142.json
@@ -14,5 +14,6 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": []
 }

--- a/backend/database/fixtures/designs/concept_sets/untitled-concept-set-144.json
+++ b/backend/database/fixtures/designs/concept_sets/untitled-concept-set-144.json
@@ -14,6 +14,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 501,

--- a/backend/database/fixtures/designs/concept_sets/untitled-concept-set-146.json
+++ b/backend/database/fixtures/designs/concept_sets/untitled-concept-set-146.json
@@ -14,6 +14,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 508,

--- a/backend/database/fixtures/designs/concept_sets/untitled-concept-set-158.json
+++ b/backend/database/fixtures/designs/concept_sets/untitled-concept-set-158.json
@@ -14,5 +14,6 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": []
 }

--- a/backend/database/fixtures/designs/concept_sets/untitled-concept-set.json
+++ b/backend/database/fixtures/designs/concept_sets/untitled-concept-set.json
@@ -14,5 +14,6 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": []
 }

--- a/backend/database/fixtures/designs/concept_sets/urine-protein-tests.json
+++ b/backend/database/fixtures/designs/concept_sets/urine-protein-tests.json
@@ -18,6 +18,7 @@
     "archived_at": null,
     "archived_by": null,
     "promoted_at": null,
+    "expression_sha256": null,
     "items": [
         {
             "id": 497,

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -33,6 +33,7 @@ use App\Http\Controllers\Api\V1\CharacterizationController;
 use App\Http\Controllers\Api\V1\CirceController;
 use App\Http\Controllers\Api\V1\ClaimsSearchController;
 use App\Http\Controllers\Api\V1\ClinicalCoherenceController;
+use App\Http\Controllers\Api\V1\ClioAgentController;
 use App\Http\Controllers\Api\V1\CohortAuthoringArtifactController;
 use App\Http\Controllers\Api\V1\CohortDefinitionController;
 use App\Http\Controllers\Api\V1\CohortDiagnosticsController;
@@ -882,6 +883,17 @@ Route::prefix('v1')->group(function () {
                 ->middleware('permission:studies.edit');
             Route::post('gates/{studyGate}/override', [StudyGateController::class, 'override'])
                 ->middleware('permission:studies.edit');
+
+            // Clio orchestrator agent (ADR-0020 Phase 5b)
+            Route::post('agent/sessions', [ClioAgentController::class, 'start'])
+                ->middleware('throttle:20,1');
+            Route::post('agent/sessions/{agentSession}/messages', [ClioAgentController::class, 'message'])
+                ->middleware('throttle:30,1');
+            Route::post('agent/sessions/{agentSession}/approve', [ClioAgentController::class, 'approve'])
+                ->middleware('throttle:60,1');
+            Route::get('agent/sessions/{agentSession}/snapshot', [ClioAgentController::class, 'snapshot']);
+            Route::post('agent/sessions/{agentSession}/ingest', [ClioAgentController::class, 'ingest'])
+                ->middleware('throttle:120,1');
 
             // Synthesis
             Route::get('synthesis', [StudySynthesisController::class, 'index']);

--- a/backend/tests/Feature/Studies/ClioAgentControllerTest.php
+++ b/backend/tests/Feature/Studies/ClioAgentControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use App\Models\App\AgentSession;
+use App\Models\App\Study;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+it('starts a clio agent session for a study collaborator and calls the AI harness', function () {
+    Http::fake(['*/agent/sessions' => Http::response(['ok' => true], 200)]);
+
+    $user = User::factory()->create();
+    $study = Study::create(['title' => 'HTN study', 'created_by' => $user->id, 'status' => 'draft']);
+
+    $resp = $this->actingAs($user)->postJson("/api/v1/studies/{$study->slug}/agent/sessions");
+
+    $resp->assertStatus(201)
+        ->assertJsonPath('data.channel_name', "private-clio.study.{$study->id}");
+
+    $this->assertDatabaseHas('agent_sessions', [
+        'profile' => 'clio',
+        'subject_id' => $study->id,
+        'user_id' => $user->id,
+        'status' => 'active',
+    ]);
+
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/agent/sessions')
+        && $req['profile'] === 'clio'
+        && $req['context']['study_slug'] === $study->slug);
+});
+
+it('rejects a non-collaborator with 404 and never calls the agent service', function () {
+    Http::fake();
+
+    $owner = User::factory()->create();
+    $intruder = User::factory()->create();
+    $study = Study::create(['title' => 'HTN study', 'created_by' => $owner->id, 'status' => 'draft']);
+
+    $this->actingAs($intruder)
+        ->postJson("/api/v1/studies/{$study->slug}/agent/sessions")
+        ->assertStatus(404);
+
+    // The true invariant: a blocked intruder created no session.
+    $this->assertDatabaseCount('agent_sessions', 0);
+});
+
+it('returns 503 and marks the session errored when the agent service is down', function () {
+    Http::fake(['*/agent/sessions' => Http::response(null, 500)]);
+
+    $user = User::factory()->create();
+    $study = Study::create(['title' => 'HTN study', 'created_by' => $user->id, 'status' => 'draft']);
+
+    $this->actingAs($user)
+        ->postJson("/api/v1/studies/{$study->slug}/agent/sessions")
+        ->assertStatus(503);
+
+    $this->assertDatabaseHas('agent_sessions', [
+        'subject_id' => $study->id,
+        'status' => 'error',
+    ]);
+});
+
+it('forwards a message to the agent turn endpoint', function () {
+    Http::fake([
+        '*/agent/sessions' => Http::response(['ok' => true], 200),
+        '*/turn' => Http::response(['ok' => true], 202),
+    ]);
+
+    $user = User::factory()->create();
+    $study = Study::create(['title' => 'HTN study', 'created_by' => $user->id, 'status' => 'draft']);
+    $session = AgentSession::create([
+        'profile' => 'clio',
+        'subject_type' => 'study',
+        'subject_id' => $study->id,
+        'user_id' => $user->id,
+        'status' => 'active',
+        'context_json' => ['study_slug' => $study->slug],
+        'last_active_at' => now(),
+    ]);
+
+    $this->actingAs($user)
+        ->postJson("/api/v1/studies/{$study->slug}/agent/sessions/{$session->id}/messages", [
+            'text' => 'What is blocking this study?',
+            'idempotency_key' => 'abc-123',
+        ])
+        ->assertStatus(202)
+        ->assertJsonPath('data.accepted', true);
+
+    Http::assertSent(fn ($req) => str_contains($req->url(), "/agent/sessions/{$session->id}/turn"));
+});

--- a/frontend/src/features/studies/api/clioAgentApi.ts
+++ b/frontend/src/features/studies/api/clioAgentApi.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import apiClient from "@/lib/api-client";
+
+// ---------------------------------------------------------------------------
+// Clio orchestrator agent client (ADR-0020 Phase 5b)
+// ---------------------------------------------------------------------------
+
+const base = (slug: string): string => `/studies/${slug}/agent/sessions`;
+
+export const startClioSessionResponse = z.object({
+  agent_session_id: z.number(),
+  channel_name: z.string(),
+});
+export type StartClioSessionResponse = z.infer<typeof startClioSessionResponse>;
+
+export async function startClioSession(slug: string): Promise<StartClioSessionResponse> {
+  const { data } = await apiClient.post(base(slug), {});
+  return startClioSessionResponse.parse(data.data ?? data);
+}
+
+export async function sendClioMessage(
+  slug: string,
+  sessionId: number,
+  text: string,
+): Promise<void> {
+  await apiClient.post(`${base(slug)}/${sessionId}/messages`, {
+    text,
+    idempotency_key: crypto.randomUUID(),
+  });
+}
+
+export async function approveClioTool(
+  slug: string,
+  sessionId: number,
+  toolUseId: string,
+  approved: boolean,
+): Promise<void> {
+  await apiClient.post(`${base(slug)}/${sessionId}/approve`, {
+    tool_use_id: toolUseId,
+    approved,
+  });
+}
+
+// ── Reverb event payloads (emitted by the python-ai harness) ────────────────
+export const agentTextDelta = z.object({ text: z.string() });
+export const agentToolStart = z.object({ name: z.string(), input: z.unknown() });
+export const agentTurnDone = z.object({
+  cost_usd: z.number(),
+  tokens_in: z.number(),
+  tokens_out: z.number(),
+  anthropic_session_id: z.string().nullable(),
+});
+export const agentError = z.object({ message: z.string() });
+export const agentApprovalRequest = z.object({
+  tool_use_id: z.string(),
+  tool: z.string(),
+  input: z.unknown(),
+});
+export const agentApprovalDenied = z.object({
+  tool_use_id: z.string(),
+  tool: z.string(),
+});
+
+export type AgentEvent =
+  | { type: "text"; text: string }
+  | { type: "tool"; name: string; input: unknown }
+  | { type: "done"; costUsd: number }
+  | { type: "error"; message: string }
+  | { type: "approval-request"; toolUseId: string; tool: string; input: unknown }
+  | { type: "approval-denied"; toolUseId: string };

--- a/frontend/src/features/studies/components/ClioCopilotPanel.tsx
+++ b/frontend/src/features/studies/components/ClioCopilotPanel.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import { Sparkles, Loader2, Send } from "lucide-react";
+import { useClioAgent } from "../hooks/useClioAgent";
+import { useClioAgentStore } from "../stores/clioAgentStore";
+
+interface ClioCopilotPanelProps {
+  slug: string;
+}
+
+/**
+ * The Clio orchestrator surface (ADR-0020 Phase 5b). Lets a study collaborator
+ * start a Clio session, chat with it, and approve/reject its approval-gated
+ * actions. Started explicitly (not on mount) since each session consumes LLM
+ * budget. Clio proposes; gate approvals/overrides stay in the Gates timeline.
+ */
+export function ClioCopilotPanel({ slug }: ClioCopilotPanelProps) {
+  const { start, starting, send, approve } = useClioAgent({ slug });
+  const { transcript, isStreaming, agentSessionId, errorMessage, pendingApprovals, lastCostUsd } =
+    useClioAgentStore();
+  const [draft, setDraft] = useState("");
+
+  return (
+    <div
+      data-testid="clio-copilot-panel"
+      className="rounded-lg border border-border-default bg-surface-raised p-4 space-y-3"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Sparkles size={16} className="text-accent" />
+          <h3 className="text-sm font-semibold text-text-primary">Clio Orchestrator</h3>
+        </div>
+        {agentSessionId == null ? (
+          <button
+            type="button"
+            onClick={() => start()}
+            disabled={starting}
+            className="inline-flex items-center gap-1.5 rounded-md bg-accent/15 px-3 py-1.5 text-xs font-medium text-accent hover:bg-accent/25 disabled:opacity-40"
+          >
+            {starting ? <Loader2 size={12} className="animate-spin" /> : <Sparkles size={12} />}
+            Start Clio
+          </button>
+        ) : (
+          lastCostUsd != null && (
+            <span className="font-['IBM_Plex_Mono',monospace] text-[10px] text-text-ghost">
+              ${lastCostUsd.toFixed(3)}
+            </span>
+          )
+        )}
+      </div>
+
+      {agentSessionId == null ? (
+        <p className="text-xs text-text-muted">
+          Clio reads this study's gates, evaluates them from the latest diagnostics, and explains
+          what is blocking progress — proposing concrete remediations. It never decides validity:
+          gate approvals and overrides stay yours in the timeline above.
+        </p>
+      ) : (
+        <>
+          {errorMessage && (
+            <div className="rounded bg-critical/15 p-2 text-xs text-critical">{errorMessage}</div>
+          )}
+
+          {pendingApprovals.length > 0 && (
+            <div className="space-y-2">
+              {pendingApprovals.map((a) => (
+                <div
+                  key={a.toolUseId}
+                  data-testid="clio-approval-card"
+                  className="rounded border border-accent/30 bg-accent/5 p-2 text-xs"
+                >
+                  <p className="font-semibold text-accent">{a.tool}</p>
+                  <p className="mb-2 break-all text-text-muted">
+                    {JSON.stringify(a.input).slice(0, 160)}
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => void approve(a.toolUseId, true)}
+                      className="rounded bg-success/20 px-2 py-0.5 text-success"
+                    >
+                      Approve
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void approve(a.toolUseId, false)}
+                      className="rounded bg-critical/20 px-2 py-0.5 text-critical"
+                    >
+                      Reject
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="max-h-80 space-y-2 overflow-y-auto">
+            {transcript.map((turn, i) => (
+              <div key={i}>
+                <span className="text-[10px] uppercase tracking-wider text-text-ghost">
+                  {turn.role === "user" ? "You" : "Clio"}
+                </span>
+                <p
+                  className={
+                    "whitespace-pre-wrap text-xs " +
+                    (turn.role === "user" ? "text-text-secondary" : "text-text-primary")
+                  }
+                >
+                  {turn.text}
+                </p>
+                {turn.tools && turn.tools.length > 0 && (
+                  <p className="mt-1 font-['IBM_Plex_Mono',monospace] text-[10px] text-text-ghost">
+                    ↳ {turn.tools.map((t) => t.name).join(", ")}
+                  </p>
+                )}
+              </div>
+            ))}
+            {isStreaming && <Loader2 size={12} className="animate-spin text-text-ghost" />}
+          </div>
+
+          <form
+            className="flex gap-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (draft.trim() && !isStreaming) {
+                void send(draft.trim());
+                setDraft("");
+              }
+            }}
+          >
+            <input
+              aria-label="Message Clio"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              disabled={isStreaming}
+              placeholder="Ask Clio what's blocking this study…"
+              className="flex-1 rounded-md border border-border-default bg-surface-base px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:border-accent"
+            />
+            <button
+              type="submit"
+              disabled={isStreaming}
+              className="rounded-md bg-accent/15 px-3 py-1.5 text-xs text-accent disabled:opacity-40"
+            >
+              <Send size={12} />
+            </button>
+          </form>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/studies/components/StudyGatesTab.tsx
+++ b/frontend/src/features/studies/components/StudyGatesTab.tsx
@@ -17,6 +17,7 @@ import {
   type GateStatus,
   type StudyGate,
 } from "../api/gatesApi";
+import { ClioCopilotPanel } from "./ClioCopilotPanel";
 
 const STAGES: { stage: GateStage; label: string }[] = [
   { stage: "design", label: "1 · Design (PICO)" },
@@ -228,6 +229,8 @@ export function StudyGatesTab({ slug, canDecide = false }: StudyGatesTabProps) {
           );
         })}
       </div>
+
+      <ClioCopilotPanel slug={slug} />
     </div>
   );
 }

--- a/frontend/src/features/studies/hooks/useClioAgent.ts
+++ b/frontend/src/features/studies/hooks/useClioAgent.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getEcho } from "@/lib/echo";
+import {
+  agentApprovalDenied,
+  agentApprovalRequest,
+  agentError,
+  agentTextDelta,
+  agentToolStart,
+  agentTurnDone,
+  approveClioTool,
+  sendClioMessage,
+  startClioSession,
+} from "../api/clioAgentApi";
+import { useClioAgentStore } from "../stores/clioAgentStore";
+
+interface Params {
+  slug: string | null;
+}
+
+/**
+ * Drives a Clio orchestrator agent session for a study (ADR-0020 Phase 5b):
+ * starts the session, subscribes to its private Reverb channel, and relays
+ * user messages + tool approvals. When a turn completes it refreshes the gate
+ * timeline (the agent may have evaluated gates).
+ */
+export function useClioAgent({ slug }: Params) {
+  const qc = useQueryClient();
+  const channelName = useClioAgentStore((s) => s.channelName);
+  const setSession = useClioAgentStore((s) => s.setSession);
+  const subscribedRef = useRef<string | null>(null);
+
+  const startMutation = useMutation({
+    mutationFn: () => startClioSession(slug!),
+    onSuccess: (data) => setSession(data.agent_session_id, data.channel_name),
+  });
+
+  useEffect(() => {
+    if (!channelName) return;
+    const echo = getEcho();
+    if (!echo) return;
+
+    const name = channelName.replace(/^private-/, "");
+    if (subscribedRef.current === name) return;
+    if (subscribedRef.current) echo.leave(subscribedRef.current);
+
+    const { applyEvent } = useClioAgentStore.getState();
+    echo
+      .private(name)
+      .listen(".agent.text.delta", (e: unknown) =>
+        applyEvent({ type: "text", ...agentTextDelta.parse(e) }),
+      )
+      .listen(".agent.tool.start", (e: unknown) => {
+        const p = agentToolStart.parse(e);
+        applyEvent({ type: "tool", name: p.name, input: p.input });
+      })
+      .listen(".agent.turn.done", (e: unknown) => {
+        applyEvent({ type: "done", costUsd: agentTurnDone.parse(e).cost_usd });
+        if (slug) qc.invalidateQueries({ queryKey: ["study-gates", slug] });
+      })
+      .listen(".agent.error", (e: unknown) =>
+        applyEvent({ type: "error", ...agentError.parse(e) }),
+      )
+      .listen(".agent.approval.request", (e: unknown) => {
+        const p = agentApprovalRequest.parse(e);
+        applyEvent({ type: "approval-request", toolUseId: p.tool_use_id, tool: p.tool, input: p.input });
+      })
+      .listen(".agent.approval.denied", (e: unknown) => {
+        const p = agentApprovalDenied.parse(e);
+        applyEvent({ type: "approval-denied", toolUseId: p.tool_use_id });
+      });
+
+    subscribedRef.current = name;
+    return () => {
+      echo.leave(name);
+      subscribedRef.current = null;
+    };
+  }, [channelName, slug, qc]);
+
+  const send = useCallback(
+    async (text: string) => {
+      const { agentSessionId, pushUserMessage } = useClioAgentStore.getState();
+      if (!slug || agentSessionId == null) return;
+      pushUserMessage(text);
+      await sendClioMessage(slug, agentSessionId, text);
+    },
+    [slug],
+  );
+
+  const approve = useCallback(
+    async (toolUseId: string, approved: boolean) => {
+      const { agentSessionId } = useClioAgentStore.getState();
+      if (!slug || agentSessionId == null) return;
+      await approveClioTool(slug, agentSessionId, toolUseId, approved);
+    },
+    [slug],
+  );
+
+  return { start: startMutation.mutate, starting: startMutation.isPending, send, approve };
+}

--- a/frontend/src/features/studies/stores/clioAgentStore.ts
+++ b/frontend/src/features/studies/stores/clioAgentStore.ts
@@ -1,0 +1,109 @@
+import { create } from "zustand";
+import type { AgentEvent } from "../api/clioAgentApi";
+
+export interface ToolCall {
+  name: string;
+  input: unknown;
+}
+
+export interface TranscriptTurn {
+  role: "user" | "assistant";
+  text: string;
+  tools?: ToolCall[];
+}
+
+export interface PendingApproval {
+  toolUseId: string;
+  tool: string;
+  input: unknown;
+}
+
+interface ClioAgentState {
+  agentSessionId: number | null;
+  channelName: string | null;
+  transcript: TranscriptTurn[];
+  isStreaming: boolean;
+  lastCostUsd: number | null;
+  errorMessage: string | null;
+  pendingApprovals: PendingApproval[];
+  setSession: (id: number, channel: string) => void;
+  pushUserMessage: (text: string) => void;
+  applyEvent: (event: AgentEvent) => void;
+  reset: () => void;
+}
+
+function ensureAssistantTurn(transcript: TranscriptTurn[]): TranscriptTurn[] {
+  const last = transcript[transcript.length - 1];
+  if (last && last.role === "assistant") {
+    return transcript;
+  }
+  return [...transcript, { role: "assistant", text: "", tools: [] }];
+}
+
+export const useClioAgentStore = create<ClioAgentState>((set) => ({
+  agentSessionId: null,
+  channelName: null,
+  transcript: [],
+  isStreaming: false,
+  lastCostUsd: null,
+  errorMessage: null,
+  pendingApprovals: [],
+
+  setSession: (id, channel) => set({ agentSessionId: id, channelName: channel }),
+
+  pushUserMessage: (text) =>
+    set((s) => ({
+      transcript: [...s.transcript, { role: "user", text }],
+      isStreaming: true,
+      errorMessage: null,
+    })),
+
+  applyEvent: (event) =>
+    set((s) => {
+      if (event.type === "text") {
+        const t = ensureAssistantTurn(s.transcript);
+        const last = t[t.length - 1];
+        const updated: TranscriptTurn = { ...last, text: last.text + event.text };
+        return { transcript: [...t.slice(0, -1), updated] };
+      }
+      if (event.type === "tool") {
+        const t = ensureAssistantTurn(s.transcript);
+        const last = t[t.length - 1];
+        const updated: TranscriptTurn = {
+          ...last,
+          tools: [...(last.tools ?? []), { name: event.name, input: event.input }],
+        };
+        return { transcript: [...t.slice(0, -1), updated] };
+      }
+      if (event.type === "approval-request") {
+        const already = s.pendingApprovals.some((p) => p.toolUseId === event.toolUseId);
+        if (already) return {};
+        return {
+          pendingApprovals: [
+            ...s.pendingApprovals,
+            { toolUseId: event.toolUseId, tool: event.tool, input: event.input },
+          ],
+        };
+      }
+      if (event.type === "approval-denied") {
+        return {
+          pendingApprovals: s.pendingApprovals.filter((p) => p.toolUseId !== event.toolUseId),
+        };
+      }
+      if (event.type === "done") {
+        return { isStreaming: false, lastCostUsd: event.costUsd, pendingApprovals: [] };
+      }
+      return { isStreaming: false, errorMessage: event.message };
+    }),
+
+  reset: () =>
+    set({
+      agentSessionId: null,
+      channelName: null,
+      transcript: [],
+      isStreaming: false,
+      lastCostUsd: null,
+      errorMessage: null,
+      pendingApprovals: [],
+    }),
+}));


### PR DESCRIPTION
Makes the Clio orchestrator (merged in #357, Phase 5) **user-facing**. No AI-service change — the generic `/agent` router and `clio` profile already accept it.

## Backend
- `ClioAgentController` — study-scoped `start`/`message`/`approve`/`snapshot`/`ingest`, mirroring the publish/study-design agent controllers. Mints a scoped Sanctum token (`studies.view`/`execute`/`create`), registers a `clio` session with python-ai, relays turns + tool approvals. Gated to study collaborators (creator/PI/lead-scientist/lead-statistician/team) or admins.
- Routes under `studies/{study}/agent/sessions` with throttling.

## Frontend
- `clioAgentApi` + `clioAgentStore` + `useClioAgent` (Reverb streaming; refreshes the gate timeline when a turn completes) + `ClioCopilotPanel` (explicit-start chat with approval cards), wired into the study **Gates** tab.
- The execute tools (`evaluate_gates`, `build_study_package`) surface as **approval cards** — the human-in-the-loop gate. Gate approve/override stays in the timeline; the agent only proposes.

## Verification
4 PHP feature tests (start, collaborator guard, service-down, message relay), Pint, PHPStan L8, tsc, ESLint, vite build — all green.

## Remaining
Phase 6 — `ManuscriptComposer` (STROBE/RECORD document from calibrated results + provenance + the gate-ledger decision trail).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)