### PR TITLE
feat: Clio manuscript composer (ADR-0020 Phase 6)

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/StudyManuscriptController.php
+++ b/backend/app/Http/Controllers/Api/V1/StudyManuscriptController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\App\Study;
+use App\Services\Publication\ManuscriptComposer;
+use App\Services\Publication\PublicationService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Assembles a STROBE/RECORD manuscript from a study's calibrated results,
+ * gate-ledger decisions, and provenance (ADR-0020 Phase 6), and exports it via
+ * the existing publication exporters.
+ *
+ * @group Studies
+ */
+class StudyManuscriptController extends Controller
+{
+    public function __construct(
+        private readonly ManuscriptComposer $composer,
+        private readonly PublicationService $publication,
+    ) {}
+
+    /**
+     * GET /v1/studies/{study}/manuscript
+     */
+    public function compose(Study $study): JsonResponse
+    {
+        try {
+            return response()->json(['data' => $this->composer->compose($study)]);
+        } catch (\Throwable $e) {
+            return $this->errorResponse('Failed to compose manuscript', $e);
+        }
+    }
+
+    /**
+     * POST /v1/studies/{study}/manuscript/export
+     */
+    public function export(Request $request, Study $study): JsonResponse|StreamedResponse
+    {
+        $validated = $request->validate([
+            'format' => ['required', 'string', Rule::in(['docx', 'pdf'])],
+        ]);
+
+        try {
+            $document = $this->composer->compose($study);
+
+            return $this->publication->export([...$document, 'format' => $validated['format']]);
+        } catch (\Throwable $e) {
+            return $this->errorResponse('Failed to export manuscript', $e);
+        }
+    }
+
+    private function errorResponse(string $message, \Throwable $exception): JsonResponse
+    {
+        $response = [
+            'error' => $message,
+            'message' => $exception->getMessage(),
+        ];
+
+        if (config('app.debug')) {
+            $response['trace'] = $exception->getTraceAsString();
+        }
+
+        return response()->json($response, 500);
+    }
+}

