### PR TITLE
feat(agents): admin-switchable copilot provider (cloud ↔ local)

### DIFF
--- a/ai/app/agents/service.py
+++ b/ai/app/agents/service.py
@@ -59,6 +59,9 @@ class AgentSessionState:
     tool_context: AgentToolContext
     anthropic_session_id: Optional[str] = None
     last_idempotency_key: Optional[str] = None
+    # Runtime provider override from Laravel (agents.provider_mode): authoritative
+    # over the AGENT_PROVIDER env default. None = use env/profile default.
+    provider_override: Optional[str] = None
     # pending approval futures: keyed by tool_use_id, set by resolve_approval()
     _pending: dict = field(default_factory=dict, repr=False)
 
@@ -192,7 +195,7 @@ class ParthenonAgentService:
         # approval-gated WRITE tools are withdrawn entirely so CE runs reads/chat
         # only — operators opt into actions once their local model proves it can
         # drive the tool-use + approval loop reliably.
-        resolved = settings.resolve_agent_provider(profile.provider)
+        resolved = settings.resolve_agent_provider(profile.provider, state.provider_override)
         if resolved.provider == "local" and not resolved.actions_enabled:
             writes = set()
 

--- a/ai/app/config.py
+++ b/ai/app/config.py
@@ -170,16 +170,23 @@ class Settings(BaseSettings):
     def phenotype_llm_base_url(self) -> str:
         return self.phenotype_interpreter_base_url or self.ollama_base_url
 
-    def resolve_agent_provider(self, profile_provider: str | None = None) -> ResolvedAgentProvider:
+    def resolve_agent_provider(
+        self,
+        profile_provider: str | None = None,
+        request_provider: str | None = None,
+    ) -> ResolvedAgentProvider:
         """Resolve the effective provider for an agent turn.
 
-        ``profile_provider`` lets a profile force a provider; ``None`` inherits
-        the global ``agent_provider``. For the local provider, returns the local
-        model/effort and the proxy transport, and whether write tools are enabled.
-        Anthropic returns the cloud model with no transport override (the CLI uses
-        its built-in endpoint + ANTHROPIC_API_KEY).
+        Precedence: ``request_provider`` (Laravel's runtime agents.provider_mode
+        decision, authoritative) > ``profile_provider`` (a profile forcing one) >
+        the global ``agent_provider`` env default. For the local provider, returns
+        the local model/effort and the proxy transport, and whether write tools are
+        enabled. Anthropic returns the cloud model with no transport override (the
+        CLI uses its built-in endpoint + ANTHROPIC_API_KEY).
         """
-        provider = (profile_provider or self.agent_provider or "anthropic").lower()
+        provider = (
+            request_provider or profile_provider or self.agent_provider or "anthropic"
+        ).lower()
         if provider == "local":
             return ResolvedAgentProvider(
                 provider="local",

--- a/ai/app/routers/agent.py
+++ b/ai/app/routers/agent.py
@@ -38,6 +38,9 @@ class CreateSessionRequest(BaseModel):
     ingest_path: str
     scoped_token: str
     context: dict = Field(default_factory=dict)
+    # Runtime provider override from Laravel (agents.provider_mode): "anthropic"
+    # or "local". None = use python-ai's AGENT_PROVIDER env default.
+    provider: str | None = None
 
 
 class TurnRequest(BaseModel):
@@ -55,12 +58,14 @@ async def create_session(body: CreateSessionRequest) -> dict:
         channel=body.channel,
         ingest_path=body.ingest_path,
         tool_context=ctx,
+        provider_override=body.provider,
     )
     registry.put(state)
     # Surface the effective provider + whether approval-gated WRITE actions are
     # available, so the UI can hide action affordances on a reads-only CE
