### PR TITLE
docs: fix API health URL in CLAUDE.md (api/v1/health → api/health)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -286,7 +286,7 @@ Services: php, nginx, postgres, redis, python-ai, r-runtime, solr, chromadb, qdr
 
 - App: http://localhost:8082
 - Vite dev server: http://localhost:5175
-- API health: http://localhost:8082/api/v1/health
+- API health: http://localhost:8082/api/health
 - AI service: http://localhost:8002
 - Solr admin: http://localhost:8983
 - Horizon dashboard: http://localhost:8082/horizon


### PR DESCRIPTION
Re-do of the closed #362 (its branch was deleted before merge). One-line docs fix: the dev health URL in `.claude/CLAUDE.md` was `api/v1/health` (404s); the real comprehensive endpoint is `GET /api/health` (`Api\V1\HealthController@index`).