--- a/backend/app/Services/Publication/ManuscriptComposer.php
+++ b/backend/app/Services/Publication/ManuscriptComposer.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace App\Services\Publication;
+
+use App\Models\App\EstimationAnalysis;
+use App\Models\App\Study;
+use App\Models\App\StudyGate;
+use App\Support\EstimationResultNormalizer;
+
+/**
+ * Assembles a STROBE/RECORD-structured manuscript from a study's ACTUAL data
+ * (ADR-0020 Phase 6). Deterministic and fabrication-free: every figure comes
+ * from a stored result, every limitation from the gate ledger, and the
+ * provenance appendix from the recorded hashes and decision trail. The output
+ * shape matches PublicationService::export(), so it flows straight to docx/pdf.
+ *
+ * Crucially, the Results section is gate-aware: calibrated effect estimates are
+ * reported only when the study's study-diagnostics gate has cleared (passed,
+ * approved, or overridden). Otherwise the effect is withheld and only the
+ * diagnostics are reported — the same blinding the live API enforces.
+ */
+class ManuscriptComposer
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function compose(Study $study): array
+    {
+        $study->loadMissing(['cohorts.cohortDefinition', 'analyses', 'gates']);
+
+        $estimation = $this->latestEstimationResult($study);
+        $s5Cleared = $this->gateCleared($study, 'study_diagnostics');
+
+        $sections = [
+            $this->section('abstract', 'Abstract', $this->abstract($study)),
+            $this->section('introduction', 'Introduction', $this->introduction($study)),
+            $this->section('methods', 'Methods', $this->methods($study)),
+            $this->section('results', 'Results', $this->results($study, $estimation, $s5Cleared)),
+            $this->section('limitations', 'Limitations', $this->limitations($study)),
+            $this->section('provenance', 'Provenance & Reproducibility', $this->provenance($study)),
+        ];
+
+        return [
+            'title' => $study->title,
+            'authors' => $this->authors($study),
+            'template' => 'strobe-record',
+            'sections' => $sections,
+            'manuscript_meta' => [
+                'effect_estimates_included' => $s5Cleared && $estimation !== null,
+                'gating_enabled' => (bool) config('studies.gating_enabled', false),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $estimation
+     */
+    private function results(Study $study, ?array $estimation, bool $s5Cleared): string
+    {
+        if ($estimation === null) {
+            return 'No population-level estimation has completed for this study; comparative effect estimates are not yet available.';
+        }
+
+        $ps = is_array($estimation['propensity_score'] ?? null) ? $estimation['propensity_score'] : [];
+        $lines = [];
+
+        $lines[] = sprintf(
+            'Propensity-score diagnostics: AUC %s, equipoise %s, maximum post-adjustment standardized mean difference %s.',
+            $this->fmt($ps['auc'] ?? null),
+            $this->fmt($ps['equipoise'] ?? null),
+            $this->fmt($ps['max_smd_after'] ?? null),
+        );
+
+        if (! $s5Cleared) {
+            $lines[] = 'Effect estimates are withheld: the study-diagnostics gate has not cleared. '
+                .'Only diagnostics are reported, pending reviewer approval or a documented override.';
+
+            return implode(' ', $lines);
+        }
+
+        $calibration = is_array($estimation['calibration'] ?? null) ? $estimation['calibration'] : null;
+
+        if ($calibration === null || ($calibration['status'] ?? null) !== 'completed') {
+            $lines[] = 'Empirical calibration was not performed (insufficient informative negative controls), '
+                .'so only uncalibrated estimates are available and should be interpreted with caution.';
+            $lines[] = $this->uncalibratedTable($estimation);
+
+            return implode(' ', array_filter($lines));
+        }
+
+        $lines[] = sprintf(
+            'Estimates were empirically calibrated against %d negative controls (EASE %s).',
+            (int) ($calibration['informative_negative_controls'] ?? 0),
+            $this->fmt($calibration['ease'] ?? null),
+        );
+        $lines[] = $this->calibratedTable($calibration);
+
+        return implode(' ', array_filter($lines));
+    }
+
+    /**
+     * @param  array<string, mixed>  $calibration
+     */
+    private function calibratedTable(array $calibration): string
+    {
+        $rows = [];
+        $estimates = is_array($calibration['calibrated_estimates'] ?? null) ? $calibration['calibrated_estimates'] : [];
+        foreach ($estimates as $est) {
+            if (! is_array($est) || ($est['calibrated'] ?? false) !== true) {
+                continue;
+            }
+            $rows[] = sprintf(
+                '%s: calibrated HR %s (95%% CI %s–%s), calibrated p %s.',
+                (string) ($est['outcome_name'] ?? 'Outcome'),
+                $this->fmt($est['calibrated_hr'] ?? null),
+                $this->fmt($est['cal_ci_lower'] ?? null),
+                $this->fmt($est['cal_ci_upper'] ?? null),
+                $this->fmt($est['calibrated_p'] ?? null),
+            );
+        }
+
+        return $rows === [] ? 'No calibrated outcome estimates were produced.' : 'Calibrated effect estimates: '.implode(' ', $rows);
+    }
+
+    /**
+     * @param  array<string, mixed>  $estimation
+     */
+    private function uncalibratedTable(array $estimation): string
+    {
+        $rows = [];
+        foreach ($estimation['estimates'] ?? [] as $est) {
+            if (! is_array($est)) {
+                continue;
+            }
+            $rows[] = sprintf(
+                '%s: HR %s (95%% CI %s–%s), p %s.',
+                (string) ($est['outcome_name'] ?? 'Outcome'),
+                $this->fmt($est['hazard_ratio'] ?? null),
+                $this->fmt($est['ci_95_lower'] ?? null),
+                $this->fmt($est['ci_95_upper'] ?? null),
+                $this->fmt($est['p_value'] ?? null),
+            );
+        }
+
+        return $rows === [] ? '' : 'Uncalibrated estimates: '.implode(' ', $rows);
+    }
+
+    private function methods(Study $study): string
+    {
+        $cohorts = [];
+        foreach ($study->cohorts as $cohort) {
+            $cohorts[] = sprintf('%s (%s)', (string) ($cohort->label ?? $cohort->role), (string) $cohort->role);
+        }
+
+        $thresholds = config('studies.gate_thresholds.study_diagnostics', []);
+        $thresholdText = is_array($thresholds) ? sprintf(
+            'Pre-specified diagnostic gates required propensity-score AUC below %s, maximum post-adjustment SMD below %s, and equipoise of at least %s.',
+            $this->fmt($thresholds['max_ps_auc'] ?? null),
+            $this->fmt($thresholds['max_smd_after'] ?? null),
+            $this->fmt($thresholds['min_equipoise'] ?? null),
+        ) : '';
+
+        $design = $study->study_design ? sprintf('This was a %s observational study on the OMOP CDM. ', (string) $study->study_design)
+            : 'This was an observational study on the OMOP CDM. ';
+
+        return $design
+            .($cohorts === [] ? '' : 'Cohorts: '.implode('; ', $cohorts).'. ')
+            .$thresholdText;
+    }
+
+    private function limitations(Study $study): string
+    {
+        $lines = [];
+        foreach ($study->gates as $gate) {
+            if (! $gate instanceof StudyGate) {
+                continue;
+            }
+            $reasons = is_array($gate->metrics_json['reasons'] ?? null)
+                ? implode(' ', array_map('strval', $gate->metrics_json['reasons']))
+                : '';
+            $stage = $gate->stage->value;
+
+            if ($gate->status->value === 'overridden') {
+                $lines[] = sprintf(
+                    'The %s gate did not pass (%s) and was overridden with the documented rationale: "%s".',
+                    $stage, $reasons, (string) ($gate->override_rationale ?? '')
+                );
+            } elseif ($gate->status->value === 'failed') {
+                $lines[] = sprintf(
+                    'The %s gate failed (%s); affected estimates remain blinded and were not interpreted.',
+                    $stage, $reasons
+                );
+            }
+        }
+
+        if ($lines === []) {
+            return 'No scientific gate failures or overrides were recorded for this study.';
+        }
+
+        return 'The following gate decisions qualify the findings. '.implode(' ', $lines);
+    }
+
+    private function provenance(Study $study): string
+    {
+        $cohortLines = [];
+        $vocab = null;
+        $cdm = null;
+        foreach ($study->cohorts as $cohort) {
+            $def = $cohort->cohortDefinition;
+            if ($def === null) {
+                continue;
+            }
+            $gen = $def->generations()->orderByDesc('id')->first();
+            $vocab ??= $gen?->vocabulary_version;
+            $cdm ??= $gen?->cdm_source_release;
+            $cohortLines[] = sprintf('%s [sha256:%s]', (string) $def->name, substr((string) $def->expression_sha256, 0, 12) ?: 'unhashed');
+        }
+
+        $gateTrail = [];
+        foreach ($study->gates as $gate) {
+            if ($gate instanceof StudyGate) {
+                $gateTrail[] = sprintf('%s=%s', $gate->stage->value, $gate->status->value);
+            }
+        }
+
+        return 'This study is reproducible from its content-addressed artifacts. '
+            .($cohortLines === [] ? '' : 'Cohort definitions: '.implode('; ', $cohortLines).'. ')
+            .($vocab ? sprintf('Vocabulary version %s. ', $vocab) : '')
+            .($cdm ? sprintf('CDM release %s. ', $cdm) : '')
+            .($gateTrail === [] ? '' : 'Gate-ledger decision trail: '.implode(', ', $gateTrail).'.');
+    }
+
+    private function abstract(Study $study): string
+    {
+        return (string) ($study->primary_objective
+            ?: $study->scientific_rationale
+            ?: sprintf('An observational study (%s) conducted on the OMOP CDM.', (string) $study->title));
+    }
+
+    private function introduction(Study $study): string
+    {
+        return (string) ($study->scientific_rationale ?: $study->hypothesis ?: 'Background and rationale for this study.');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function authors(Study $study): array
+    {
+        $authors = [];
+        if ($study->principalInvestigator !== null) {
+            $authors[] = (string) $study->principalInvestigator->name;
+        }
+        if ($study->leadStatistician !== null) {
+            $authors[] = (string) $study->leadStatistician->name;
+        }
+
+        return array_values(array_unique($authors));
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function latestEstimationResult(Study $study): ?array
+    {
+        foreach ($study->analyses as $studyAnalysis) {
+            if ($studyAnalysis->analysis_type !== EstimationAnalysis::class) {
+                continue;
+            }
+            /** @var EstimationAnalysis|null $analysis */
+            $analysis = $studyAnalysis->analysis;
+            $execution = $analysis?->executions()
+                ->where('status', 'completed')
+                ->orderByDesc('created_at')
+                ->first();
+
+            if ($execution !== null && is_array($execution->result_json)) {
+                return EstimationResultNormalizer::normalize($execution->result_json);
+            }
+        }
+
+        return null;
+    }
+
+    private function gateCleared(Study $study, string $stage): bool
+    {
+        foreach ($study->gates as $gate) {
+            if ($gate instanceof StudyGate && $gate->stage->value === $stage) {
+                return $gate->status->clears();
+            }
+        }
+
+        // No gate recorded → not blocked (gating may be disabled or not yet run).
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function section(string $key, string $title, string $content): array
+    {
+        return [
+            'key' => $key,
+            'title' => $title,
+            'content' => $content,
+            'type' => 'text',
+            'included' => true,
+        ];
+    }
+
+    private function fmt(mixed $value): string
+    {
+        return is_numeric($value) ? (string) round((float) $value, 4) : '—';
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -142,6 +142,7 @@ use App\Http\Controllers\Api\V1\StudyController;
 use App\Http\Controllers\Api\V1\StudyDesignAgentController;
 use App\Http\Controllers\Api\V1\StudyDesignController;
 use App\Http\Controllers\Api\V1\StudyGateController;
+use App\Http\Controllers\Api\V1\StudyManuscriptController;
 use App\Http\Controllers\Api\V1\StudyMilestoneController;
 use App\Http\Controllers\Api\V1\StudyPackageController;
 use App\Http\Controllers\Api\V1\StudyResultController;
@@ -894,6 +895,12 @@ Route::prefix('v1')->group(function () {
             Route::get('agent/sessions/{agentSession}/snapshot', [ClioAgentController::class, 'snapshot']);
             Route::post('agent/sessions/{agentSession}/ingest', [ClioAgentController::class, 'ingest'])
                 ->middleware('throttle:120,1');
+
+            // Manuscript synthesis (Clio / ADR-0020 Phase 6)
+            Route::get('manuscript', [StudyManuscriptController::class, 'compose'])
+                ->middleware('permission:studies.view');
+            Route::post('manuscript/export', [StudyManuscriptController::class, 'export'])
+                ->middleware('permission:studies.view');
 
             // Synthesis
             Route::get('synthesis', [StudySynthesisController::class, 'index']);

--- a/backend/tests/Feature/Studies/ManuscriptComposerTest.php
+++ b/backend/tests/Feature/Studies/ManuscriptComposerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Enums\GateStatus;
+use App\Models\App\EstimationAnalysis;
+use App\Models\App\Source;
+use App\Models\App\Study;
+use App\Models\App\StudyAnalysis;
+use App\Models\App\StudyGate;
+use App\Models\User;
+use App\Services\Publication\ManuscriptComposer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+if (! function_exists('clioManuscriptStudy')) {
+    function clioManuscriptStudy(User $user, string $gateStatus): Study
+    {
+        $study = Study::create([
+            'title' => 'Hypertension MACE study',
+            'created_by' => $user->id,
+            'principal_investigator_id' => $user->id,
+            'status' => 'draft',
+            'primary_objective' => 'Estimate MACE risk in treated hypertension.',
+        ]);
+
+        $analysis = EstimationAnalysis::create(['name' => 'PLE', 'author_id' => $user->id, 'design_json' => []]);
+        StudyAnalysis::create([
+            'study_id' => $study->id,
+            'analysis_type' => EstimationAnalysis::class,
+            'analysis_id' => $analysis->id,
+        ]);
+
+        $source = Source::create(['source_name' => 'Test CDM', 'source_key' => 'TEST']);
+
+        $analysis->executions()->create([
+            'source_id' => $source->id,
+            'status' => 'completed',
+            'result_json' => [
+                'propensity_score' => ['auc' => 0.7, 'equipoise' => 0.5, 'max_smd_after' => 0.05],
+                'estimates' => [[
+                    'outcome_id' => 1, 'outcome_name' => 'MACE',
+                    'hazard_ratio' => 1.6, 'ci_95_lower' => 1.3, 'ci_95_upper' => 2.0, 'p_value' => 0.001,
+                ]],
+                'calibration' => [
+                    'status' => 'completed',
+                    'informative_negative_controls' => 8,
+                    'ease' => 0.14,
+                    'calibrated_estimates' => [[
+                        'outcome_id' => 1, 'outcome_name' => 'MACE', 'calibrated' => true,
+                        'calibrated_hr' => 1.47, 'cal_ci_lower' => 1.06, 'cal_ci_upper' => 2.04, 'calibrated_p' => 0.02,
+                    ]],
+                ],
+            ],
+        ]);
+
+        StudyGate::create([
+            'study_id' => $study->id,
+            'stage' => 'study_diagnostics',
+            'gate_key' => 'default',
+            'status' => $gateStatus,
+            'metrics_json' => ['reasons' => ['Max post-adjustment SMD 0.312 exceeds 0.10.']],
+            'decision' => 'human',
+            'override_rationale' => $gateStatus === GateStatus::Overridden->value
+                ? 'Active comparator unavailable in this CDM; documented limitation.'
+                : null,
+        ]);
+
+        return $study->fresh();
+    }
+}
+
+it('composes a gate-aware manuscript with calibrated results and an override limitation', function () {
+    $user = User::factory()->create();
+    $study = clioManuscriptStudy($user, GateStatus::Overridden->value);
+
+    $doc = app(ManuscriptComposer::class)->compose($study);
+    $byKey = collect($doc['sections'])->keyBy('key');
+
+    expect($doc['title'])->toBe('Hypertension MACE study')
+        ->and($doc['template'])->toBe('strobe-record')
+        ->and($doc['manuscript_meta']['effect_estimates_included'])->toBeTrue()
+        ->and($byKey['results']['content'])->toContain('calibrated HR 1.47')
+        ->and($byKey['results']['content'])->toContain('EASE 0.14')
+        ->and($byKey['limitations']['content'])->toContain('Active comparator unavailable')
+        ->and($byKey['provenance']['content'])->toContain('study_diagnostics=overridden');
+});
+
+it('withholds effect estimates when the study-diagnostics gate has not cleared', function () {
+    $user = User::factory()->create();
+    $study = clioManuscriptStudy($user, GateStatus::Failed->value);
+
+    $doc = app(ManuscriptComposer::class)->compose($study);
+    $results = collect($doc['sections'])->firstWhere('key', 'results')['content'];
+
+    expect($results)->toContain('withheld')
+        ->and($results)->not->toContain('1.47')
+        ->and($doc['manuscript_meta']['effect_estimates_included'])->toBeFalse();
+});
+
+it('reports diagnostics-only when no estimation has completed', function () {
+    $user = User::factory()->create();
+    $study = Study::create(['title' => 'Empty study', 'created_by' => $user->id, 'status' => 'draft']);
+
+    $doc = app(ManuscriptComposer::class)->compose($study);
+    $results = collect($doc['sections'])->firstWhere('key', 'results')['content'];
+
+    expect($results)->toContain('No population-level estimation')
+        ->and($doc['manuscript_meta']['effect_estimates_included'])->toBeFalse();
+});


### PR DESCRIPTION
The final Clio phase — assembles a publication-ready manuscript from a study's **actual** data, closing the protocol→document loop and replacing the hand-written report the Hypertension v3 study required.

## What
- **`ManuscriptComposer`** — deterministic, fabrication-free assembly of Methods / Results / Limitations / Provenance from the study's calibrated estimation results, gate ledger, and content hashes. Output shape matches `PublicationService::export` (flows straight to docx/pdf).
  - **Gate-aware Results**: calibrated effect estimates appear ONLY when the study-diagnostics gate clears (passed/approved/overridden) — the same blinding the live API enforces. Otherwise diagnostics-only.
  - **Limitations** reproduce each gate override rationale verbatim.
  - **Provenance appendix**: definition hashes, vocabulary/CDM versions, and the gate-ledger decision trail.
- **`StudyManuscriptController`** — `compose` (JSON) + `export` (docx/pdf) under `studies/{study}/manuscript`.

## Verification
3 feature tests — calibrated+override path, blinded-withheld path, no-estimation path — plus Pint and PHPStan L8, all green.

## Follow-up
A frontend "Generate manuscript" action and optional per-section AI prose enrichment over the existing narrative endpoint.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)