-    # deployment (local provider with actions disabled).
-    resolved = settings.resolve_agent_provider(get_profile(body.profile).provider)
+    # deployment (local provider with actions disabled). body.provider (Laravel's
+    # agents.provider_mode) is authoritative over the env default.
+    resolved = settings.resolve_agent_provider(get_profile(body.profile).provider, body.provider)
     return {
         "agent_session_id": body.agent_session_id,
         "channel": body.channel,

--- a/ai/tests/test_agent_router.py
+++ b/ai/tests/test_agent_router.py
@@ -69,6 +69,23 @@ def test_create_session_reports_local_reads_only(monkeypatch):
     assert body["actions_enabled"] is False
 
 
+def test_create_session_request_provider_overrides_env():
+    """Laravel's agents.provider_mode (body.provider) is authoritative over the
+    AGENT_PROVIDER env default — env stays anthropic but the request forces local."""
+    from app.agents import registry as reg
+    create = client.post(
+        "/agent/sessions",
+        json={**_CREATE_BODY, "agent_session_id": 313, "provider": "local"},
+    )
+    assert create.status_code == 200
+    body = create.json()
+    assert body["provider"] == "local"
+    # The override is recorded on the session state for the turn's _options().
+    state = reg.get(313)
+    assert state is not None
+    assert state.provider_override == "local"
+
+
 def test_create_session_stores_context_on_tool_context(monkeypatch):
     from app.agents import registry as reg
 

--- a/ai/tests/test_agent_service.py
+++ b/ai/tests/test_agent_service.py
@@ -517,3 +517,19 @@ async def test_options_local_actions_disabled_withdraws_writes(monkeypatch):
     assert opts.permission_mode == "dontAsk"
     assert opts.can_use_tool is None
     assert opts.env["ANTHROPIC_BASE_URL"] == cfg.settings.agent_local_base_url
+
+
+async def test_options_request_provider_override_beats_env(monkeypatch):
+    """A per-session provider override (Laravel's agents.provider_mode) wins over
+    the AGENT_PROVIDER env: env stays anthropic but the session forces local."""
+    import app.config as cfg
+    # env default stays anthropic (do NOT touch cfg.settings.agent_provider)
+    assert cfg.settings.agent_provider == "anthropic"
+
+    state = _publish_state()
+    state.provider_override = "local"
+
+    opts = ParthenonAgentService(publisher=MagicMock())._options(state)
+
+    assert opts.model == cfg.settings.agent_local_model
+    assert opts.env["ANTHROPIC_BASE_URL"] == cfg.settings.agent_local_base_url

--- a/backend/app/Http/Controllers/Api/V1/AbbyAgentController.php
+++ b/backend/app/Http/Controllers/Api/V1/AbbyAgentController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\App\AgentSession;
 use App\Models\App\Study;
 use App\Models\User;
+use App\Services\Agents\AgentProviderResolver;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
@@ -89,6 +90,10 @@ class AbbyAgentController extends Controller
             'channel' => $channel,
             'ingest_path' => "/api/v1/studies/{$study->slug}/agent/sessions/{$agentSession->id}/ingest",
             'scoped_token' => $newToken->plainTextToken,
+            // Runtime provider override from the super-admin's agents.provider_mode
+            // (cloud=Anthropic / local=claude-router proxy). python-ai treats this
+            // as authoritative over its AGENT_PROVIDER env default.
+            'provider' => (new AgentProviderResolver)->resolveProvider(),
             'context' => [
                 'study_slug' => $study->slug,
                 'study_id' => $study->id,

--- a/backend/app/Http/Controllers/Api/V1/Admin/AgentSettingsController.php
+++ b/backend/app/Http/Controllers/Api/V1/Admin/AgentSettingsController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\Api\V1\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\App\AiProviderSetting;
 use App\Models\App\SystemSetting;
+use App\Services\Agents\AgentProviderResolver;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -39,15 +40,33 @@ class AgentSettingsController extends Controller
      */
     public function update(Request $request): JsonResponse
     {
-        $request->validate([
-            'enabled' => ['required', 'boolean'],
+        $validated = $request->validate([
+            'enabled' => ['required_without:provider_mode', 'boolean'],
+            'provider_mode' => [
+                'required_without:enabled',
+                'in:'.implode(',', [
+                    AgentProviderResolver::MODE_CLOUD,
+                    AgentProviderResolver::MODE_LOCAL,
+                    AgentProviderResolver::MODE_AUTO,
+                ]),
+            ],
         ]);
 
-        SystemSetting::setValue(
-            'agents.enabled',
-            $request->boolean('enabled') ? '1' : '0',
-            'agents',
-        );
+        if (array_key_exists('enabled', $validated)) {
+            SystemSetting::setValue(
+                'agents.enabled',
+                $request->boolean('enabled') ? '1' : '0',
+                'agents',
+            );
+        }
+
+        if (array_key_exists('provider_mode', $validated)) {
+            SystemSetting::setValue(
+                'agents.provider_mode',
+                $validated['provider_mode'],
+                'agents',
+            );
+        }
 
         return response()->json($this->payload());
     }
@@ -62,7 +81,12 @@ class AgentSettingsController extends Controller
      * fresh installs that set the key in .env before seeding still report
      * ready=true.
      *
-     * @return array{enabled: bool, anthropic_ready: bool}
+     * `provider_mode` is which provider the action-taking copilots use
+     * (cloud=Anthropic / local=claude-router proxy / auto=follow active).
+     * `local_ready` is true when a proxy-frontable local provider (ollama) is
+     * the active, enabled one — the prerequisite for local/auto to run locally.
+     *
+     * @return array{enabled: bool, anthropic_ready: bool, provider_mode: string, local_ready: bool}
      */
     private function payload(): array
     {
@@ -77,9 +101,13 @@ class AgentSettingsController extends Controller
             $anthropicReady = (bool) env('ANTHROPIC_API_KEY');
         }
 
+        $resolver = new AgentProviderResolver;
+
         return [
             'enabled' => $enabled,
             'anthropic_ready' => $anthropicReady,
+            'provider_mode' => $resolver->mode(),
+            'local_ready' => $resolver->activeProviderIsLocal(),
         ];
     }
 }

--- a/backend/app/Http/Controllers/Api/V1/PublishAgentController.php
+++ b/backend/app/Http/Controllers/Api/V1/PublishAgentController.php
@@ -7,6 +7,7 @@ use App\Models\App\AgentSession;
 use App\Models\App\PublicationDraft;
 use App\Models\User;
 use App\Policies\PublicationDraftPolicy;
+use App\Services\Agents\AgentProviderResolver;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
@@ -76,6 +77,8 @@ class PublishAgentController extends Controller
             'channel' => $channel,
             'ingest_path' => "/api/v1/publish/drafts/{$draft->id}/agent/sessions/{$agentSession->id}/ingest",
             'scoped_token' => $newToken->plainTextToken,
+            // Runtime provider override from agents.provider_mode (cloud/local/auto).
+            'provider' => (new AgentProviderResolver)->resolveProvider(),
             'context' => [
                 'draft_id' => $draft->id,
                 'study_id' => $draft->study_id,

--- a/backend/app/Http/Controllers/Api/V1/StudyDesignAgentController.php
+++ b/backend/app/Http/Controllers/Api/V1/StudyDesignAgentController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\App\AgentSession;
 use App\Models\App\Study;
 use App\Models\App\StudyDesignSession;
+use App\Services\Agents\AgentProviderResolver;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
@@ -70,6 +71,8 @@ class StudyDesignAgentController extends Controller
             'channel' => $channel,
             'ingest_path' => "/api/v1/studies/{$study->slug}/design-sessions/{$session->id}/agent/sessions/{$agentSession->id}/ingest",
             'scoped_token' => $newToken->plainTextToken,
+            // Runtime provider override from agents.provider_mode (cloud/local/auto).
+            'provider' => (new AgentProviderResolver)->resolveProvider(),
             'context' => [
                 'study_slug' => $study->slug,
                 'design_session_id' => $session->id,

--- a/backend/app/Services/Agents/AgentProviderResolver.php
+++ b/backend/app/Services/Agents/AgentProviderResolver.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Agents;
+
+use App\Models\App\AiProviderSetting;
+use App\Models\App\SystemSetting;
+
+/**
+ * Resolves which provider the action-taking Claude Agent SDK copilots
+ * (Studies / Publish / Abby orchestrator) should use, from the super-admin's
+ * runtime setting. Laravel is authoritative; python-ai treats the value it
+ * sends as an override of its own AGENT_PROVIDER env default.
+ *
+ * Modes (system_settings key `agents.provider_mode`):
+ *   - cloud (default) — Anthropic cloud (Claude). Preserves EE behavior.
+ *   - local           — the local model via the claude-router proxy.
+ *   - auto            — local IF the active AI provider is a proxy-frontable
+ *                       local type (ollama) AND enabled; otherwise cloud.
+ *
+ * Default is `cloud` deliberately: the AiProviderSeeder makes `ollama` the
+ * ACTIVE provider for the chat/RAG path, so an `auto`-by-default would flip the
+ * copilots to a proxy that may not be running and break a cloud deployment.
+ */
+class AgentProviderResolver
+{
+    public const MODE_CLOUD = 'cloud';
+
+    public const MODE_LOCAL = 'local';
+
+    public const MODE_AUTO = 'auto';
+
+    public const PROVIDER_ANTHROPIC = 'anthropic';
+
+    public const PROVIDER_LOCAL = 'local';
+
+    /**
+     * Provider types the claude-router proxy can front for the copilots. The
+     * proxy speaks the Anthropic Messages API and forwards to Ollama, so only
+     * `ollama` qualifies — other cloud providers (openai, gemini, ...) are not
+     * reachable through it and fall back to the Anthropic copilot path.
+     *
+     * @var list<string>
+     */
+    private const LOCAL_PROVIDER_TYPES = ['ollama'];
+
+    /**
+     * The provider override to send to python-ai: 'anthropic' or 'local'.
+     */
+    public function resolveProvider(): string
+    {
+        return match ($this->mode()) {
+            self::MODE_LOCAL => self::PROVIDER_LOCAL,
+            self::MODE_AUTO => $this->activeProviderIsLocal()
+                ? self::PROVIDER_LOCAL
+                : self::PROVIDER_ANTHROPIC,
+            default => self::PROVIDER_ANTHROPIC,
+        };
+    }
+
+    /**
+     * Current provider mode, normalized to a known value (unknown → cloud).
+     */
+    public function mode(): string
+    {
+        $mode = (string) SystemSetting::getValue('agents.provider_mode', self::MODE_CLOUD);
+
+        return in_array($mode, [self::MODE_CLOUD, self::MODE_LOCAL, self::MODE_AUTO], true)
+            ? $mode
+            : self::MODE_CLOUD;
+    }
+
+    /**
+     * Whether a proxy-frontable local provider is the active, enabled one —
+     * used by `auto` and surfaced to the admin UI as readiness for local mode.
+     */
+    public function activeProviderIsLocal(): bool
+    {
+        return AiProviderSetting::query()
+            ->where('is_active', true)
+            ->where('is_enabled', true)
+            ->whereIn('provider_type', self::LOCAL_PROVIDER_TYPES)
+            ->exists();
+    }
+}

--- a/backend/tests/Feature/Api/V1/Admin/AgentSettingsControllerTest.php
+++ b/backend/tests/Feature/Api/V1/Admin/AgentSettingsControllerTest.php
@@ -113,4 +113,46 @@ class AgentSettingsControllerTest extends TestCase
 
         $this->putJson('/api/v1/admin/ai-agents', [])->assertUnprocessable();
     }
+
+    // ── Copilot provider mode ─────────────────────────────────────────────────
+
+    public function test_get_reports_provider_mode_default_cloud(): void
+    {
+        $super = User::factory()->create();
+        $super->assignRole('super-admin');
+        Sanctum::actingAs($super);
+
+        $this->getJson('/api/v1/admin/ai-agents')
+            ->assertOk()
+            ->assertJsonStructure(['enabled', 'anthropic_ready', 'provider_mode', 'local_ready'])
+            ->assertJsonPath('provider_mode', 'cloud')
+            ->assertJsonPath('local_ready', false);
+    }
+
+    public function test_put_provider_mode_persists_without_enabled(): void
+    {
+        $super = User::factory()->create();
+        $super->assignRole('super-admin');
+        Sanctum::actingAs($super);
+
+        $this->putJson('/api/v1/admin/ai-agents', ['provider_mode' => 'local'])
+            ->assertOk()
+            ->assertJsonPath('provider_mode', 'local');
+
+        $this->assertSame('local', SystemSetting::getValue('agents.provider_mode'));
+
+        $this->getJson('/api/v1/admin/ai-agents')
+            ->assertOk()
+            ->assertJsonPath('provider_mode', 'local');
+    }
+
+    public function test_put_invalid_provider_mode_returns_422(): void
+    {
+        $super = User::factory()->create();
+        $super->assignRole('super-admin');
+        Sanctum::actingAs($super);
+
+        $this->putJson('/api/v1/admin/ai-agents', ['provider_mode' => 'gpt'])
+            ->assertUnprocessable();
+    }
 }

--- a/backend/tests/Feature/Services/Agents/AgentProviderResolverTest.php
+++ b/backend/tests/Feature/Services/Agents/AgentProviderResolverTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services\Agents;
+
+use App\Models\App\AiProviderSetting;
+use App\Models\App\SystemSetting;
+use App\Services\Agents\AgentProviderResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AgentProviderResolverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setMode(string $mode): void
+    {
+        SystemSetting::setValue('agents.provider_mode', $mode, 'agents');
+    }
+
+    private function seedProvider(string $type, bool $active, bool $enabled): void
+    {
+        AiProviderSetting::create([
+            'provider_type' => $type,
+            'display_name' => ucfirst($type),
+            'is_active' => $active,
+            'is_enabled' => $enabled,
+            'model' => 'x',
+            'settings' => [],
+        ]);
+    }
+
+    public function test_defaults_to_anthropic_when_unset(): void
+    {
+        $this->assertSame('anthropic', (new AgentProviderResolver)->resolveProvider());
+        $this->assertSame('cloud', (new AgentProviderResolver)->mode());
+    }
+
+    public function test_cloud_mode_resolves_anthropic(): void
+    {
+        $this->setMode('cloud');
+        $this->assertSame('anthropic', (new AgentProviderResolver)->resolveProvider());
+    }
+
+    public function test_local_mode_resolves_local(): void
+    {
+        $this->setMode('local');
+        $this->assertSame('local', (new AgentProviderResolver)->resolveProvider());
+    }
+
+    public function test_auto_mode_resolves_local_when_ollama_is_active_and_enabled(): void
+    {
+        $this->setMode('auto');
+        $this->seedProvider('ollama', active: true, enabled: true);
+
+        $resolver = new AgentProviderResolver;
+        $this->assertTrue($resolver->activeProviderIsLocal());
+        $this->assertSame('local', $resolver->resolveProvider());
+    }
+
+    public function test_auto_mode_resolves_anthropic_when_active_is_cloud(): void
+    {
+        $this->setMode('auto');
+        $this->seedProvider('anthropic', active: true, enabled: true);
+
+        $this->assertSame('anthropic', (new AgentProviderResolver)->resolveProvider());
+    }
+
+    public function test_auto_mode_ignores_inactive_or_disabled_local_provider(): void
+    {
+        $this->setMode('auto');
+        // Ollama present but DISABLED — must not count as a local target.
+        $this->seedProvider('ollama', active: true, enabled: false);
+
+        $this->assertFalse((new AgentProviderResolver)->activeProviderIsLocal());
+        $this->assertSame('anthropic', (new AgentProviderResolver)->resolveProvider());
+    }
+
+    public function test_unknown_mode_normalizes_to_cloud(): void
+    {
+        $this->setMode('weird-value');
+        $resolver = new AgentProviderResolver;
+        $this->assertSame('cloud', $resolver->mode());
+        $this->assertSame('anthropic', $resolver->resolveProvider());
+    }
+}

--- a/backend/tests/Feature/Studies/AbbyAgentControllerTest.php
+++ b/backend/tests/Feature/Studies/AbbyAgentControllerTest.php
@@ -31,6 +31,7 @@ it('starts a abby agent session for a study collaborator and calls the AI harnes
 
     Http::assertSent(fn ($req) => str_contains($req->url(), '/agent/sessions')
         && $req['profile'] === 'abby'
+        && $req['provider'] === 'anthropic'  // default provider_mode=cloud
         && $req['context']['study_slug'] === $study->slug);
 });
 

--- a/docs/lineage/modules/abby-ai/admin-copilot-provider-switch.md
+++ b/docs/lineage/modules/abby-ai/admin-copilot-provider-switch.md
@@ -1,0 +1,73 @@
+# Admin-switchable copilot provider (cloud ↔ local)
+
+**Date:** 2026-06-15
+**Builds on:** `local-model-agent-backend-ce` (the env-driven EE/CE provider switch)
+**Related:** `project_parthenon_agent_copilots`
+
+## Why
+
+The previous change made the action-taking Claude Agent SDK copilots
+(Studies/Publish/Abby) able to run on a local model, but only via the
+`AGENT_PROVIDER` **env** var — switching required editing `.env` and recreating
+`python-ai`. Parthenon already has an **Admin → AI Providers** page that lets a
+super-admin pick the active provider (anthropic/ollama/...) for the *chat/RAG*
+path. This wires that same admin surface to the **copilots**, so the provider can
+be switched at runtime with no redeploy.
+
+Key gap closed: `python-ai` never read `ai_provider_settings`; the copilots only
+listened to env. Now **Laravel is authoritative** and passes a per-session
+provider override into the session-create call.
+
+## Design
+
+A new system setting `agents.provider_mode` (super-admin controlled):
+
+- `cloud` (**default**) — copilots use Anthropic (Claude). Preserves EE.
+- `local` — copilots use the local model via the claude-router proxy.
+- `auto` — local IF the active `ai_provider_settings` row is a proxy-frontable
+  local type (`ollama`) AND enabled; otherwise cloud.
+
+**Default is `cloud` deliberately:** the `AiProviderSeeder` makes `ollama` the
+*active* provider for chat, so an `auto`-by-default would flip the copilots to a
+proxy that may not be running and break a cloud deployment.
+
+Precedence in `python-ai`: **request override (Laravel) > profile provider > env
+default**. Model/transport/actions for the local path still come from `python-ai`
+env (the proxy is deployment config); Laravel only decides *which provider*.
+
+## What changed
+
+| Layer | File | Change |
+|---|---|---|
+| Resolver | `backend/app/Services/Agents/AgentProviderResolver.php` | maps `agents.provider_mode` (+ active provider) → `anthropic`\|`local` |
+| Admin API | `AgentSettingsController` | show returns `provider_mode`+`local_ready`; update accepts `provider_mode` (cloud/local/auto), `required_without` enabled |
+| Controllers | `AbbyAgentController`, `StudyDesignAgentController`, `PublishAgentController` | pass `provider => resolver->resolveProvider()` into the `/agent/sessions` payload |
+| python-ai | `routers/agent.py`, `agents/service.py`, `config.py` | `CreateSessionRequest.provider`; `AgentSessionState.provider_override`; `resolve_agent_provider(profile, request)` — request wins |
+| Frontend | `adminApi.ts`, `useAiProviders.ts`, `AiProvidersPage.tsx` | `provider_mode`/`local_ready` types, `useSetAgentProviderMode`, a Cloud/Local/Auto segmented selector in the AI Agents card with a "no local provider active" warning |
+
+## Behavior
+
+- Admin → AI Providers → **AI Agents** card now has a **Copilot provider**
+  selector (Cloud / Local / Auto) below the enable toggle.
+- Switching to **Local** (or Auto with an active Ollama provider) makes every
+  *new* copilot session run on the local proxy — no redeploy. Existing env
+  (`AGENT_PROVIDER`) remains the fallback when Laravel sends nothing.
+- EE default is unchanged: `provider_mode=cloud` → `anthropic`.
+
+## Caveat (unchanged from the env-switch work)
+
+The copilots speak the Anthropic Messages API, so "local" routes through the
+**claude-router** proxy (which fronts Ollama), not raw `:11434`. The proxy must
+be running (`docker compose --profile ce up -d claude-router`) and serving the
+configured local model. The selector shows a warning when local/auto is chosen
+but no local provider is active. The specific local model + actions-enabled
+remain deployment config (`AGENT_LOCAL_*`), not per-row admin settings.
+
+## Verification
+
+- PHP: `AgentProviderResolverTest` (7) + `AgentSettingsControllerTest` (11, incl.
+  provider_mode) + `AbbyAgentControllerTest` (5) → **23 passed**; Pint + PHPStan clean.
+- Python: `test_agent_router` + `test_agent_service` + `test_agent_config` →
+  **28 passed** (incl. request-override-beats-env); mypy clean.
+- Frontend: `AiAgentsToggle.test.tsx` → **8 passed** (incl. selector PUT +
+  not-ready warning); tsc + vite build clean.

--- a/frontend/src/features/administration/__tests__/AiAgentsToggle.test.tsx
+++ b/frontend/src/features/administration/__tests__/AiAgentsToggle.test.tsx
@@ -221,4 +221,59 @@ describe("AI Agents toggle card", () => {
     const body = JSON.parse(putHistory[0]?.data as string) as { enabled: boolean };
     expect(body.enabled).toBe(false);
   });
+
+  it("renders the copilot provider-mode selector and PUTs provider_mode on click", async () => {
+    mock.onGet("/api/v1/admin/ai-agents").reply(200, {
+      enabled: true,
+      anthropic_ready: true,
+      provider_mode: "cloud",
+      local_ready: false,
+    });
+    mock.onPut("/api/v1/admin/ai-agents").reply(200, {
+      enabled: true,
+      anthropic_ready: true,
+      provider_mode: "local",
+      local_ready: false,
+    });
+
+    const client = makeClient();
+    render(
+      <Wrapper client={client}>
+        <AiProvidersPage />
+      </Wrapper>,
+    );
+
+    // Selector only renders when agents are enabled.
+    const localBtn = await waitFor(() => screen.getByTestId("copilot-mode-local"));
+    fireEvent.click(localBtn);
+
+    await waitFor(() => {
+      const putHistory = mock.history["put"] ?? [];
+      expect(putHistory.length).toBeGreaterThan(0);
+    });
+
+    const putHistory = mock.history["put"] ?? [];
+    const body = JSON.parse(putHistory[0]?.data as string) as { provider_mode: string };
+    expect(body.provider_mode).toBe("local");
+  });
+
+  it("warns when local/auto mode is selected but no local provider is ready", async () => {
+    mock.onGet("/api/v1/admin/ai-agents").reply(200, {
+      enabled: true,
+      anthropic_ready: true,
+      provider_mode: "local",
+      local_ready: false,
+    });
+
+    const client = makeClient();
+    render(
+      <Wrapper client={client}>
+        <AiProvidersPage />
+      </Wrapper>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/No local provider is active/i)).toBeInTheDocument(),
+    );
+  });
 });

--- a/frontend/src/features/administration/api/adminApi.ts
+++ b/frontend/src/features/administration/api/adminApi.ts
@@ -131,9 +131,17 @@ export const testAiProvider = (type: string) =>
 
 // ── AI Agents Feature Flag ────────────────────────────────────────────────────
 
+export type AgentProviderMode = "cloud" | "local" | "auto";
+
 export interface AgentSettings {
   enabled: boolean;
   anthropic_ready: boolean;
+  // Which provider the action-taking copilots use: cloud=Anthropic,
+  // local=claude-router proxy, auto=follow the active AI provider.
+  provider_mode: AgentProviderMode;
+  // True when a proxy-frontable local provider (ollama) is the active, enabled
+  // one — the prerequisite for local/auto to actually run locally.
+  local_ready: boolean;
 }
 
 export const fetchAgentSettings = (): Promise<AgentSettings> =>
@@ -141,6 +149,9 @@ export const fetchAgentSettings = (): Promise<AgentSettings> =>
 
 export const setAgentSettings = (enabled: boolean): Promise<AgentSettings> =>
   apiClient.put<AgentSettings>("/admin/ai-agents", { enabled }).then((r) => r.data);
+
+export const setAgentProviderMode = (provider_mode: AgentProviderMode): Promise<AgentSettings> =>
+  apiClient.put<AgentSettings>("/admin/ai-agents", { provider_mode }).then((r) => r.data);
 
 // ── System Health ─────────────────────────────────────────────────────────────
 

--- a/frontend/src/features/administration/hooks/useAiProviders.ts
+++ b/frontend/src/features/administration/hooks/useAiProviders.ts
@@ -10,12 +10,14 @@ import {
   fetchLiveKitConfig,
   fetchServiceDetail,
   fetchSystemHealth,
+  setAgentProviderMode,
   setAgentSettings,
   testAiProvider,
   testLiveKitConnection,
   updateAiProvider,
   updateLiveKitConfig,
 } from "../api/adminApi";
+import type { AgentProviderMode } from "../api/adminApi";
 
 // Feature-flags query key — must match the key used in useFeatureFlagsQuery
 // (frontend/src/features/system/api.ts) so invalidation refreshes useFlag().
@@ -140,6 +142,17 @@ export function useSetAgentSettings() {
       // app-wide. FlagsLoader calls useFeatureFlagsQuery which uses this key;
       // the refetch re-runs setFlags() on the store, updating every subscriber.
       void qc.invalidateQueries({ queryKey: [...FEATURE_FLAGS_KEY] });
+    },
+  });
+}
+
+export function useSetAgentProviderMode() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: (mode: AgentProviderMode) => setAgentProviderMode(mode),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: [AGENT_SETTINGS_KEY] });
     },
   });
 }

--- a/frontend/src/features/administration/pages/AiProvidersPage.tsx
+++ b/frontend/src/features/administration/pages/AiProvidersPage.tsx
@@ -8,11 +8,13 @@ import {
   useActivateAiProvider,
   useAgentSettings,
   useAiProviders,
+  useSetAgentProviderMode,
   useSetAgentSettings,
   useTestAiProvider,
   useToggleAiProvider,
   useUpdateAiProvider,
 } from "../hooks/useAiProviders";
+import type { AgentProviderMode } from "../api/adminApi";
 
 // ── Provider metadata ─────────────────────────────────────────────────────────
 
@@ -89,9 +91,30 @@ function AgentsToggleCard() {
   const { t } = useTranslation("app");
   const { data, isLoading } = useAgentSettings();
   const setAgents = useSetAgentSettings();
+  const setProviderMode = useSetAgentProviderMode();
 
   const enabled = data?.enabled ?? false;
   const anthropicReady = data?.anthropic_ready ?? false;
+  const providerMode: AgentProviderMode = data?.provider_mode ?? "cloud";
+  const localReady = data?.local_ready ?? false;
+
+  const modeOptions: Array<{ value: AgentProviderMode; label: string; hint: string }> = [
+    {
+      value: "cloud",
+      label: t("admin.agents.mode.cloud", "Cloud (Claude)"),
+      hint: t("admin.agents.mode.cloudHint", "Copilots run on the Anthropic API."),
+    },
+    {
+      value: "local",
+      label: t("admin.agents.mode.local", "Local model"),
+      hint: t("admin.agents.mode.localHint", "Copilots run on the local model via the claude-router proxy."),
+    },
+    {
+      value: "auto",
+      label: t("admin.agents.mode.auto", "Auto"),
+      hint: t("admin.agents.mode.autoHint", "Local when a local provider is active, otherwise Cloud."),
+    },
+  ];
 
   return (
     <Panel>
@@ -145,6 +168,55 @@ function AgentsToggleCard() {
 
         {setAgents.isPending && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
       </div>
+
+      {/* Copilot provider mode — which backend the action-taking copilots use. */}
+      {enabled && (
+        <div className="mt-4 border-t border-border pt-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                {t("admin.agents.mode.title", "Copilot provider")}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {modeOptions.find((m) => m.value === providerMode)?.hint}
+              </p>
+            </div>
+            <div
+              className="inline-flex rounded-md border border-border bg-muted p-0.5"
+              role="group"
+              aria-label={t("admin.agents.mode.title", "Copilot provider")}
+            >
+              {modeOptions.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  data-testid={`copilot-mode-${opt.value}`}
+                  disabled={isLoading || setProviderMode.isPending || providerMode === opt.value}
+                  onClick={() => setProviderMode.mutate(opt.value)}
+                  className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
+                    providerMode === opt.value
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          {(providerMode === "local" || providerMode === "auto") && !localReady && (
+            <p className="mt-2 text-xs text-amber-500">
+              {t(
+                "admin.agents.mode.localNotReady",
+                "No local provider is active — set an Ollama provider as Active below, and ensure the claude-router sidecar is running.",
+              )}
+            </p>
+          )}
+          {setProviderMode.isPending && (
+            <Loader2 className="mt-2 h-4 w-4 animate-spin text-muted-foreground" />
+          )}
+        </div>
+      )}
     </Panel>
   );
 }


### PR DESCRIPTION
Stacked on #365. Makes the **Admin → AI Providers** page switch the action-taking copilots between cloud (Claude) and a local model — at runtime, no redeploy.

## Why
#365 made the copilots able to run on a local model, but only via the `AGENT_PROVIDER` **env** (edit `.env` + recreate `python-ai`). The Admin → AI Providers page already picks the active provider for the *chat/RAG* path; `python-ai`'s copilots never read `ai_provider_settings`. This wires Laravel as authoritative and passes a per-session provider override into the session-create call.

## What
- New system setting **`agents.provider_mode`**: `cloud` (default) | `local` | `auto`.
  - `cloud` → Anthropic (preserves EE) · `local` → local via claude-router proxy · `auto` → local iff the active `ai_provider_settings` row is an enabled `ollama`, else cloud.
- `AgentProviderResolver` maps mode (+ active provider) → `anthropic`|`local`.
- The 3 copilot controllers (Abby/StudyDesign/Publish) pass `provider` into `/agent/sessions`.
- `python-ai`: `CreateSessionRequest.provider` + `AgentSessionState.provider_override`; resolve precedence **request > profile > env**.
- `AgentSettingsController` show/update manage `provider_mode` (+ `local_ready`).
- AI Agents admin card gets a **Cloud / Local / Auto** selector + a "no local provider active" warning.

**Default is `cloud` deliberately** — the seeder makes `ollama` the *active chat* provider, so `auto`-by-default would flip copilots to a possibly-absent proxy. The specific local model + actions stay deployment config (`AGENT_LOCAL_*`); the admin picks only the provider.

## Verification
PHP **23** (resolver 7 / settings 11 / abby 5) + Pint + PHPStan · Python **28** + mypy · frontend **8** + tsc + vite build. All green.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)