### PR TITLE
feat(studies): surface Hypertension v5 results in the frontend

### DIFF
--- a/backend/app/Console/Commands/SeedHtnV5Fixture.php
+++ b/backend/app/Console/Commands/SeedHtnV5Fixture.php
@@ -1,0 +1,588 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Concerns\SourceAware;
+use App\Context\SourceContext;
+use App\Models\App\Source;
+use App\Models\App\Study;
+use App\Models\App\StudyAnalysis;
+use App\Models\App\StudyResult;
+use Illuminate\Console\Command;
+use Illuminate\Database\Connection;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seeds a representative, clearly-labelled demonstration fixture for the
+ * Hypertension Outcomes Program **v5** so the frontend surfacing layer
+ * (per-analysis renderers + the v5 Report tab) has data to display.
+ *
+ * The full v5 executor (analyses M–R + triangulation from CLAUDE_PROMPT_v5.md)
+ * has not been run — study 165 currently carries only its four v4 results.
+ * Rather than block the frontend on a multi-hour causal-inference run, this
+ * command populates the two physical surfaces the frontend reads:
+ *
+ *   1. app.study_results — one curated row per v5 analysis (O, P, R, M, N, Q,
+ *      triangulation) with a compact, chart-ready summary_data payload.
+ *   2. results.htn_v4_* — the long-form tables behind the "view full matrix"
+ *      drawers and CSV exports (comorbidity matrix, BP distribution, phenotype
+ *      grid, IV tertile balance, triangulation).
+ *
+ * Every row is flagged `_fixture: true` and carries `_provenance` so the UI can
+ * render an explicit "demonstration data" banner. The numbers are grounded in
+ * the real v4 baseline facts recorded in CHANGELOG_v4_to_v5.md (T = 109,763;
+ * never-diagnosed ≈ 90%; latency_b ≈ 1,106 d; CKD HR ≈ 2.60; 37.9% encounter
+ * coverage) so the demonstration is realistic — but it is NOT a real v5 result
+ * and must never be presented as one.
+ *
+ * Idempotent: re-running replaces its own fixture rows and truncates the
+ * fixture tables. Additive only — it writes to app.* and results.* and never
+ * touches CDM (omop / vocab) data.
+ */
+class SeedHtnV5Fixture extends Command
+{
+    use SourceAware;
+
+    protected $signature = 'study:seed-htn-v5-fixture
+        {--study=165 : Study id to attach the v5 fixture to}
+        {--source=ACUMENUS : Source key whose results schema holds the long-form tables}
+        {--dry-run : Report what would be written without persisting}
+        {--force : Skip the confirmation prompt}';
+
+    protected $description = 'Seed a representative (non-production) v5 result fixture for the Hypertension study so the frontend surfacing layer has data to render';
+
+    private const PROVENANCE = 'Representative demonstration fixture — grounded in v4 baseline facts (CHANGELOG_v4_to_v5.md), NOT a real v5 execution. Do not present as a study finding.';
+
+    /** result_types this fixture owns; used for idempotent cleanup. */
+    private const V5_RESULT_TYPES = [
+        'overlap_weighted_effect',
+        'target_trial',
+        'instrumental_variable',
+        'comorbidity_matrix',
+        'bp_distribution',
+        'phenotype_robustness',
+        'triangulation',
+    ];
+
+    public function handle(): int
+    {
+        $studyId = (int) $this->option('study');
+        $dryRun = (bool) $this->option('dry-run');
+
+        $study = Study::find($studyId);
+        if (! $study instanceof Study) {
+            $this->error("Study {$studyId} not found.");
+
+            return self::FAILURE;
+        }
+
+        $this->info("Seeding v5 demonstration fixture for study {$studyId} ({$study->slug}).");
+        $this->warn('This is REPRESENTATIVE, non-production data. Rows are flagged _fixture:true.');
+
+        // Resolve existing analyses to attach the curated rows to. The v5
+        // analyses (M–R) have no analysis records of their own, so we hang the
+        // projected rows off the study's existing analyses; the (study, analysis,
+        // result_type) key stays unique because the v5 result_types are new.
+        $analyses = StudyAnalysis::query()
+            ->where('study_id', $studyId)
+            ->orderBy('id')
+            ->get();
+
+        if ($analyses->isEmpty()) {
+            $this->error("Study {$studyId} has no analyses to attach results to.");
+
+            return self::FAILURE;
+        }
+
+        $descriptiveAnalysisId = $this->firstAnalysisId($analyses, 'Characterization') ?? (int) $analyses->first()->id;
+        $estimationIds = $this->estimationAnalysisIds($analyses);
+        $estA = $estimationIds[0] ?? (int) $analyses->first()->id;
+        $estB = $estimationIds[1] ?? $estA;
+
+        if (! $dryRun && ! $this->option('force') && ! $this->confirm('Write fixture rows now?', true)) {
+            $this->line('Aborted.');
+
+            return self::SUCCESS;
+        }
+
+        $rows = [
+            ['analysis_id' => $estA, 'type' => 'overlap_weighted_effect', 'primary' => true, 'publishable' => true, 'data' => $this->overlapWeighted()],
+            ['analysis_id' => $estB, 'type' => 'target_trial', 'primary' => false, 'publishable' => true, 'data' => $this->targetTrial()],
+            ['analysis_id' => $estB, 'type' => 'instrumental_variable', 'primary' => false, 'publishable' => false, 'data' => $this->instrumentalVariable()],
+            ['analysis_id' => $descriptiveAnalysisId, 'type' => 'comorbidity_matrix', 'primary' => false, 'publishable' => true, 'data' => $this->comorbidityMatrix()],
+            ['analysis_id' => $descriptiveAnalysisId, 'type' => 'bp_distribution', 'primary' => false, 'publishable' => true, 'data' => $this->bpDistribution()],
+            ['analysis_id' => $descriptiveAnalysisId, 'type' => 'phenotype_robustness', 'primary' => false, 'publishable' => true, 'data' => $this->phenotypeRobustness()],
+            ['analysis_id' => $estA, 'type' => 'triangulation', 'primary' => false, 'publishable' => true, 'data' => $this->triangulation()],
+        ];
+
+        if ($dryRun) {
+            foreach ($rows as $row) {
+                $keys = implode(', ', array_keys($row['data']));
+                $this->line("  [dry-run] {$row['type']} → analysis {$row['analysis_id']} · summary keys: {$keys}");
+            }
+            $this->line('  [dry-run] long-form tables: '.implode(', ', array_keys($this->longFormTables())));
+
+            return self::SUCCESS;
+        }
+
+        DB::transaction(function () use ($studyId, $rows): void {
+            // Idempotent: clear this fixture's own prior rows only.
+            StudyResult::query()
+                ->where('study_id', $studyId)
+                ->whereIn('result_type', self::V5_RESULT_TYPES)
+                ->delete();
+
+            foreach ($rows as $row) {
+                StudyResult::create([
+                    'study_id' => $studyId,
+                    'study_analysis_id' => $row['analysis_id'],
+                    'result_type' => $row['type'],
+                    'summary_data' => $this->stamp($row['data']),
+                    'diagnostics' => ['fixture' => true, 'gates' => $row['data']['gates'] ?? null],
+                    'is_primary' => $row['primary'],
+                    'is_publishable' => $row['publishable'],
+                ]);
+                $this->line("  ✓ {$row['type']}");
+            }
+        });
+
+        $source = Source::query()->where('source_key', $this->option('source'))->first();
+        if ($source instanceof Source) {
+            SourceContext::forSource($source);
+            $this->seedLongFormTables();
+        } else {
+            $this->warn("  ⚠ Source '{$this->option('source')}' not found — skipped long-form tables (study rows still seeded).");
+        }
+
+        $this->info('v5 fixture seeded. Reload study 165 → Results tab / v5 Report tab.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function stamp(array $data): array
+    {
+        return array_merge(['_fixture' => true, '_provenance' => self::PROVENANCE], $data);
+    }
+
+    /**
+     * @param  Collection<int, StudyAnalysis>  $analyses
+     */
+    private function firstAnalysisId(Collection $analyses, string $needle): ?int
+    {
+        $match = $analyses->first(fn (StudyAnalysis $a): bool => str_contains((string) $a->analysis_type, $needle));
+
+        return $match instanceof StudyAnalysis ? (int) $match->id : null;
+    }
+
+    /**
+     * @param  Collection<int, StudyAnalysis>  $analyses
+     * @return list<int>
+     */
+    private function estimationAnalysisIds(Collection $analyses): array
+    {
+        return array_values($analyses
+            ->filter(fn (StudyAnalysis $a): bool => str_contains((string) $a->analysis_type, 'Estimation'))
+            ->map(fn (StudyAnalysis $a): int => (int) $a->id)
+            ->all());
+    }
+
+    // ---------------------------------------------------------------------
+    // Compact summary_data payloads (Appendix A contracts)
+    // ---------------------------------------------------------------------
+
+    /** Analysis O — overlap-weighted (ATO) timely vs delayed initiation. */
+    private function overlapWeighted(): array
+    {
+        return [
+            'analysis_code' => 'O',
+            'label' => 'Overlap-Weighted (ATO) — Timely vs Delayed Antihypertensive Initiation',
+            'estimable' => true,
+            'gates' => ['max_smd' => 0.06, 'equipoise' => 0.41, 'null_centered' => true],
+            'target_count' => 109763,
+            'comparator_count' => 41288,
+            'estimates' => [
+                ['outcome_name' => 'MACE', 'hazard_ratio' => 0.88, 'ci_95_lower' => 0.79, 'ci_95_upper' => 0.98, 'e_value' => 1.52, 'calibrated_hr' => 0.90, 'cal_ci_lower' => 0.79, 'cal_ci_upper' => 1.02],
+                ['outcome_name' => 'CKD progression', 'hazard_ratio' => 0.74, 'ci_95_lower' => 0.66, 'ci_95_upper' => 0.83, 'e_value' => 2.04, 'calibrated_hr' => 0.76, 'cal_ci_lower' => 0.66, 'cal_ci_upper' => 0.88],
+            ],
+            'risk_difference_5y' => ['mace' => -0.021, 'ckd' => -0.038],
+            'gradient' => [
+                ['group' => 1, 'label' => 'Q1 (most delayed)', 'hr' => 1.00, 'ci_95_lower' => 1.00, 'ci_95_upper' => 1.00],
+                ['group' => 2, 'label' => 'Q2', 'hr' => 0.94, 'ci_95_lower' => 0.85, 'ci_95_upper' => 1.04],
+                ['group' => 3, 'label' => 'Q3', 'hr' => 0.86, 'ci_95_lower' => 0.77, 'ci_95_upper' => 0.96],
+                ['group' => 4, 'label' => 'Q4 (most timely)', 'hr' => 0.74, 'ci_95_lower' => 0.66, 'ci_95_upper' => 0.83],
+            ],
+            'balance' => $this->balanceCovariates(),
+            'calibration' => ['ease' => 0.09, 'informative_negative_controls' => 48, 'null_mean' => 0.01, 'null_sd' => 0.21],
+        ];
+    }
+
+    /** @return list<array{covariate: string, smd_before: float, smd_after: float}> */
+    private function balanceCovariates(): array
+    {
+        $covs = [
+            ['Age', 0.31, 0.04], ['Female', 0.18, 0.02], ['Diabetes', 0.27, 0.05],
+            ['Prior MI', 0.22, 0.03], ['Heart failure', 0.19, 0.06], ['CKD stage ≥3', 0.34, 0.05],
+            ['Statin use', 0.24, 0.03], ['Smoking', 0.16, 0.02], ['Obesity', 0.14, 0.04],
+            ['Prior stroke', 0.20, 0.03], ['COPD', 0.12, 0.02], ['Atrial fibrillation', 0.17, 0.05],
+            ['Baseline SBP', 0.29, 0.06], ['eGFR', 0.33, 0.04], ['Charlson index', 0.36, 0.05],
+        ];
+
+        return array_map(
+            fn (array $c): array => ['covariate' => $c[0], 'smd_before' => $c[1], 'smd_after' => $c[2]],
+            $covs,
+        );
+    }
+
+    /** Analysis P — target-trial emulation (clone-censor-weight, IPCW). */
+    private function targetTrial(): array
+    {
+        return [
+            'analysis_code' => 'P',
+            'label' => 'Target-Trial Emulation — Per-Protocol (90-day grace)',
+            'grace_days' => 90,
+            'immortal_time_check' => 'PASS',
+            'estimates' => [
+                ['outcome_name' => 'MACE', 'hazard_ratio' => 0.86, 'ci_95_lower' => 0.76, 'ci_95_upper' => 0.97, 'risk_diff_5y' => -0.024],
+                ['outcome_name' => 'CKD progression', 'hazard_ratio' => 0.72, 'ci_95_lower' => 0.63, 'ci_95_upper' => 0.82, 'risk_diff_5y' => -0.041],
+            ],
+            'sensitivity' => [
+                ['grace_days' => 30, 'outcome_name' => 'MACE', 'hazard_ratio' => 0.89],
+                ['grace_days' => 180, 'outcome_name' => 'MACE', 'hazard_ratio' => 0.84],
+            ],
+            'km' => [
+                'timely' => $this->cumulativeIncidence(0.135),
+                'delayed' => $this->cumulativeIncidence(0.171),
+            ],
+            'ipcw' => ['max_stabilized_weight' => 6.8, 'mean_stabilized_weight' => 1.02, 'flag' => false],
+        ];
+    }
+
+    /** @return list<array{time: int, surv: float, nAtRisk: int, nEvents: int}> cumulative-incidence points. */
+    private function cumulativeIncidence(float $fiveYearRisk): array
+    {
+        $points = [];
+        $atRisk = 90000;
+        $cumEvents = 0;
+        for ($month = 0; $month <= 60; $month += 6) {
+            $frac = $fiveYearRisk * ($month / 60) ** 0.85;
+            $cumInc = round($frac, 4);
+            $events = (int) round($cumInc * 90000) - $cumEvents;
+            $cumEvents += max(0, $events);
+            $points[] = [
+                'time' => $month,
+                'surv' => round(1 - $cumInc, 4),
+                'nAtRisk' => max(0, $atRisk - $cumEvents),
+                'nEvents' => max(0, $events),
+            ];
+        }
+
+        return $points;
+    }
+
+    /** Analysis R — instrumental variable (2SRI; regional prescribing preference). */
+    private function instrumentalVariable(): array
+    {
+        return [
+            'analysis_code' => 'R',
+            'label' => 'Instrumental Variable (2SRI) — Regional Prescribing Preference',
+            'first_stage_f' => 14.2,
+            'interpretable' => true,
+            'n_sites' => 521,
+            'coverage_pct' => 37.9,
+            'nc_on_instrument_null' => true,
+            'late' => [
+                ['outcome_name' => 'MACE', 'estimate' => 0.83, 'ci_95_lower' => 0.68, 'ci_95_upper' => 1.01],
+                ['outcome_name' => 'CKD progression', 'estimate' => 0.70, 'ci_95_lower' => 0.55, 'ci_95_upper' => 0.89],
+            ],
+            'tertile_balance' => [
+                ['covariate' => 'Age', 't1' => 61.2, 't2' => 61.5, 't3' => 61.1, 'balanced' => true],
+                ['covariate' => 'Diabetes %', 't1' => 28.4, 't2' => 28.9, 't3' => 28.1, 'balanced' => true],
+                ['covariate' => 'CKD ≥3 %', 't1' => 11.7, 't2' => 12.0, 't3' => 11.5, 'balanced' => true],
+                ['covariate' => 'Charlson', 't1' => 2.3, 't2' => 2.4, 't3' => 2.3, 'balanced' => true],
+            ],
+            'result_table' => 'iv-instrument',
+        ];
+    }
+
+    /** Analysis M — comorbidity prevalence matrix (17 morbidities × 6 populations). */
+    private function comorbidityMatrix(): array
+    {
+        $cells = [];
+        foreach ($this->comorbidityRows() as $r) {
+            $cells[] = [
+                'morbidity' => $r['morbidity'],
+                'population' => $r['population'],
+                'prevalence' => $r['prevalence'],
+                'wilson_lo' => $r['wilson_lo'],
+                'wilson_hi' => $r['wilson_hi'],
+            ];
+        }
+
+        return [
+            'analysis_code' => 'M',
+            'label' => 'Comorbidity Prevalence Matrix',
+            'morbidities' => self::MORBIDITIES,
+            'populations' => self::POPULATIONS,
+            'heatmap' => $cells,
+            'result_table' => 'comorbidity-matrix',
+        ];
+    }
+
+    /** Analysis N — blood-pressure distribution across groups × timepoints. */
+    private function bpDistribution(): array
+    {
+        $summary = [];
+        foreach (self::BP_GROUPS as $group) {
+            foreach (['t1', 't2', 't_dx'] as $tp) {
+                foreach (['SBP', 'DBP'] as $measure) {
+                    $base = $measure === 'SBP' ? 148 : 88;
+                    $shift = $tp === 't1' ? 0 : ($tp === 't2' ? -4 : -9);
+                    $mean = $base + $shift + (crc32($group) % 5) - 2;
+                    $summary[] = [
+                        'group' => $group,
+                        'timepoint' => $tp,
+                        'measure' => $measure,
+                        'n' => 109763,
+                        'mean' => $mean,
+                        'sd' => $measure === 'SBP' ? 16.4 : 10.2,
+                        'median' => $mean - 1,
+                        'q1' => $mean - ($measure === 'SBP' ? 11 : 7),
+                        'q3' => $mean + ($measure === 'SBP' ? 11 : 7),
+                        'skew' => 0.34,
+                        'kurt' => 3.1,
+                    ];
+                }
+            }
+        }
+
+        return [
+            'analysis_code' => 'N',
+            'label' => 'Blood-Pressure Distribution (t1 → t2 → t_dx)',
+            'groups' => self::BP_GROUPS,
+            'timepoints' => ['t1', 't2', 't_dx'],
+            'summary' => $summary,
+            'kde' => $this->bpKde(),
+            'trellis' => $this->bpTrellis(),
+            'below_trigger_fraction' => 0.184,
+            'result_table' => 'bp-distribution',
+        ];
+    }
+
+    /** @return list<array{group: string, timepoint: string, measure: string, points: list<array{0: float, 1: float}>}> */
+    private function bpKde(): array
+    {
+        $out = [];
+        foreach (self::BP_GROUPS as $group) {
+            foreach (['t1', 't_dx'] as $tp) {
+                $center = $tp === 't1' ? 150 : 141;
+                $points = [];
+                for ($x = 100; $x <= 200; $x += 5) {
+                    $z = ($x - $center) / 16.4;
+                    $points[] = [$x, round(exp(-0.5 * $z * $z), 4)];
+                }
+                $out[] = ['group' => $group, 'timepoint' => $tp, 'measure' => 'SBP', 'points' => $points];
+            }
+        }
+
+        return $out;
+    }
+
+    /** @return list<array{group: string, t1: float, t2: float, t_dx: float}> paired-arrow trellis (mean SBP). */
+    private function bpTrellis(): array
+    {
+        $out = [];
+        foreach (self::BP_GROUPS as $i => $group) {
+            $out[] = ['group' => $group, 't1' => 150 + $i, 't2' => 146 + $i, 't_dx' => 141 + $i];
+        }
+
+        return $out;
+    }
+
+    /** Analysis Q — phenotype robustness (index-rule × threshold × max-gap grid). */
+    private function phenotypeRobustness(): array
+    {
+        $grid = [];
+        foreach (['first-dx', 'two-dx', 'dx+rx'] as $rule) {
+            foreach ([1, 2] as $threshold) {
+                foreach ([90, 365] as $maxGap) {
+                    $neverDx = round(0.90 - (str_contains($rule, 'rx') ? 0.06 : 0) - ($threshold - 1) * 0.03 - ($maxGap === 365 ? 0.02 : 0), 3);
+                    $grid[] = [
+                        'index_rule' => $rule,
+                        'threshold' => $threshold,
+                        'max_gap' => $maxGap,
+                        'never_dx_fraction' => $neverDx,
+                        'n' => 109763,
+                        'median_latency' => 1106 - ($threshold - 1) * 90,
+                    ];
+                }
+            }
+        }
+
+        return [
+            'analysis_code' => 'Q',
+            'label' => 'Phenotype Robustness — Never-Diagnosed Fraction',
+            'grid' => $grid,
+            'visit_split' => [
+                'visit_linked' => ['coverage_pct' => 37.9, 'never_dx' => 0.71, 'mace' => 0.089, 'ckd' => 0.142],
+                'measurement_only' => ['coverage_pct' => 62.1, 'never_dx' => 0.98, 'mace' => 0.041, 'ckd' => 0.067],
+            ],
+            'e_values' => ['mace' => 1.52, 'ckd' => 2.04],
+            'qba_interval' => [0.70, 0.94],
+            'result_table' => 'phenotype-grid',
+        ];
+    }
+
+    /** Cross-design triangulation of the causal estimate (O / P / R). */
+    private function triangulation(): array
+    {
+        return [
+            'analysis_code' => 'Triangulation',
+            'label' => 'Cross-Design Triangulation — Timely vs Delayed Initiation',
+            'designs' => [
+                ['name' => 'O — Overlap-weighted (ATO)', 'code' => 'O', 'hr_mace' => 0.88, 'mace_lo' => 0.79, 'mace_hi' => 0.98, 'hr_ckd' => 0.74, 'ckd_lo' => 0.66, 'ckd_hi' => 0.83, 'estimable' => true, 'gate_status' => 'cleared'],
+                ['name' => 'P — Target-trial emulation', 'code' => 'P', 'hr_mace' => 0.86, 'mace_lo' => 0.76, 'mace_hi' => 0.97, 'hr_ckd' => 0.72, 'ckd_lo' => 0.63, 'ckd_hi' => 0.82, 'estimable' => true, 'gate_status' => 'cleared'],
+                ['name' => 'R — Instrumental variable (2SRI)', 'code' => 'R', 'hr_mace' => 0.83, 'mace_lo' => 0.68, 'mace_hi' => 1.01, 'hr_ckd' => 0.70, 'ckd_lo' => 0.55, 'ckd_hi' => 0.89, 'estimable' => true, 'gate_status' => 'triangulation-only'],
+            ],
+            'concordance' => 'concordant',
+            'most_credible' => 'P',
+            'narrative' => 'All three designs point the same direction for both endpoints; the target-trial emulation (P) is the most credible primary basis, with O and R providing concordant support. R is retained for triangulation only.',
+        ];
+    }
+
+    // ---------------------------------------------------------------------
+    // Long-form results.htn_v4_* tables (Layer 2 drawer + CSV)
+    // ---------------------------------------------------------------------
+
+    /** @return array<string, string> key → schema-qualified table (documentation + dry-run). */
+    private function longFormTables(): array
+    {
+        return [
+            'comorbidity-matrix' => 'results.htn_v4_m_comorbidity_matrix',
+            'bp-distribution' => 'results.htn_v4_n_bp_distribution',
+            'phenotype-grid' => 'results.htn_v4_q_phenotype_grid',
+            'iv-instrument' => 'results.htn_v4_r_instrument',
+            'triangulation' => 'results.htn_v4_triangulation',
+        ];
+    }
+
+    private function longFormTablesExist(Connection $c): bool
+    {
+        $row = $c->selectOne("select to_regclass('results.htn_v4_triangulation') is not null as ok");
+
+        return (bool) ($row->ok ?? false);
+    }
+
+    private function seedLongFormTables(): void
+    {
+        $c = $this->results();
+
+        // The runtime role (parthenon_app) has no DDL on the results schema, so
+        // the tables are pre-created + granted by the owner via
+        // scripts/sql/htn-v5-fixture-tables.sql. If they are missing, skip the
+        // long-form seed with a clear hint rather than failing the study rows.
+        if (! $this->longFormTablesExist($c)) {
+            $this->warn('  ⚠ results.htn_v4_* tables missing — run scripts/sql/htn-v5-fixture-tables.sql as the owner first, then re-run to populate the long-form drawers.');
+
+            return;
+        }
+
+        foreach (['htn_v4_m_comorbidity_matrix', 'htn_v4_n_bp_distribution', 'htn_v4_q_phenotype_grid', 'htn_v4_r_instrument', 'htn_v4_triangulation'] as $t) {
+            $c->statement("TRUNCATE results.{$t}");
+        }
+
+        // M — full 17 × 6 matrix with adjusted OR vs control population.
+        foreach ($this->comorbidityRows() as $r) {
+            $c->table('htn_v4_m_comorbidity_matrix')->insert($r);
+        }
+
+        // N — per group × timepoint × measure summary.
+        foreach ($this->bpDistribution()['summary'] as $s) {
+            $c->table('htn_v4_n_bp_distribution')->insert([
+                'grp' => $s['group'], 'timepoint' => $s['timepoint'], 'measure' => $s['measure'],
+                'n' => $s['n'], 'mean' => $s['mean'], 'sd' => $s['sd'], 'median' => $s['median'],
+                'q1' => $s['q1'], 'q3' => $s['q3'], 'skew' => $s['skew'], 'kurt' => $s['kurt'],
+            ]);
+        }
+
+        // Q — full grid.
+        foreach ($this->phenotypeRobustness()['grid'] as $g) {
+            $c->table('htn_v4_q_phenotype_grid')->insert([
+                'index_rule' => $g['index_rule'], 'threshold' => $g['threshold'], 'max_gap' => $g['max_gap'],
+                'never_dx_fraction' => $g['never_dx_fraction'], 'n' => $g['n'],
+                'median_latency' => $g['median_latency'], 'visit_linked' => $g['max_gap'] === 90,
+            ]);
+        }
+
+        // R — aggregated tertile balance only (never member-grain).
+        foreach ($this->instrumentalVariable()['tertile_balance'] as $b) {
+            foreach ([1 => 't1', 2 => 't2', 3 => 't3'] as $tertile => $key) {
+                $c->table('htn_v4_r_instrument')->insert([
+                    'tertile' => $tertile, 'covariate' => $b['covariate'],
+                    'mean_value' => $b[$key], 'balanced' => $b['balanced'],
+                ]);
+            }
+        }
+
+        // Triangulation — one row per (design × outcome).
+        foreach ($this->triangulation()['designs'] as $d) {
+            $c->table('htn_v4_triangulation')->insert([
+                'design' => $d['name'], 'outcome' => 'MACE', 'estimate' => $d['hr_mace'],
+                'ci_lo' => $d['mace_lo'], 'ci_hi' => $d['mace_hi'], 'estimable' => $d['estimable'], 'gate_status' => $d['gate_status'],
+            ]);
+            $c->table('htn_v4_triangulation')->insert([
+                'design' => $d['name'], 'outcome' => 'CKD progression', 'estimate' => $d['hr_ckd'],
+                'ci_lo' => $d['ckd_lo'], 'ci_hi' => $d['ckd_hi'], 'estimable' => $d['estimable'], 'gate_status' => $d['gate_status'],
+            ]);
+        }
+
+        $this->line('  ✓ long-form results.htn_v4_* tables');
+    }
+
+    private const MORBIDITIES = [
+        'Diabetes', 'CKD', 'Heart failure', 'Prior MI', 'Prior stroke', 'Atrial fibrillation',
+        'COPD', 'Obesity', 'Dyslipidemia', 'Depression', 'Anemia', 'Peripheral arterial disease',
+        'Sleep apnea', 'Gout', 'Osteoarthritis', 'Chronic liver disease', 'Dementia',
+    ];
+
+    private const POPULATIONS = [
+        'All hypertensives', 'Timely initiators', 'Delayed initiators', 'Never-diagnosed', 'Visit-linked', 'Measurement-only',
+    ];
+
+    private const BP_GROUPS = ['Timely', 'Delayed', 'Never-diagnosed'];
+
+    /** @return list<array{morbidity: string, population: string, prevalence: float, wilson_lo: float, wilson_hi: float, n_present: int, n_total: int, adjusted_or: float, or_ci_lo: float, or_ci_hi: float}> */
+    private function comorbidityRows(): array
+    {
+        $rows = [];
+        foreach (self::MORBIDITIES as $mi => $morbidity) {
+            $basePrev = 0.08 + (($mi * 37) % 40) / 100.0; // deterministic 0.08–0.47
+            foreach (self::POPULATIONS as $pi => $population) {
+                $adj = $pi === 2 ? 0.06 : ($pi === 3 ? -0.03 : ($pi === 1 ? -0.02 : 0));
+                $prev = round(max(0.01, min(0.92, $basePrev + $adj + ($pi % 3) * 0.01)), 4);
+                $nTotal = 109763;
+                $nPresent = (int) round($prev * $nTotal);
+                $half = round(1.96 * sqrt($prev * (1 - $prev) / $nTotal), 4);
+                $or = $pi === 0 ? 1.00 : round(1.0 + $adj * 6, 2);
+                $rows[] = [
+                    'morbidity' => $morbidity,
+                    'population' => $population,
+                    'prevalence' => $prev,
+                    'wilson_lo' => round(max(0, $prev - $half), 4),
+                    'wilson_hi' => round(min(1, $prev + $half), 4),
+                    'n_present' => $nPresent,
+                    'n_total' => $nTotal,
+                    'adjusted_or' => $or,
+                    'or_ci_lo' => round($or * 0.9, 2),
+                    'or_ci_hi' => round($or * 1.1, 2),
+                ];
+            }
+        }
+
+        return $rows;
+    }
+}

--- a/docs/devlog/modules/studies/2026-07-04-htn-v5-frontend-surfacing.md
+++ b/docs/devlog/modules/studies/2026-07-04-htn-v5-frontend-surfacing.md
@@ -1,0 +1,76 @@
+# HTN v5 — Frontend Result Surfacing
+
+**Date:** 2026-07-04
+**Branch:** `feature/htn-v5-frontend-surfacing`
+**Study:** `app.studies.id = 165` (`hypertension-study-v4`)
+
+## Goal
+
+Surface every result of the Hypertension Outcomes Program **v5** (analyses M–R +
+triangulation from `docs/research/CLAUDE_PROMPT_v5.md`) natively in the React
+studies module — not just as a standalone HTML/PDF report.
+
+## Key finding
+
+v5 has **not been executed**. Study 165 carried only its four **v4** results
+(`characterization`, `effect_estimate`×2, `incidence_rate`); there were zero
+`results.htn_v4_*` tables and no M–R/triangulation rows anywhere. So the task was
+to build the full surfacing pipeline and drive it with a **representative,
+clearly-labelled demonstration fixture** (the Phase-8 fallback in the plan) —
+grounded in the real v4 baseline facts (T = 109,763; never-dx ≈ 90%;
+latency_b ≈ 1,106 d; CKD HR ≈ 2.60; 37.9% encounter coverage). Every fixture row
+carries `_fixture: true` + `_provenance`, and the UI renders an explicit
+"Demonstration data" banner on every figure so the numbers can never be mistaken
+for a real v5 finding.
+
+## What shipped
+
+### Backend
+- `SeedHtnV5Fixture` command (`study:seed-htn-v5-fixture`) — idempotent; writes
+  7 curated `app.study_results` rows (one per v5 analysis) with compact,
+  chart-ready `summary_data`, plus the long-form `results.htn_v4_*` tables.
+  Comparative designs (O/P/R) carry estimability gates; IV (R) is withheld from
+  publish (`is_publishable=false`) as designed. Pint + PHPStan L8 clean; uses the
+  sanctioned `SourceAware` trait (no direct `DB::connection('results')`).
+- `scripts/sql/htn-v5-fixture-tables.sql` — owner-run DDL + grants for the
+  `results.htn_v4_*` tables (the runtime role `parthenon_app` has USAGE but no
+  CREATE on the results schema; owner creates, app populates/reads).
+
+### Frontend (`frontend/src/features/studies/components/`)
+- 7 per-analysis renderers under `v5/` dispatched from `StudyResultSummary`'s
+  switch: `OverlapWeightedEffectView` (O), `TargetTrialView` (P),
+  `InstrumentalVariableView` (R), `ComorbidityMatrixView` (M),
+  `BpDistributionView` (N), `PhenotypeRobustnessView` (Q), `TriangulationView`.
+- Reuses existing self-contained SVG charts (`ForestPlot`, `LovePlot`,
+  `KaplanMeierPlot`, `HeatmapChart`) via small adapters (`v5/narrow.ts`,
+  `v5/charts/chartAdapters.ts`) that fill the required `EstimateEntry` /
+  `CovariateBalanceEntry` / `KaplanMeierPoint` fields from the compact payloads.
+- Two net-new primitives: `RidgelinePlot` (KDE) and `PairedArrowTrellis`
+  (t₁→t₂→t_dx) for Analysis N.
+- `StudyV5ReportTab` (Layer 3) — assembled native report composing the
+  triangulation headline, ATO/target-trial/IV designs, descriptive matrices, and
+  a derived `VvAcceptanceMatrix` (V&V §8). Gated to studies that have a
+  `triangulation` result, wired into the Evidence tab group in `StudyDetailPage`.
+- Estimability withholding: failed gates render an explicit withheld banner,
+  never a blinded number.
+- M/N/Q "view full" + CSV export render client-side from `summary_data` (which
+  already carries the full arrays), so no PHI-bearing member-grain egress.
+
+## Verification
+- Backend: `pint` + `phpstan --level=8` clean; seeder run verified 7 study_results
+  rows + long-form counts (matrix 102, bp 18, grid 12, instrument 12,
+  triangulation 6).
+- API: `GET /studies/hypertension-study-v4/results` returns all 11 rows with the
+  7 v5 types, correct `_fixture` flag and publishability gating.
+- Frontend: `tsc --noEmit` clean, `vite build` clean, `eslint` clean, `vitest`
+  14/14 (adapter + narrowing logic).
+
+## Deferred / follow-up
+- Generic source-scoped long-form table-reader endpoint (Layer 2 server side) —
+  not needed for the fixture (summary_data carries the full arrays); the
+  `results.htn_v4_*` tables + DDL script are the substrate for it.
+- Full v5 executor (`StudyHtnV4` per CLAUDE_PROMPT_v5 §2) — when it runs, the same
+  renderers display the real rows; the projector should learn the v5 analysis
+  types so real executions project automatically.
+- i18n: new strings use `defaultValue` fallbacks; add `app` namespace keys for
+  full localisation.

--- a/docs/devlog/plans/htn-v5-frontend-surfacing-plan.md
+++ b/docs/devlog/plans/htn-v5-frontend-surfacing-plan.md
@@ -1,0 +1,185 @@
+# HTN v5 — Frontend Result-Surfacing Plan (detailed todo)
+
+**Author:** Sanjay M. Udoshi, MD (plan drafted by Claude)
+**Date:** 2026-07-04
+**Scope:** Surface every result the Hypertension Outcomes Program **v5** produces (analyses A–R + triangulation) in the Parthenon React frontend — not just the standalone HTML report.
+**Study:** `app.studies.id = 165`, slug `hypertension-study-v4`, `analysis_plan_version → v5.0`.
+**Source docs:** `docs/research/CLAUDE_PROMPT_v5.md` (executable spec), `docs/research/CHANGELOG_v4_to_v5.md` (deep diff).
+**Branch:** `feature/htn-v5-frontend-surfacing` from `main`.
+
+---
+
+## 0. What "surface V5 results" means
+
+v5 emits results in **three physical places**. Each needs a frontend path:
+
+| Producer | Physical location | Grain | Frontend path today | Gap |
+|---|---|---|---|---|
+| Per-analysis summaries (A–R, triangulation) | `app.study_analyses.summary_data` → projected to `app.study_results.summary_data` (JSONB) | 1 row / analysis × result_type | **Results tab** (`StudyResultsTab`) → expand → `StudyResultSummary` | Only 3 shapes render; M/N/P/Q/R/triangulation dump raw JSON |
+| Long-form result tables | `results.htn_v4_{m,n,o,p,q,r}_*`, `results.htn_v4_triangulation` | 1 row / (morbidity×group×epoch), (member×timepoint), (site), (grid cell)… | **none** | No API to read a `results.*` study table; too big for `summary_data` |
+| Report + provenance artifacts | `htn_v5_report.{html,pdf}`, `analysis_plan_v5.0.lock.json`, `v5-reuse-manifest.md` | files | **Artifacts tab** (`StudyArtifactsTab`) download only | No embedded/interactive report; no lock-hash surfacing |
+
+**Design decision (recommended): three complementary layers, not one.**
+
+1. **Layer 1 — extend the generic pipeline.** Teach the projector + `StudyResultSummary` the seven new v5 shapes so each analysis renders correctly inside the existing Results tab (chips, expand, mark-primary/publishable, Ask-Abby, synthesis all keep working for free). This is the backbone.
+2. **Layer 2 — long-form table reader.** One generic, permissioned, paginated + CSV endpoint to read whitelisted `results.htn_v4_*` rows, so the big matrices (M/N/Q/R) render as real interactive tables/heatmaps and download as CSV (the prompt requires CSV for M and N).
+3. **Layer 3 — assembled "v5 Report" surface.** A new sub-tab under the **Evidence** group that composes the headline **triangulation figure (O/P/R)**, ATO forest/love plots, M heatmap, N ridgelines, Q robustness panel, negative-control calibration, **Lu 2025 PASS/FAIL/N-A**, and the **V&V acceptance matrix** — mirroring the HTML report structure natively in React, palette-correct, with the lock hash in the header.
+
+Reuse-first: the SVG chart components below already exist and are self-contained (no new chart library).
+
+| v5 need | Reuse this existing component | Path |
+|---|---|---|
+| O / G / H / triangulation forest | `ForestPlot` (`estimates: EstimateEntry[]`, `predictionInterval`) | `frontend/src/features/estimation/components/ForestPlot.tsx` |
+| O love plot (SMD before/after ATO) | `LovePlot` (`data: CovariateBalanceEntry[]`) | `frontend/src/features/estimation/components/LovePlot.tsx` |
+| O propensity/overlap distribution | `PropensityScorePlot` | `frontend/src/features/estimation/components/PropensityScorePlot.tsx` |
+| P cumulative-incidence curves | `KaplanMeierPlot` (`targetCurve/comparatorCurve: KaplanMeierPoint[]`) | `frontend/src/features/estimation/components/KaplanMeierPlot.tsx` |
+| Negative-control calibration + EASE | `CalibrationPanel`, `SystematicErrorPlot` | `frontend/src/features/estimation/components/` |
+| M prevalence heatmap | `HeatmapChart` | `frontend/src/features/data-explorer/components/charts/HeatmapChart.tsx` |
+| N distribution / violin+box | `BoxPlotChart` | `frontend/src/features/data-explorer/components/charts/BoxPlotChart.tsx` |
+
+New-build charts (no reuse candidate): **ridgeline (KDE)** for N, **paired-arrow trellis** (t1→t2→t_dx) for N. Both are small D3/SVG components; D3 7.9 is already a dependency.
+
+---
+
+## Phase 1 — Backend: v5 result-type taxonomy + projector normalizers
+
+Goal: every v5 analysis lands in `app.study_results` with a compact, chart-ready `summary_data` and a new `result_type` the frontend can switch on.
+
+- [ ] **1.1 Add v5 `result_type` constants.** Extend the result-type taxonomy (wherever `effect_estimate|incidence_rate|characterization|pathway|prediction_performance|sccs|custom` is enumerated — check `app/Models/App/StudyResult.php`, `StudyResultProjector`, and any `ResultType` enum/const) with: `overlap_weighted_effect` (O), `target_trial` (P), `comorbidity_matrix` (M), `bp_distribution` (N), `phenotype_robustness` (Q), `instrumental_variable` (R), `triangulation`.
+- [ ] **1.2 Extend `StudyResultProjector::buildRows()`** (`backend/app/Services/Studies/StudyResultProjector.php`) to recognize the v5 analysis FQCNs / `analysis_type` slugs and emit one `study_results` row each with the compact `summary_data` contract in §Appendix A. **Keep long-form rows OUT of `summary_data`** — store only the headline scalars, the small arrays needed to draw a chart (≤ a few hundred points), and a `result_table` pointer (schema-qualified table name + the filter columns) for anything larger. Preserve `is_primary` on re-projection (existing behavior).
+- [ ] **1.3 Publishability gating for O/P/R.** These are comparative effects → gate `is_publishable` on the estimability gates (weighted |SMD| < 0.1, equipoise ≥ 0.3, calibrated-null centered) exactly as v4 gated G4-vs-G1. When a gate fails, project the row with `summary_data.estimable=false` + `summary_data.gates=[…]` and `is_publishable=false` (withheld, not missing). M/N/Q descriptive → `is_publishable=true`.
+- [ ] **1.4 Triangulation row.** Project `results.htn_v4_triangulation` into a single `result_type='triangulation'` row whose `summary_data` carries the O/P/R estimates side-by-side + each design's estimability status + the concordance verdict (`concordant|divergent` + most-credible design).
+- [ ] **1.5 Reproject wiring.** Confirm `POST /studies/{study}/results/reproject` (`StudyResultController::reproject`) picks up the new rows; the `StudyHtnV4 --action=run` command (Phase 5) should call the projector on completion.
+- [ ] **1.6 Tests (Pest).** `backend/tests/` — projector emits the 7 new types; O withheld-vs-cleared both project correctly; no PHI/`person_id` in `summary_data`. Run `vendor/bin/pint` + `phpstan analyse` (level 8, no new baseline entries).
+
+## Phase 2 — Backend: long-form `results.htn_v4_*` table reader
+
+Goal: a safe, generic way for the frontend to page through and export the big v5 tables (M matrix, N distribution, Q grid, R instrument).
+
+- [ ] **2.1 New endpoint.** `GET /api/v1/studies/{study}/result-tables/{key}` returning paginated rows, plus `GET …/result-tables/{key}.csv` for download. Add to the `studies/{study}` route group in `backend/routes/api.php` (~L869–893) under `permission:studies.view`.
+- [ ] **2.2 Whitelist, don't interpolate.** Map a small set of `key` slugs → fixed table names so no user string ever reaches SQL: `comorbidity-matrix→results.htn_v4_m_comorbidity_matrix`, `bp-distribution→…_n_bp_distribution`, `bp-summary→…_n_bp_summary`, `phenotype-grid→…_q_phenotype_grid`, `iv-instrument→…_r_instrument`, `triangulation→…_triangulation`. Reject anything not in the map (404).
+- [ ] **2.3 Read path.** Query via the `results` connection (or a thin `ResultsModel` subclass); support server-side filter params (e.g. `morbidity`, `group`, `epoch`, `timepoint`, `phenotype_variant`) and `page`/`per_page`. **Never** select `person_id`/MRN columns — project only group-level aggregate columns (enforce a column allow-list per table; the R-instrument table is member-grain, so expose only aggregated/binned views, not raw member rows).
+- [ ] **2.4 Controller.** New `StudyResultTableController` (thin) or a method on `StudyResultController`. Group-level aggregates only in any egress (HIGHSEC §7).
+- [ ] **2.5 Tests (Pest).** Whitelist rejects unknown keys; pagination; CSV headers; asserts no PHI columns leak. Pint + PHPStan.
+
+## Phase 3 — Backend: artifacts, lock hash, OpenAPI
+
+- [ ] **3.1 Report + lock as artifacts.** Ensure the `StudyHtnV4 --action=report`/`lock` steps register `htn_v5_report.html`, `htn_v5_report.pdf`, and `analysis_plan_v5.0.lock.json` as `study_artifacts` rows (they already download via `StudyArtifactController::download`). Add `metadata.sha256` for the lock so the frontend can show it.
+- [ ] **3.2 Lock-hash accessor.** Expose the v5 lock hash + verification status (matches rendered report?) on the study `show` payload or a tiny `GET …/lock` endpoint, for the report header badge.
+- [ ] **3.3 Regenerate OpenAPI + types.** `./deploy.sh --openapi` → refresh `frontend/src/types/api.generated.ts` so the new result_types, `result-tables` shapes, and lock fields are typed. Do **not** hand-edit the generated file.
+
+## Phase 4 — Frontend: per-analysis renderers (Layer 1)
+
+Goal: expand `StudyResultSummary` so each v5 result type renders with the right chart instead of a JSON dump. All under `frontend/src/features/studies/components/`.
+
+- [ ] **4.1 Router switch.** In `StudyResultSummary.tsx` add `case` arms for the 7 new types dispatching to new sub-components (below). Keep `GenericView` as the final fallback. Add the labels to `RESULT_TYPE_LABELS` in `StudyResultsTab.tsx` and the `studies.results.resultTypes.*` i18n namespace.
+- [ ] **4.2 `OverlapWeightedEffectView` (O).** Headline timely-vs-delayed HR (MACE, CKD) + 5-yr risk difference + E-value; reuse `ForestPlot` for the effect + secondary 4-group gradient, `LovePlot` for SMD-before/after-ATO, `PropensityScorePlot` for overlap. **Estimability-gate banner**: if `estimable=false`, render a prominent "withheld — gate X failed" state (do not show a blinded estimate). Reuse `EffectEstimateView`'s calibrated-HR table + EASE note.
+- [ ] **4.3 `TargetTrialView` (P).** Per-protocol HR (grace 90d; 30/180 sensitivity toggle) + 5-yr risk difference; reuse `KaplanMeierPlot` for cumulative-incidence by strategy; IPCW weight-distribution mini-histogram (flag if max stabilized weight > 10); **immortal-time check badge** (PASS/FAIL from `summary_data`).
+- [ ] **4.4 `InstrumentalVariableView` (R).** First-stage **F** (with ≥10 interpretability flag), LATE (MACE, CKD) via `ForestPlot`, tertile-balance falsification mini-table, negative-control-on-instrument null check. Prominent "triangulation only — never sole basis" caveat.
+- [ ] **4.5 `ComorbidityMatrixView` (M).** Reuse `HeatmapChart` for the prevalence heatmap (17 morbidities × 6 populations); compact top-line table (Wilson CIs, adjusted OR vs C); "View full matrix" → opens the Phase-6 long-form table drawer; CSV download button.
+- [ ] **4.6 `BpDistributionView` (N).** Summary stats table (mean/SD/median/IQR/skew/kurtosis per group×timepoint); **ridgeline** (new KDE component) per group per timepoint; violin+box via `BoxPlotChart` comparing t_dx across groups; **paired-arrow trellis** (t1→t2→t_dx, new small SVG); below-trigger (RTM/white-coat) fraction callout; CSV download.
+- [ ] **4.7 `PhenotypeRobustnessView` (Q).** The 90%-headline sensitivity: never-diagnosed fraction across the index-rule × threshold × max-gap grid (heatmap or small-multiples); **visit-linked vs measurement-only split** (the 37.9% encounter-coverage finding — NEW-17); E-values for O/P headline effects; QBA bias-adjusted interval.
+- [ ] **4.8 `TriangulationView` (headline).** Side-by-side O (ATO) / P (target-trial) / R (IV) via a single grouped `ForestPlot` (or three aligned rows), each with its estimability status; concordance verdict banner + most-credible-design flag. This is the study's headline causal figure.
+- [ ] **4.9 New chart primitives.** `RidgelinePlot.tsx` and `PairedArrowTrellis.tsx` under `frontend/src/features/studies/components/charts/` (D3 7.9, self-contained SVG, palette-correct). Unit tests (Vitest) for scale/empty-data.
+- [ ] **4.10 Types + Zod.** Add v5 `summary_data` shapes to `frontend/src/features/studies/types/study.ts` and Zod schemas (`schemas/`). No `any` — narrow `unknown`. Recharts tooltip `formatter as never` where used.
+
+## Phase 5 — Frontend: long-form table drawer + hooks (Layer 2)
+
+- [ ] **5.1 API + hooks.** Add `getStudyResultTable(slug, key, params)` + `downloadStudyResultTableCsv` to `frontend/src/features/studies/api/studyApi.ts`; TanStack Query hook `useStudyResultTable` in `hooks/useStudies.ts`.
+- [ ] **5.2 Reusable table drawer.** `StudyResultTableDrawer.tsx` — paginated, filterable (server-side params), CSV download; TanStack Table if the studies feature already uses it, else a simple table. Opened from M/N/Q/R "view full …" buttons.
+- [ ] **5.3 Guardrail.** Drawer never requests member-grain columns; only the whitelisted aggregate views from Phase 2.
+
+## Phase 6 — Frontend: assembled "v5 Report" surface (Layer 3)
+
+Goal: a native, palette-correct report view that mirrors `htn_v5_report.html` §7 requirements.
+
+- [ ] **6.1 New tab.** Add a `report` tab to the **Evidence** `TAB_GROUPS` block in `StudyDetailPage.tsx` (`TabKey`, `TAB_GROUPS`, `ALL_TABS`, render line ~505, i18n `studies.detail.tabs.report`). Gate its visibility to studies that have v5 results (e.g. slug `hypertension-study-v4` with `analysis_plan_version=v5.0`, or presence of a `triangulation` result) so it doesn't appear on unrelated studies.
+- [ ] **6.2 `StudyV5ReportTab.tsx`.** Compose, top-to-bottom: header with **`analysis_plan_v5.0` lock hash** + verification badge; **triangulation figure** (from 4.8) as the headline; ATO forest + love (O); M heatmap; N ridgelines/violin/trellis; Q phenotype-robustness panel + E-values; per-family negative-control calibration plots + EASE; **Lu 2025 PASS/FAIL/N-A** panel (Analysis F); **V&V acceptance matrix** panel.
+- [ ] **6.3 `VvAcceptanceMatrix.tsx`.** Render the 9 V&V rows from the prompt §8 (estimand robustness, positivity handling, lock integrity, negative-control coverage, reproducibility, governance, external validity, sensitivity transparency) with PASS/PRESENT/MISSING status pulled from result diagnostics.
+- [ ] **6.4 Palette + Arial.** Acumenus tokens (crimson `#9B1B30`, dark `#0E0E11`, gold `#C9A227`, teal `#2DD4BF`) — use existing CSS vars; match the dark clinical theme.
+- [ ] **6.5 Fallback link.** If the standalone `htn_v5_report.html` artifact exists, surface an "Open full HTML report" / "Download PDF" affordance (via `StudyArtifactController::download`) alongside the native view.
+
+## Phase 7 — Frontend: wiring, i18n, tests, build
+
+- [ ] **7.1 i18n.** Add all new keys to the `app` translation namespace (`studies.results.resultTypes.*`, `studies.v5report.*`, chart labels). No hardcoded strings.
+- [ ] **7.2 Vitest.** Unit tests for each new view (withheld-O state, immortal-time badge, triangulation concordance, ridgeline empty-data, table drawer pagination). Target ≥80% on new components.
+- [ ] **7.3 Build gates.** `npx tsc --noEmit` **and** `npx vite build` (vite is stricter — catches UNRESOLVED_IMPORT). ESLint clean. `Pick<T,…>` for component props where only a subset is needed.
+- [ ] **7.4 Manual QA.** Load study 165 → Results tab renders all A–R rows with correct charts (no JSON dumps); Report tab renders triangulation + V&V matrix; long-form drawers page + export CSV; withheld O shows the gate banner, not a number.
+
+## Phase 8 — Build the v5 study data (prerequisite / parallel track)
+
+The renderers are inert without data. This is the executor work from `CLAUDE_PROMPT_v5.md` §2–§5 — sequence it so at least a smoke dataset exists to develop against.
+
+- [ ] **8.1 `StudyHtnV4` command.** Create `backend/app/Console/Commands/StudyHtnV4.php` with `--action={reuse-audit,concept-sets,cohorts,analyses,lock,run,report}` + `--version=v5` (does not exist yet — net-new per changelog §4.1).
+- [ ] **8.2 Run analyses M–R + triangulation** against the `omop` source; write `results.htn_v4_*` tables; persist `analysis_plan_v5.0.lock.json` **before** run; project into `study_results`.
+- [ ] **8.3 Reconcile** the v4 baseline facts (T=109,763; never-diagnosed 90%; latency_b 1,106d; CKD HR 2.60) — any deviation >0.1% investigated.
+- [ ] *(If executing the full study is out of scope for the frontend task, seed a representative fixture into `results.htn_v4_*` + `study_results` so Phases 4–6 can be built and demoed. Mark fixtures clearly as non-production.)*
+
+## Phase 9 — Deploy + devlog
+
+- [ ] **9.1** `make lint` + `make test` green; PHPStan level 8 clean; `vite build` succeeds.
+- [ ] **9.2** `./deploy.sh --openapi` then `./deploy.sh --frontend` (prod serves `frontend/dist/`).
+- [ ] **9.3** Devlog under `docs/devlog/modules/` (studies) — what shipped, screenshots of the Report tab.
+- [ ] **9.4** Conventional-commit on `feature/htn-v5-frontend-surfacing`; PR to `main` with test plan.
+
+---
+
+## Appendix A — compact `summary_data` contracts (Phase 1.2)
+
+Chart-ready only; long-form stays in `results.htn_v4_*` and is fetched via Phase 2.
+
+```jsonc
+// overlap_weighted_effect (O)
+{ "estimable": true, "gates": {"max_smd": 0.06, "equipoise": 0.41, "null_centered": true},
+  "estimates": [{"outcome_name":"MACE","hazard_ratio":..,"ci_95_lower":..,"ci_95_upper":..,"e_value":..}, {"outcome_name":"CKD",...}],
+  "risk_difference_5y": {...}, "gradient": [{group:1..4, hr:..}],
+  "balance": [{covariate, smd_before, smd_after}], "calibration": {ease:.., informative_negative_controls:..} }
+
+// target_trial (P)
+{ "grace_days": 90, "estimates":[{outcome_name, hazard_ratio, ci_95_lower, ci_95_upper, risk_diff_5y}],
+  "km": {"strategyA":[{time,surv,nAtRisk,nEvents}], "strategyB":[...]},
+  "ipcw": {"max_stabilized_weight":.., "flag": false}, "immortal_time_check":"PASS" }
+
+// instrumental_variable (R)
+{ "first_stage_f": 14.2, "interpretable": true,
+  "late":[{outcome_name,estimate,ci_95_lower,ci_95_upper}],
+  "tertile_balance":[{covariate, t1, t2, t3, balanced}], "nc_on_instrument_null": true, "n_sites": 521, "coverage_pct": 37.9 }
+
+// comorbidity_matrix (M)  — heatmap cells + pointer to full table
+{ "heatmap":[{morbidity, population, prevalence, wilson_lo, wilson_hi}], "result_table":"comorbidity-matrix" }
+
+// bp_distribution (N)  — summary cells + pointer
+{ "summary":[{group, timepoint, measure:"SBP"|"DBP", n, mean, sd, median, q1, q3, skew, kurt}],
+  "kde":[{group,timepoint,measure,points:[[x,density]]}], "below_trigger_fraction":.., "result_table":"bp-distribution" }
+
+// phenotype_robustness (Q)
+{ "grid":[{index_rule, threshold, max_gap, never_dx_fraction, n, median_latency}],
+  "visit_split":{"visit_linked":{never_dx,mace,ckd}, "measurement_only":{...}},
+  "e_values":{mace:.., ckd:..}, "qba_interval":[lo,hi], "result_table":"phenotype-grid" }
+
+// triangulation
+{ "designs":[{name:"O (ATO)", hr_mace, hr_ckd, estimable, gate_status},
+             {name:"P (target trial)", ...}, {name:"R (IV)", ...}],
+  "concordance":"concordant", "most_credible":"O" }
+```
+
+## Appendix B — key files
+
+- Detail page / tabs: `frontend/src/features/studies/pages/StudyDetailPage.tsx`
+- Results tab: `frontend/src/features/studies/components/StudyResultsTab.tsx`
+- Result renderer (switch): `frontend/src/features/studies/components/StudyResultSummary.tsx`
+- Hooks / API / types: `frontend/src/features/studies/{hooks/useStudies.ts, api/studyApi.ts, types/study.ts}`
+- Reusable charts: `frontend/src/features/estimation/components/*`, `frontend/src/features/data-explorer/components/charts/*`
+- Projector: `backend/app/Services/Studies/StudyResultProjector.php`
+- Result controller / model: `backend/app/Http/Controllers/Api/V1/StudyResultController.php`, `backend/app/Models/App/StudyResult.php`
+- Routes: `backend/routes/api.php` (studies group ~L819–893)
+- Study command (net-new): `backend/app/Console/Commands/StudyHtnV4.php`
+
+## Appendix C — guardrails (must hold)
+
+- HIGHSEC: all new routes `auth:sanctum + permission:studies.view` (read) / `studies.execute` (run/reproject). No unauthenticated path to cohort/PHI data.
+- No `person_id`/MRN/PHI in `summary_data`, API responses, CSV exports, or logs — group-level aggregates only.
+- `CdmModel` read-only; writes only to `app.*`, `results.htn_v4_*`, `php.*`.
+- Pint (Docker) after every PHP edit; PHPStan level 8, no new baseline; `tsc --noEmit` **and** `vite build`.
+- Withheld estimates (failed gates) render as an explicit withheld state — never a blinded/silent number.
+```

--- a/docs/research/CHANGELOG_v4_to_v5.md
+++ b/docs/research/CHANGELOG_v4_to_v5.md
@@ -1,0 +1,214 @@
+# Hypertension Outcomes Program — Changelog v4 → v5
+
+**Author:** Sanjay M. Udoshi, MD
+**Date:** 2026-07-03
+**Doc ID:** ACUM-PROT-HTN-V5-001 (companion changelog)
+**Inputs reviewed:**
+- `Hypertension_v4_Consolidated_Acumenus.docx` — consolidated v4 protocol (Protocol #1 + #2 + IRB framework)
+- `CLAUDE_PROMPT.md` — v4 executable spec (Protocol #1)
+- `CHANGE_REQUEST_v4.1_Bock_2026-05-23.md` — Dr. Bock's v4.1 request (Analyses M and N)
+- `hypertension-study-v4-manuscript.pdf` — the v4 run's generated manuscript (July 2, 2026)
+- **Live database** — `pgsql.acumenus.net` / `parthenon`, read-only reconciliation, 2026-07-03 (study `app.studies` id 165, slug `hypertension-study-v4`)
+
+---
+
+## 0. Top-line finding
+
+The v4 run did almost everything it set out to do — and produced one hard, honest failure that defines v5. On 109,763 treatment-naïve patients with two consecutive elevated office BPs, Parthenon reproduced the Lu-style under-diagnosis signal (90% never diagnosed; median 1,106 days from the second elevated reading to diagnosis) and delivered a well-calibrated elevated-BP-versus-normotensive contrast (incident CKD calibrated HR 2.60, p < 0.0001; MACE calibrated HR 1.03, p 0.50). But the headline causal contrast — **delayed (> 12 mo, G4) versus timely (≤ 3 mo, G1) diagnosis — was not estimable.** The propensity model reached AUC 0.7984 with a maximum post-adjustment standardized mean difference of 0.2443; the groups could not be balanced, so the platform correctly withheld (blinded) the effect estimates.
+
+**v5 is the go-forward that makes that contrast answerable without over-claiming, finishes the two analyses Dr. Bock added in v4.1, closes the outstanding open questions, and grounds the whole plan in the live database.** Five moves:
+
+1. **Rescue the delay-effect causal design** — replace 1:1 propensity matching with overlap weighting (ATO), add a target-trial emulation and a site-preference instrumental variable.
+2. **Complete Analyses M and N** — the comorbidity comparison matrix and the BP-distribution/variance analysis, neither of which appears in the v4 manuscript.
+3. **Stress-test the 90%-undiagnosed phenotype** — index-rule, threshold, surveillance/recording bias, informative-visit, and quantitative bias analysis.
+4. **Close the fourteen open questions** — each with a recommended default and rationale.
+5. **Formalize Parthenon validation** — an explicit verification-and-validation acceptance matrix.
+
+The consolidated program remains dual-protocol: Protocol #1 (retrospective, executable) advances to v5; Protocol #2 (prospective BP-capture pilot) carries a readiness plan.
+
+---
+
+## 1. The central change — rescuing the delay-effect estimand
+
+### 1.1 Why the v4 contrast failed (diagnosed, not hand-waved)
+
+A propensity contrast is trustworthy only where the two groups overlap. Two facts destroyed that overlap in v4:
+
+- **Determinism of delay.** Whether a patient is diagnosed quickly or slowly is driven by the same covariates the propensity model uses (age, care-site type, visit frequency, number of recording sites, baseline BP). AUC 0.7984 means the model can almost separate the groups from covariates alone — the opposite of equipoise.
+- **Extreme size and event asymmetry.** 139 timely versus 9,896 delayed. 1:1 matching discards almost the entire delayed arm and still cannot find timely matches. The live database makes the deeper problem explicit: the G4-vs-G1 contrast rests on **18 MACE and 26 CKD events across both arms combined.** No weighting scheme recovers a reliable causal estimate from that.
+
+The fix is therefore not a better matching algorithm; it is a different estimand (defined only where overlap exists) or an identification strategy that does not rely on within-tail comparability.
+
+### 1.2 Estimand changes (v4 → v5)
+
+| Element | v4 | v5 |
+|---|---|---|
+| Primary comparator method | 1:1 PSM (caliper 0.2 SD) | **Overlap weighting (ATO)**; PSM demoted to sensitivity |
+| Primary exposure contrast | Five-level delay group; tail G4-vs-G1 estimation | **Binary timely (≤ 3 mo) vs delayed (> 3 mo)**; 4-group gradient kept as secondary dose-response |
+| Target population | (implicit ATT via matching) | **Overlap (ATO) population** — the clinical-equipoise patients |
+| Immortal-time / reverse-causation handling | Not addressed for the delay contrast | **Target-trial emulation** (clone-censor-weight + IPCW), time zero = index t2 |
+| Unmeasured-confounding robustness | Negative-control calibration only | Adds a **site diagnostic-propensity instrument** (2SRI) as a natural experiment |
+| Estimability gate on report | AUC / SMD thresholds; withhold if failed | **Retained and extended** — weighted |SMD| < 0.1, equipoise ≥ 0.3, calibrated null centered; withhold otherwise |
+
+### 1.3 New analyses added for the causal redesign
+
+- **Analysis O — Overlap-weighted delay effect (primary).** ATO-weighted Cox for MACE and CKD, timely vs delayed, with the 4-group gradient as a secondary trend test.
+- **Analysis P — Target-trial emulation.** "Record HTN diagnosis and initiate antihypertensive within 90 days of index" vs not, via clone-censor-weight with stabilized IPCW; 30/180-day grace as sensitivity; explicit immortal-time unit test.
+- **Analysis R — Site diagnostic-propensity instrument.** Leave-one-out site diagnosis propensity as an instrument for individual delay; first-stage F, tertile-balance falsification, negative-control-outcome check; reported only as triangulation, never as the sole basis for a conclusion.
+- **Analysis Q — Phenotype robustness + quantitative bias.** Index-rule and threshold sensitivity, surveillance/recording-bias checks, informative-visit process, E-values, probabilistic bias analysis.
+
+A **triangulation summary** (`results.htn_v4_triangulation`) reports the delay→outcome effect from O, P, and R side by side; concordance strengthens the claim, divergence is reported transparently.
+
+---
+
+## 2. Completing Analyses M and N (Bock v4.1)
+
+The v4.1 change request (Dr. Bock, 2026-05-23) added two analyses. **Neither appears in the v4 manuscript, and the live database confirms neither was executed** (study 165 has only four analysis rows: one characterization, one incidence, two estimation). v5 executes both, exactly as scoped.
+
+| Analysis | Scope | v5 status |
+|---|---|---|
+| **M — Comorbidity comparison matrix** | 17 morbidities × six populations (g1–g4, never-diagnosed, comparator C) × {pre-existing, newly-occurring}; Wilson CIs; chi-square/Fisher pairwise; logistic OR vs C (unadjusted + adjusted); heatmap + CSV | **Executed** |
+| **N — BP distribution & variance at t1/t2/t_dx** | Per-group distribution stats, KDE, per-person deltas, below-trigger (RTM/white-coat) fraction, Stage split; Kruskal-Wallis / Dunn / Levene / Fligner-Killeen; ridgelines, violin+box, paired-arrow trellis | **Executed** |
+
+Both join the study-wide negative-control-calibrated FDR family; the analysis-plan lock is re-issued as v5.0 with M/N/O–R in the amendment log.
+
+---
+
+## 3. Open questions — resolved for v5
+
+All fourteen open questions carried out of the v4 consolidation are resolved with a recommended default (PI sign-off recorded in the go-forward document, ACUM-PROT-HTN-V5-001).
+
+| # | Question | v4 status | v5 resolution |
+|---|---|---|---|
+| 1 | Max gap between consecutive elevated BPs | Open | 365-day cap, distinct calendar days; sensitivity 90/180 |
+| 4 | Antihypertensive scope | Open | ATC C02–C09 primary; JNC-8 first-line sensitivity |
+| 5 | Comparator method | Open | **Overlap weighting (ATO) primary; PSM sensitivity** |
+| 6 | Max follow-up window | Open (all-available implied) | 5 yr primary; all-available sensitivity; 1-yr landmark |
+| 7 | Cost / utilization fidelity | Open | **Settled empirically — `omop.cost` is empty; utilization proxies only, CAUTION** |
+| 8 | Sample-size justification | Open | Positivity-bound, not N-bound; report minimum detectable HR per contrast |
+| 10 | Renal-denervation code completeness | Open | Validate procedure + device codes against registry |
+| 11 | Index BP rule (avg vs two-consecutive) | Open | Run both; default average_of_two_recent; report both (feeds Q) |
+| 12 | Lu reproducibility framing | Open | Sensitivity analysis F |
+| 13 | Kidney exclusion wording | Open | Retain dx_ckd exclusion AND capture eGFR/CrCl covariate |
+| 14 | Drug dose fidelity | Open | Scope dose to RxNorm strength if drug_exposure sparse |
+| 15 | Protocol #2 IRB framing | Open | Expedited cat. 7 (QI/human-factors); partner-IRB pre-consult |
+| 16 | Protocol #2 EPIC integration | Open | Two layers — EPIC-side out-of-platform; Parthenon ingests post-pilot data |
+| 9 | IRB / data-governance | Framework resolved | File administrative review for exemption; framework unchanged from v4 Part 3 |
+
+---
+
+## 4. Live-database grounding (new in v5) — what reconciled and what surfaced
+
+Read-only reconciliation against `pgsql.acumenus.net` / `parthenon` on 2026-07-03. **Every headline figure in the v4 manuscript matched the database exactly.**
+
+### 4.1 Confirmed to the digit
+
+| Quantity | Live DB (cohort_definition_id) | Manuscript |
+|---|---|---|
+| Target T | 109,763 (5441) | 109,763 |
+| G1 / G2 / G3 / G4 | 139 / 284 / 675 / 9,896 (5450–5453) | identical (sum = T) |
+| Never-diagnosed | 98,769 (5454) | identical |
+| Comparator C | 37,582 (5455) | (new detail) |
+| Elevated vs normotensive | AUC 0.5723, equipoise 0.9884, max SMD 0.0155, EASE 0.0197; calibrated MACE HR 1.0345, CKD HR 2.6024 | identical |
+| Delayed vs timely | AUC 0.7984, equipoise 0.9255, max SMD 0.2443 | identical (withheld) |
+
+### 4.2 New facts the manuscript understated or omitted (each shapes v5)
+
+- **Study state.** The study is `app.studies` id 165, slug `hypertension-study-v4`, `protocol_version` ACUM-PROT-HTN-V4-001, status **`running`** / phase `analysis` — not `run_complete`, and there is no `htn-v4-bock-2026` key. v5 continues study 165 in place.
+- **Executed scope is lean.** Only **4** analyses ran (Characterization, IncidenceRateAnalysis, two EstimationAnalyses = T-vs-C and G4-vs-G1). **Lettered analyses B–L and M/N were never separate executed analyses**, and **S1 (resistant-HTN) and S2 (renal-denervation) cohorts do not exist.** Most of the v5 inventory is net-new build, not reuse.
+- **No plan lock was ever persisted.** `app.study_artifacts` for study 165 = 0 rows. The v5 `lock` step is a first-time write, not a re-issue.
+- **The delay contrast is empirically hopeless as posed.** 18 MACE and 26 CKD events total across G1+G4, plus a degenerate negative control (log_rr ≈ 30.9). This is the empirical proof that both positivity and power fail — the core motivation for Analyses O/P/R.
+- **`omop.cost` is empty (0 rows).** OQ-7 is settled: no cost analysis; utilization proxies only.
+- **Care-site typing is degraded.** `care_site.place_of_service_concept_id` is unpopulated; `person.care_site_id` and `person.provider_id` are **100% empty**. Care-site type must be derived from source-value heuristics.
+- **Encounter coverage is partial — the single most consequential finding.** `visit_occurrence.care_site_id`/`provider_id` are 100% populated (2,405 sites / 1,818 providers in use), but **only 41,642 / 109,763 (37.9%) of T have any `visit_occurrence` row.** The other ~62% carry qualifying BPs in `measurement` with no encounter link.
+  - **Site-IV feasibility:** assigning T to most-recent-visit care site gives 2,314 sites hosting T, **521 with ≥ 25** (191 ≥ 50, 40 ≥ 100) — the instrument is structurally viable but covers only the ~38% visit-linked subset. `person.location_id` (100% populated, 3,027 locations) is the full-coverage fallback instrument.
+  - **Phenotype implication:** a large share of the "90% never diagnosed" may be measurement-only patients whose data feed lacks encounters — a linkage artifact, not necessarily clinical inaction. Analysis Q investigates this first.
+- **Source CDM size:** `omop.person` ≈ 1,005,788; `measurement` ≈ 710M; `drug_exposure` ≈ 86M; `visit_occurrence` ≈ 52M.
+
+---
+
+## 5. Substantive content changes (v4 → v5)
+
+| Area | v4 | v5 | Impact |
+|---|---|---|---|
+| Version / doc ID | ACUM-PROT-HTN-V4-001 | ACUM-PROT-HTN-V5-001 (companion go-forward) | New protocol lineage node |
+| Primary causal estimand | Tail G4-vs-G1 PSM (not estimable) | ATO overlap-weighted timely-vs-delayed | The core fix |
+| Comparator method (OQ-5) | 1:1 PSM | Overlap weighting; PSM = sensitivity | Estimability |
+| Immortal-time bias | Unaddressed for delay | Clone-censor-weight target trial | Removes a key bias |
+| Unmeasured confounding | Negative-control calibration | + site-preference IV + E-values | Triangulation |
+| Analyses M, N | Requested (v4.1), not run | Executed | Closes v4.1 |
+| Analyses O, P, Q, R | — | New | Causal + phenotype workstream |
+| Phenotype scrutiny | Implicit | Analysis Q + QBA | Guards the 90% headline |
+| Cost analysis (L, OQ-7) | Conditional on omop.cost | Utilization proxies mandatory (cost empty) | Data-grounded |
+| Care-site typology | place_of_service assumed usable | Source-value heuristics; ~38% coverage caveat | Data-grounded |
+| S1 / S2 cohorts | Described in prompt | Confirmed absent; net-new if E/I run | Scope honesty |
+| Analysis-plan lock | Assumed persisted | Confirmed absent; v5.0 is first lock | Reproducibility |
+| Parthenon validation | Implicit | Explicit V&V acceptance matrix | Platform-validation framing |
+
+---
+
+## 6. Net effect on the Parthenon executable plan
+
+- **Study container.** Continue `app.studies` id 165 (slug `hypertension-study-v4`); bump `analysis_plan_version` to v5.0; extend `StudyHtnV4` command with `--version=v5` actions (reuse-audit, concept-sets, cohorts, analyses, lock, run, report).
+- **Concept sets.** Reuse all v4 sets; add the 15 new M-morbidity sets (diabetes, dyslipidemia, obesity, sleep apnea, CKD progression, COPD, depression/anxiety, CAD, PVD, cerebrovascular disease, atrial fibrillation, hypertensive retinopathy, cancer, dementia, liver disease).
+- **Cohorts.** Reuse T (5441), C (5455), G1–G4 (5450–5453), never-diagnosed (5454), O1 MACE (5426), O2 CKD (5427). Build **net-new**: S1/S2 (if E/I run), the ATO weight construct, the clone-censor-weight target-trial dataset, the phenotype-sensitivity grid, and the site-IV instrument (restricted to the visit-linked subset).
+- **Analyses.** Retain A–L (re-estimate C/F/G/H under ATO); execute M/N; add O/P/Q/R; re-run negative-control calibration across the expanded FDR family; report EASE per family.
+- **Guardrails.** ATO exact-balance verified on PS main-effect moments only; stabilized IPCW with weight-distribution reporting; IV assumptions stated and tested; E-values and QBA for every headline effect; estimability gates enforced (withhold if failed).
+- **Lock.** Persist `analysis_plan_v5.0.lock.json` to `study_artifacts` before `run`; the report verifies the hash.
+- **Report.** New v5 HTML + PDF: triangulation figure (O/P/R), ATO love/forest plots, M heatmap, N ridgelines/violin/trellis, Q robustness panel, negative-control calibration, and the V&V acceptance matrix.
+
+---
+
+## 7. Protocol #2 — prospective BP-capture pilot (readiness, unchanged design)
+
+No design change from v4. v5 specifies the readiness path so it can launch on Protocol #1 sign-off:
+
+- **EPIC integration (OQ-16):** two layers — (a) EPIC-side order-set + 2025 AHA/ACC technique training, out-of-platform; (b) a Parthenon study `htn-pilot-bp-capture-2026` that ingests post-pilot OMOP-mapped data and runs the comparability + outcome analyses.
+- **IRB framing (OQ-15):** pursue expedited cat. 7 (QI / human-factors), characterize site allocation as cluster-randomized, partner-IRB pre-consult before site engagement.
+- **Executable-in-Parthenon now:** subject selection from the Protocol #1 cohort, baseline comparability, in-office BP trajectory, ABPM correlation, CV/renal outcomes, eGFR trajectory, prescribing, reproducibility.
+- **Regulatory reminder:** Protocol #2 is prospective interventional research — the 45 CFR 46.101(b)(4) exemption and cat. 5 expedited paths do NOT apply.
+
+---
+
+## 8. IRB & data-governance
+
+No change from v4 Part 3. Protocol #1 remains a 45 CFR 46.101(b)(4) Exempt candidate under administrative review, contingent on no re-identification crosswalk inside the Acumenus boundary. Analyses M/N/O–R are additive on the same data source under the same posture — **no new IRB filing is triggered**; append a v5 amendment note to the existing filing stub. HIGHSEC route protection, immutable audit trail, and analysis-plan pre-registration are retained. (Note: `study_artifacts` currently has 0 rows for study 165, so the IRB stub and the plan lock are both first-time writes in v5.)
+
+---
+
+## 9. Reconciled open-question list (post-v5)
+
+| # | Question | Status | Owner |
+|---|---|---|---|
+| 1 | Max gap between consecutive elevated BPs | **Resolved** (365 d cap, distinct days) | Bock ✓ |
+| 2 | Latency bucketing | Resolved (4 groups) | — |
+| 3 | Lu 2025 citation | Resolved | — |
+| 4 | Antihypertensive scope | **Resolved** (ATC C02–C09) | Bock ✓ |
+| 5 | Comparator method | **Resolved** (ATO overlap weighting) | Bock + Sanjay ✓ |
+| 6 | Max follow-up | **Resolved** (5 yr + all-available sensitivity) | Bock ✓ |
+| 7 | Cost fidelity | **Resolved empirically** (omop.cost empty → proxies) | Sanjay ✓ |
+| 8 | Sample-size justification | **Resolved** (positivity-bound; min detectable HR) | Bock + Sanjay ✓ |
+| 9 | IRB / data-governance | Framework resolved; filings pending | Sanjay → partner IRB |
+| 10 | Renal-denervation code completeness | **Resolved** (registry validation step) | Sanjay ✓ |
+| 11 | Index BP rule (avg vs two-consecutive) | **Resolved** (both; default avg) | Bock ✓ |
+| 12 | Lu reproducibility framing | **Resolved** (sensitivity F) | Bock ✓ |
+| 13 | Kidney exclusion wording | **Resolved** (exclude + covariate) | Bock ✓ |
+| 14 | Drug dose fidelity | **Resolved** (RxNorm strength if sparse) | Sanjay ✓ |
+| 15 | Protocol #2 IRB framing | **Resolved path** (expedited cat. 7) | Bock + partner IRB |
+| 16 | Protocol #2 EPIC integration | **Resolved path** (two-layer) | Sanjay + eng |
+| NEW-17 | Encounter-coverage gap (37.9% of T have visits) | **Open — investigate in Analysis Q** | Sanjay |
+| NEW-18 | Care-site typing without place_of_service | **Open — source-value heuristics** | Sanjay + eng |
+
+---
+
+## 10. Recommended next actions
+
+1. Obtain PI sign-off on the estimand redesign (§1), the open-question resolutions (§3), and the Protocol #2 readiness path (§7) via the go-forward document ACUM-PROT-HTN-V5-001.
+2. Extend study 165 in place: bump to `analysis_plan_version=v5.0`, add the M concept sets and the O/P/Q/R constructs, and persist the first analysis-plan lock.
+3. Run Analysis Q's encounter-coverage split (visit-linked vs measurement-only) **before** publishing any "90% undiagnosed" figure — it determines how the headline is framed (NEW-17).
+4. Build the site-IV on the visit-linked subset (521 sites ≥ 25) with the location-level fallback instrument; report the ~38% selection explicitly.
+5. Re-run negative-control calibration across the expanded M/N/O–R family; block reporting of any contrast whose calibrated null is not centered or whose estimability gates fail.
+6. Schedule the partner-university IRB pre-consult covering both protocols; append the v5 amendment note to the (first-time) IRB filing stub.
+7. Persist `analysis_plan_v5.0.lock.json` before any production run; render the v5 report with the V&V acceptance matrix.
+
+— *End changelog.*

--- a/docs/research/CLAUDE_PROMPT_v5.md
+++ b/docs/research/CLAUDE_PROMPT_v5.md
@@ -1,0 +1,408 @@
+# Claude-Code Prompt — Hypertension Outcomes Program v5 (Protocol #1 executable; Protocol #2 readiness)
+
+**Protocol:** "The failure of hypertension interventions in a large study population (V5)" — Protocol #1 of the consolidated Hypertension Outcomes Program, with the Protocol #2 prospective pilot carried as a readiness workstream.
+**PI:** Glenn H. Bock, MD. **Consolidation editor / CMIO:** Sanjay M. Udoshi, MD.
+**Doc ID:** ACUM-PROT-HTN-V5-001. **Date:** 2026-07-03.
+**Use case:** Retrospective outcomes study against the Acumenus OHDSI CDM, executed inside Parthenon (OMOP CDM v5.4, schema-isolated). Single data source: Acumenus OHDSI CDM (`omop` schema, `omop` connection).
+**Mode:** **Extend the existing `htn-v4-bock-2026` study in place.** Do NOT fork a new study container. Reuse valid v4 concept sets, cohorts, and generations; re-lock the analysis plan as **v5.0**; add analyses M, N (from the v4.1 amendment) and O–R (the v5 causal redesign + phenotype stress-test); render a new v5 report.
+
+> Read alongside: `CHANGELOG_v3_to_v4.md`, `CHANGE_REQUEST_v4.1_Bock_2026-05-23.md`, the v4 prompt `CLAUDE_PROMPT.md`, `Hypertension_v4_Consolidated_Acumenus.docx`, and the v5 go-forward doc `Hypertension_v5_GoForward_Acumenus.docx` (ACUM-PROT-HTN-V5-001). This prompt supersedes the analyses section of the v4 prompt and is additive to everything else.
+
+---
+
+## 0 — Mission
+
+The v4 run succeeded on everything except the one contrast that mattered most: **delayed vs timely diagnosis (G4 vs G1) was not estimable** — the propensity model reached AUC 0.7984 with a maximum post-adjustment SMD of 0.2443, so the effect was correctly withheld. v5's mission is to make that causal question answerable without over-claiming, complete the two v4.1 analyses (comorbidity matrix M and BP-distribution N) that never landed in the v4 manuscript, stress-test the 90%-never-diagnosed phenotype, resolve the fourteen open questions with the defaults the PI signs off, and produce the platform's reference validation artifacts.
+
+Concretely, v5:
+
+1. Replaces 1:1 PSM (OQ-5) with **overlap weighting (ATO)** as the primary effect-estimation method for every delay contrast, collapsing the primary exposure to **timely (≤ 3 mo) vs delayed (> 3 mo)** with the four-group gradient retained as a secondary dose-response (Analysis **O**).
+2. Adds a **target-trial emulation** of "record HTN diagnosis + initiate antihypertensive within 90 days of index" via **clone-censor-weight with IPCW** (Analysis **P**).
+3. Adds a **site diagnostic-propensity instrumental-variable** analysis as a natural experiment robust to unmeasured confounding (Analysis **R**).
+4. Adds a **phenotype robustness + quantitative-bias** workstream (index-rule, threshold, surveillance/recording bias, informative-visit, E-values) (Analysis **Q**).
+5. Executes **Analysis M** (comorbidity comparison matrix) and **Analysis N** (BP distribution & variance at t1/t2/t_dx) exactly as scoped in the v4.1 change request.
+6. Re-estimates the retained effect analyses (C, G, H, F) under the ATO estimand and re-runs negative-control calibration across the expanded FDR family.
+7. Re-locks the analysis plan as `analysis_plan_v5.0.lock.json` and records M/N/O–R in the amendment log.
+
+**Baseline facts to preserve (from the v4 manuscript — do not recompute as if unknown; reconcile against them):** T = 109,763; never-diagnosed = 98,769 (90%); diagnosed = 10,994 (G1 139 / G2 284 / G3 675 / G4 9,896); latency_a median 175 d (IQR 84–266); latency_b median 1,106 d (IQR 704–1,862); time-to-first-drug median 1,134 d; MACE 7.00/1k py; CKD 1.67/1k py; ever-treated 18,930 (17.2%); elevated-vs-normotensive calibrated MACE HR 1.03 (0.94–1.14) p 0.50, CKD HR 2.60 (2.01–3.38) p < 0.0001.
+
+> **Live-DB verification (pgsql.acumenus.net · db=parthenon · read-only, 2026-07-03).** All of the above reconciled **exactly** against the production database. Ground truth for the executor:
+> - **Study row:** `app.studies.id = 165`, `slug = 'hypertension-study-v4'`, `protocol_version = 'ACUM-PROT-HTN-V4-001'`, `status = 'running'`, `phase = 'analysis'` (NOT `run_complete`; there is no `key = 'htn-v4-bock-2026'` column — the study is identified by `slug`/`id`).
+> - **Cohorts (17 rows in `app.study_cohorts`, study_id 165):** T `cohort_definition_id 5441` = 109,763; C `5455` = 37,582; G1 `5450` = 139; G2 `5451` = 284; G3 `5452` = 675; G4 `5453` = 9,896; never-diagnosed `5454` = 98,769; O1 MACE `5426`; O2 CKD `5427`; plus 8 negative-control cohorts. **G1–G4 + never sum to 109,763 exactly.** **No S1 (resistant-HTN) or S2 (renal-denervation) cohort exists** — treat these as net-new builds, not reuse.
+> - **Analyses actually executed (`app.study_analyses`, study_id 165):** only **4** — one `Characterization` (Table 1), one `IncidenceRateAnalysis` (MACE/CKD crude rates), and **two** `EstimationAnalysis` rows: result 21 = T(5441)-vs-C(5455) and result 22 = G4(5453)-vs-G1(5450). **Lettered analyses B–L and M/N were never separate executed analyses** — most of the v5 analysis inventory (and all of M/N/O–R) is net-new.
+> - **Estimation diagnostics (verbatim from `app.study_results.summary_data`):** result 21 — PS AUC 0.5723, equipoise 0.9884, max |SMD| after 0.0155, EASE 0.0197 (8 NCs); calibrated MACE HR 1.0345 (0.9365–1.1428), CKD HR 2.6024 (2.0065–3.3754). result 22 — PS AUC 0.7984, equipoise 0.9255, **max |SMD| after 0.2443**; only **18 MACE and 26 CKD events total across G1+G4**, and one negative control degenerate (log_rr ≈ 30.9) → diagnostics failed, estimates correctly withheld. The 18/26-event reality is the empirical proof that positivity AND power both fail for a direct G4-vs-G1 contrast — the core motivation for O/P/R.
+> - **`app.study_artifacts` for study 165 = 0 rows** → no `analysis_plan.lock` was ever persisted. The v5 `lock` step is therefore a first-time write, not a re-issue.
+> - **Source CDM:** `omop.person` ≈ 1,005,788; `omop.measurement` ≈ 710M; `omop.drug_exposure` ≈ 86M; `omop.visit_occurrence` ≈ 52M. **`omop.cost` = 0 rows** (OQ-7 settled — see §4.0/§9). `omop.care_site` = 5,630 rows but `place_of_service_concept_id` is unpopulated (null/0 or "No matching concept") → care-site typology cannot use `place_of_service`; derive from `care_site_source_value`/name heuristics and flag as a data-quality risk.
+> - **Site-IV feasibility (Analysis R, measured):** `person.care_site_id`/`person.provider_id` are 100% empty; `visit_occurrence.care_site_id`/`provider_id` are 100% populated (2,405 sites / 1,818 providers in use). Assigning T to most-recent-visit care site → 2,314 sites host T, **521 sites have ≥ 25 T patients** (191 ≥ 50, 40 ≥ 100). **Critical caveat: only 41,642/109,763 (37.9%) of T have any visit** — the IV and care-site covariate cover only that subset; `person.location_id` (100% populated, 3,027 locations) is the full-coverage fallback instrument. See §4.4 and §5.5.
+
+---
+
+## 1 — Pre-flight
+
+1. `docker compose ps` — confirm `php`, `postgres`, `redis`, `solr`, `r-runtime`, `python-ai`, `horizon`, `node` healthy.
+2. Confirm the study and its v4 state (verified 2026-07-03): it is `app.studies.id = 165`, `slug = 'hypertension-study-v4'`, `protocol_version = 'ACUM-PROT-HTN-V4-001'`, currently `status = 'running'` / `phase = 'analysis'`. `php artisan tinker --execute="echo App\Models\App\Study::where('slug','hypertension-study-v4')->value('status');"`. Do NOT assume `run_complete` — v4 left the study mid-flight with only 4 analyses executed; v5 continues it. Operate on `id 165`; there is no `key`/`htn-v4-bock-2026` column.
+3. Confirm the Acumenus OMOP source (`omop`): `search_path = omop,vocab,php`; `source_daimons` maps `vocabulary → vocab`. Vocab coverage `SELECT count(*) FROM vocab.concept_ancestor;` ≥ 100M.
+4. Parthenon Brain — search for reusable assets before drafting new ones:
+   - `chroma_query parthenon_docs query="overlap weighting ATO propensity Parthenon"`
+   - `chroma_query parthenon_docs query="clone censor weight target trial emulation"`
+   - `chroma_query parthenon_docs query="instrumental variable provider preference OMOP"`
+   - `chroma_query parthenon_code query="StudyDesignToolRunner r-runtime survival payload"`
+   - `chroma_query parthenon_code query="NegativeControlService EmpiricalCalibration EASE"`
+5. Re-read `.claude/rules/HIGHSEC.spec.md` and `.claude/rules/auth-system.md`. No new rule violations.
+6. **IRB artifact pre-check** — Protocol #1 remains a 45 CFR 46.101(b)(4) Exempt candidate. Confirm the partner-IRB administrative-review filing stub exists in `study_artifacts(kind=irb_filing)`; if the v4 stub is present, append a v5 amendment note referencing analyses M/N/O–R (no new IRB filing is triggered — additive analyses on the same data source under the same posture).
+7. **Reuse audit** — enumerate v4 assets to reuse vs re-materialize:
+   - Concept sets: reuse all v4 sets; ADD the M morbidity sets (§3).
+   - Cohorts T (5441), C (5455), G1–G4 (5450–5453), never-diagnosed (5454), O1 MACE (5426), O2 CKD (5427): reuse generations if the index_rule and exclusion params are unchanged; re-materialize only if §4 parameters change them. **S1 (resistant-HTN) and S2 (renal-denervation) do not exist in the DB — build them net-new** if Analyses E/I are to run.
+   - Print a reuse manifest to `docs/research/hypertension-v3/docs/v5-reuse-manifest.md`.
+
+---
+
+## 2 — Study container (amendment, not new)
+
+Operate on the existing row `app.studies.key = htn-v4-bock-2026`. Bump metadata:
+
+```
+analysis_plan_version:  v5.0            (was v4.1)
+status:                 draft → run_complete (after v5 run)
+phi_review:             45_cfr_46_101_b_4_pending   (unchanged)
+parent_protocol_id:     ACUM-PROT-HTN-V4-001
+child_doc_id:           ACUM-PROT-HTN-V5-001        (v5 go-forward)
+```
+
+Extend the existing command `backend/app/Console/Commands/StudyHtnV4.php` (do NOT create a competing command) with a `--version` option defaulting to `v5`, and add actions:
+
+```
+php artisan study:htn-v4 --action=reuse-audit    --version=v5
+php artisan study:htn-v4 --action=concept-sets   --version=v5   # adds M morbidity sets only
+php artisan study:htn-v4 --action=cohorts        --version=v5   # design constructs (§4)
+php artisan study:htn-v4 --action=analyses       --version=v5   # A–N re-spec + O–R
+php artisan study:htn-v4 --action=lock           --version=v5   # writes analysis_plan_v5.0.lock.json
+php artisan study:htn-v4 --action=run  --source=omop --version=v5
+php artisan study:htn-v4 --action=report         --version=v5
+```
+
+Update the idempotent seeder `HypertensionV4StudySeeder.php` to register the v5 analysis-plan version and the M/N/O–R analysis rows without duplicating v4 rows (upsert by `(study_id, analysis_id, plan_version)`).
+
+**The `lock` step remains mandatory and must run before `run`.** `analysis_plan_v5.0.lock.json` supersedes `analysis_plan_v4.1.lock.json`; both are retained in `study_artifacts(kind=analysis_plan_lock)`. The report verifies the v5 lock hash before rendering and rejects a run if the lock is missing or modified.
+
+---
+
+## 3 — Concept sets (v5 delta)
+
+Reuse every v4 concept set unchanged (`dx_essential_hypertension`, `dx_ckd`, `dx_mi/stroke/heart_failure`, `lab_sbp/dbp`, `rx_antihypertensives_all` and class subsets, `obs_bmi`, `obs_creatinine_clearance`, `dx_family_hx_htn`, `lab_tsh`, `proc_renal_denervation`, `device_abpm`, `device_home_bp_monitor`, etc.).
+
+**ADD (Analysis M morbidity list)** — materialize via `StudyConceptSetDraftService → StudyConceptSetMaterializer`, verify each with `StudyConceptSetDraftVerifier` (zero `unresolved_concept` rows). Vocabularies SNOMED unless noted:
+
+| Key | Vocab | Description |
+|---|---|---|
+| `dx_diabetes_mellitus` | SNOMED | DM type 1 + 2 + descendants |
+| `dx_dyslipidemia` | SNOMED | hyperlipidemia / dyslipidemia umbrella |
+| `dx_obesity` | SNOMED | obesity dx (+ derived `obs_bmi` ≥ 30 as sensitivity) |
+| `dx_sleep_apnea` | SNOMED | OSA + descendants |
+| `dx_ckd_progression` | SNOMED | CKD stage transitions (newly-occurring only; pre-index CKD excluded) |
+| `dx_copd` | SNOMED | COPD + descendants |
+| `dx_depression_anxiety` | SNOMED | depression + anxiety umbrella |
+| `dx_coronary_artery_disease` | SNOMED | CAD (excluded pre-index; tracked post) |
+| `dx_peripheral_vascular_disease` | SNOMED | PVD |
+| `dx_cerebrovascular_disease` | SNOMED | CVD (excluded pre-index; tracked post) |
+| `dx_atrial_fibrillation` | SNOMED | AF + flutter |
+| `dx_hypertensive_retinopathy` | SNOMED | hypertensive retinopathy |
+| `dx_cancer_all` | SNOMED | malignant neoplasm umbrella |
+| `dx_dementia` | SNOMED | dementia umbrella |
+| `dx_liver_disease` | SNOMED | chronic liver disease / cirrhosis |
+
+`dx_heart_failure` and `dx_primary_aldosteronism` already exist — reuse.
+
+**Derived attributes (NOT concept sets), materialized in §4:**
+- `care_site_type` ∈ {medicaid_clinic, provider_office, office_with_trainees, hospital_outpatient, other} — already derived in v4; reuse the persisted `study_artifacts(kind=care_site_typology_map)`.
+- `site_dx_propensity` — per-`care_site` leave-one-out diagnostic propensity used as the Analysis R instrument (§4.4).
+
+Re-run the **negative-control outcome set** (Gingivitis, Viral sinusitis, Primary dental caries, Acute viral pharyngitis, Acute bronchitis, Chronic sinusitis, Loss of teeth, Otitis media — the eight used in v4) against the expanded M/N/O–R hypothesis space so empirical calibration stays valid across the enlarged FDR family. Add 2–4 additional negative controls if `NegativeControlService` recommends them for the new outcome/exposure pairs.
+
+---
+
+## 4 — Cohort definitions & v5 design constructs
+
+`StudyCohortDraftService → StudyCohortMaterializer`; each cohort keeps its `CohortDefinition` row, Achilles-style SQL template (`{@cdmSchema}` / `{@vocabSchema}`), and `CohortGeneration` per source. **Reuse v4 T, C, S1, S2, O1, O2 unchanged** except for the parameter resolutions below and the new constructs.
+
+### 4.0 Parameter resolutions (OQ sign-offs baked in)
+
+| Param | v5 value | OQ |
+|---|---|---|
+| `index_rule` | run BOTH; primary `average_of_two_recent`; report both | OQ-11 |
+| `max_gap_between_consecutive_bps_days` | 365 (sensitivity 90 / 180); distinct calendar days required | OQ-1 |
+| `bp_threshold` | 130/80 primary; 140/90 sensitivity | phenotype |
+| `rx_scope` | ATC C02–C09 primary; JNC-8 first-line sensitivity | OQ-4 |
+| `comparator_method` | **ATO overlap weighting primary**; 1:1 PSM (caliper 0.2 SD) sensitivity | OQ-5 |
+| `max_followup_days` | 1825 (5 yr) primary; all-available sensitivity; landmark at 365 d | OQ-6 |
+| `lab_window_days` | ±28 | v4b |
+| `delay_group_cutoffs_months` | [3, 6, 12] → g1–g4 + never_diagnosed | v4b |
+| `dose_fidelity` | RxNorm strength if `drug_exposure.dose_unit_source_value` sparse | OQ-14 |
+| `dx_ckd` | retain as EXCLUSION AND capture eGFR/CrCl covariate | OQ-13 |
+
+Persist the resolved parameter set into `study_artifacts(kind=v5_parameter_resolution)` and reference it in the lock.
+
+### 4.1 Overlap-weight construct (Analysis O)
+
+Build a modeling table `results.htn_v4_o_weights` at the **T-member** grain, restricted to the **diagnosed** subset (n≈10,994), with:
+- `exposure_binary` = 1 if `delay_group == 1` (timely ≤ 3 mo) else 0 (delayed > 3 mo). Also keep the 4-level `delay_group` for the secondary gradient.
+- Propensity model covariates: age, sex, race, BMI, family_history_htn, care_site_type, eGFR/CrCl, baseline SBP/DBP at index, number of BP-recording sites, BP-recording frequency (per year), region/population-density quintile, calendar quarter of index.
+- Fit the PS in `r-runtime` (`WeightIt` or `PSweight`, `estimand = "ATO"`). Compute **overlap weights** `w = (1 - e)` for treated and `w = e` for controls.
+- Emit weighted `Table 1` with SMDs. Under a **logistic PS with the covariates entered as main effects**, ATO **exactly balances the mean of each included covariate** (Li–Morgan–Zaslavsky) — verify all |SMD| < 0.001 on those main-effect moments as a build check. This does NOT guarantee balance on interactions, non-linear terms, or any covariate omitted from the PS; check those separately and add terms to the PS if imbalanced.
+- Persist propensity distribution + weighted equipoise for the estimability gate.
+
+### 4.2 Target-trial clone-censor-weight dataset (Analysis P)
+
+Build `results.htn_v4_p_target_trial` at the **T-member × strategy-clone × interval** grain:
+- Eligibility: all treatment-naïve T members at time zero = index second-elevated reading (t2). Include the never-diagnosed (they are the natural "no-treatment-within-grace" arm).
+- Two strategies: **A** = "record HTN dx AND initiate an antihypertensive within `grace` days of t2"; **B** = "not A within grace." Clone each eligible patient into both arms at t2.
+- Grace period `grace` = 90 d primary; 30 / 180 d sensitivity.
+- Censor a clone when observed data first diverge from its assigned strategy; compute stabilized **inverse-probability-of-censoring weights (IPCW)** from a pooled logistic hazard model of artificial censoring on time-varying covariates.
+- Outcomes: O1 MACE (typed) and O2 incident CKD, with all-cause death as competing risk.
+- Estimand: per-protocol hazard ratio and 5-year risk difference (IPCW-weighted pooled logistic / weighted Cox).
+
+### 4.3 Phenotype-sensitivity cohorts (Analysis Q)
+
+For each `(index_rule, bp_threshold, max_gap)` combination in {average/two-consecutive} × {130-80/140-90} × {90/180/365}, materialize a lightweight T-variant `CohortGeneration` tagged `phenotype_variant=<hash>` and record the **never-diagnosed fraction**, N, and delay-group distribution. Do NOT re-run the full analysis stack per variant — only the counts + the never-diagnosed fraction + median latency. Persist to `results.htn_v4_q_phenotype_grid`.
+
+### 4.4 Site diagnostic-propensity instrument (Analysis R)
+
+> **Feasibility measured on the live DB (2026-07-03).** Assigning each T member to their most-recent visit's `care_site_id`: **2,314** sites host ≥ 1 T patient; **521** have ≥ 25, **191** have ≥ 50, **40** have ≥ 100 — structurally ample for a site instrument. **BUT only 41,642 / 109,763 (37.9%) of T have any `omop.visit_occurrence` row** (`person.care_site_id` and `person.provider_id` are 100% empty; `visit_occurrence.care_site_id`/`provider_id` are 100% populated but ~62% of T patients have no visit at all — their qualifying BPs live in `omop.measurement` without an encounter link). **Consequences:** (a) the care-site instrument and any care-site covariate are available only for the ~38% visit-linked subset — restrict Analysis R to that subset and report the selection explicitly; (b) this visit-vs-no-visit split is itself an informative-visit signal — feed it into Analysis Q; (c) as a full-coverage fallback instrument, `omop.person.location_id` is 100% populated (3,027 distinct locations) — a region-level diagnostic-propensity instrument covers all of T but is more distal (weaker, more confounding-prone), so use it only as a triangulation sensitivity.
+
+For each `care_site_id` with ≥ 25 treatment-naïve elevated-BP patients (521 such sites exist), compute a **leave-one-out** instrument value:
+- `site_dx_propensity_loo` = proportion of the site's other patients diagnosed within 90 d of their index (and, as an alternative continuous instrument, the site's LOO mean `latency_b_days`).
+- Assign each T member their site's LOO value as `Z`.
+- Persist to `results.htn_v4_r_instrument` at T-member grain with `Z`, site size, and the measured covariates for the tertile-balance falsification check.
+
+Persist all four constructs' build provenance (SHA-256 of the generating SQL/R) into `study_artifacts(kind=v5_construct)`.
+
+---
+
+## 5 — Analyses (v5)
+
+`StudyAnalysisPlanService → StudyAnalysisPlanMaterializer`; executed via `StudyDesignToolRunner`. Summary JSONB → `app.study_analyses`; result tables → `results.htn_v4_*`. **A–L retained** (re-estimate C/F/G/H under ATO); **M/N executed**; **O–R new**.
+
+| ID | Analysis | Engine | v5 change |
+|---|---|---|---|
+| A | Cohort characterization (Table 1) | Achilles + R FeatureExtraction | add ATO-weighted Table 1 beside unweighted |
+| B | Prevalence Stage-1+ HTN | SQL | unchanged |
+| C | Diagnostic latency (split intervals) | R survival | KM + 4-group gradient; reconcile to v4 (175 d / 1,106 d) |
+| D | Treatment trajectory (class + dose) | SQL | OQ-14 dose scoping |
+| E | Resistant-HTN composition | SQL | unchanged |
+| F | Sensitivity vs Lu 2025 | R | ATO-weighted; report PASS/FAIL/N-A of 29% CV-risk delta |
+| G | MACE incidence (typed) | R survival | **re-estimate with ATO weights**; competing risk death |
+| H | Incident CKD | R survival | **re-estimate with ATO weights** |
+| I | Renal-denervation eligibility | SQL | code-completeness check (OQ-10) |
+| J | Baseline lab ordering (±28 d) | SQL | unchanged |
+| K | Geographic stratification | GIS | unchanged |
+| L | Cost / utilization | HEOR | **`omop.cost` verified empty (0 rows)** — cost analysis infeasible; use encounter + drug-exposure utilization proxies, mark CAUTION (OQ-7 settled) |
+| **M** | **Comorbidity comparison matrix** | SQL + R | **execute** (v4.1) — §5.1 |
+| **N** | **BP distribution & variance at t1/t2/t_dx** | R | **execute** (v4.1) — §5.2 |
+| **O** | **Overlap-weighted delay effect (PRIMARY)** | R (WeightIt/PSweight) | **new** — §5.3 |
+| **P** | **Target-trial emulation (clone-censor-weight)** | R survival + IPCW | **new** — §5.4 |
+| **Q** | **Phenotype robustness + quantitative bias** | R | **new** — §5.5 |
+| **R** | **Site diagnostic-propensity IV** | R (2SRI) | **new** — §5.6 |
+
+For A, C, F, G, H, O, P, R also write **negative-control outcomes** via `Network/NegativeControlService`; apply OHDSI `EmpiricalCalibration`. Apply Holm-Bonferroni within each analysis family, then join all families to the study-wide negative-control-calibrated FDR pool. **Report EASE per family.**
+
+### 5.1 — Analysis M — Comorbidity comparison matrix (Bock v4.1)
+
+Long-form table `results.htn_v4_m_comorbidity_matrix`, one row per **morbidity × group × epoch**, across all six populations: g1–g4, never_diagnosed, and matched comparator C.
+- **Epochs:** `pre_existing` (any evidence before the T member's t2, or C's synthetic t2_c) and `newly_occurring` (first evidence between index and end of follow-up).
+- **Per cell:** count; prevalence % with **Wilson 95% CI**; for newly-occurring, person-years denominator + **incidence per 1,000 py**; age-and-sex-standardized rate ratio where the denominator is stable.
+- **Tests:** pairwise between delay groups — chi-square (Fisher's exact when any expected cell < 5), Holm-Bonferroni within the pairwise set; each delay group vs C — same test PLUS unadjusted and covariate-adjusted (age, sex, race, BMI, care_site_type) **logistic odds ratios** with 95% CI in `r-runtime`.
+- **Morbidities (17):** diabetes, dyslipidemia, obesity (dx + BMI ≥ 30 sensitivity), sleep apnea, CKD progression, COPD, depression/anxiety, CAD, PVD, cerebrovascular disease, heart failure, atrial fibrillation, hypertensive retinopathy, primary aldosteronism, cancer, dementia, liver disease.
+- **Deliverables:** the long-form table; a compact prevalence **heatmap** (report); the full comparison table with p-values + ORs (report + downloadable CSV).
+
+### 5.2 — Analysis N — BP distribution & variance at index-triggering timepoints (Bock v4.1)
+
+Long-form `results.htn_v4_n_bp_distribution` (member × timepoint) + aggregate `results.htn_v4_n_bp_summary` (group × timepoint).
+- **Timepoints per T member:** `t1` (first elevated), `t2` (second elevated = index), `t_dx` (BP nearest first `dx_essential_hypertension`, ±14 d; else most-recent-prior flagged `t_dx_bp_source='nearest_prior'`).
+- **Comparator alignment:** C aligned to synthetic `t1_c`, `t2_c` (first two BPs in the 24-mo window) and `t_dx_c` placed at the matched T's `latency_b_days` past `t2_c`.
+- **Per group × timepoint, SBP and DBP separately:** N, mean, SD, median, IQR (Q1/Q3), 5th/95th pct, skewness, kurtosis; kernel density (Silverman bandwidth) for ridgelines; per-person deltas `Δ_sbp_t1_t2`, `Δ_sbp_t2_tdx` (mean/SD/median/IQR); fraction whose `t_dx` fell **below** both triggering readings (regression-to-mean / white-coat); fraction whose `t_dx` was Stage 2/3 vs Stage 1 (Appendix 1 cut-offs).
+- **Tests:** Kruskal-Wallis across the six populations at each timepoint (SBP, DBP separately); Dunn post-hoc with Holm-Bonferroni; Levene + Fligner-Killeen for variance equality.
+- **Deliverables:** ridgeline plots per group per timepoint; violin+box comparing `t_dx` across groups; trellis of paired-arrow plots (t1 → t2 → t_dx) per group; downloadable CSV.
+
+### 5.3 — Analysis O — Overlap-weighted delay effect (PRIMARY causal analysis)
+
+Using `results.htn_v4_o_weights` (§4.1):
+- **Confirmatory contrast:** timely (≤ 3 mo) vs delayed (> 3 mo). ATO-weighted **Cox PH** for MACE (O1) and incident CKD (O2), death as competing risk (Fine-Gray sensitivity). Report weighted HR, 5-yr risk difference, and negative-control-calibrated HR + empirical p.
+- **Secondary dose-response:** 4-level `delay_group` gradient, ATO-weighted, testing monotone trend.
+- **Estimability gates (must all pass to report an effect):** after weighting (a) every covariate |SMD| < 0.1; (b) weighted equipoise ≥ 0.3; (c) calibrated null centered (|mean log-HR| < 0.1, 95% CI covers 0). **If any gate fails, WITHHOLD the effect** (persist `estimable=false`, blind the estimate) exactly as v4 did for G4-vs-G1 — this is required behavior, not an error.
+- Report the E-value for the point estimate and the CI bound.
+
+### 5.4 — Analysis P — Target-trial emulation (clone-censor-weight)
+
+Using `results.htn_v4_p_target_trial` (§4.2):
+- Strategy A ("dx + treat within `grace` days") vs B; IPCW-adjusted weighted Cox / pooled logistic hazard; per-protocol HR + 5-yr risk difference for MACE and CKD; death as competing risk.
+- Grace 90 d primary; 30 / 180 d sensitivity.
+- Report cumulative-incidence curves by strategy, IPCW weight distribution (flag if max stabilized weight > 10), and negative-control-calibrated estimates.
+- **Immortal-time check:** confirm no clone contributes person-time to a strategy before its assignment can be determined; assert in a unit test.
+
+### 5.5 — Analysis Q — Phenotype robustness + quantitative bias
+
+Using `results.htn_v4_q_phenotype_grid` (§4.3):
+- Report the **never-diagnosed fraction** and median latency across the index-rule × threshold × max-gap grid; show how the 90% figure moves.
+- **Surveillance/recording bias:** outcome ascertainment (MACE, CKD) as a function of BP-recording frequency and encounter count; report whether the comparator's "recording-comparable" match holds on recording frequency (add it to the match/weight covariates if not).
+- **Informative-visit process:** compare encounter/lab counts between diagnosed and never-diagnosed; quantify differential follow-up. **Live-DB signal to investigate first:** only 37.9% of T (41,642/109,763) have any `visit_occurrence` row — the other ~62% carry qualifying BPs in `measurement` with no encounter. Report the never-diagnosed rate, MACE, and CKD ascertainment separately for the visit-linked vs measurement-only strata; a large share of the "90% undiagnosed" may be measurement-only patients whose data feed lacks encounters rather than true clinical inaction. This materially conditions how the 90% headline is framed.
+- **Quantitative bias analysis:** E-values for the O and P headline effects (CKD, MACE); a probabilistic bias analysis for differential outcome ascertainment between diagnosed and undiagnosed (specify bias parameters + priors; report the bias-adjusted interval).
+- Deliverable: `results.htn_v4_q_phenotype_grid` + a robustness panel in the report.
+
+### 5.6 — Analysis R — Site diagnostic-propensity instrument
+
+Using `results.htn_v4_r_instrument` (§4.4):
+- **First stage:** regress individual delay (continuous `latency_b_days`, and binary ≤ 90 d) on `Z` + covariates; report first-stage **F** (require ≥ 10 to interpret).
+- **Second stage:** two-stage residual inclusion for the survival outcome (MACE, CKD); report the local average treatment effect (LATE) with 95% CI.
+- **Falsification:** covariate balance across instrument tertiles (a valid instrument should be ~balanced on measured prognostic covariates); negative-control-outcome check on the instrument (the instrument should show ~null association with the negative controls).
+- Report the IV estimate with explicit caveats; **never** present it as the sole basis for a conclusion — it triangulates with O and P.
+
+### 5.7 — Triangulation summary
+
+Produce `results.htn_v4_triangulation`: side-by-side of the delay→outcome effect from O (ATO), P (target trial), and R (IV), with each design's key assumption and estimability status. The report renders this as the study's headline causal figure. Concordance across designs strengthens the claim; divergence is reported transparently with the most-credible design flagged.
+
+---
+
+## 6 — Statistical & methodological guardrails
+
+- **Estimand of record:** ATO overlap-weighted HR + 5-yr risk difference (primary); target-trial per-protocol HR (secondary); IV LATE (tertiary). The elevated-vs-normotensive contrast (v4, well-calibrated) is retained as the anchor.
+- **Index-date alignment:** T index = t2; C synthetic index = second of the normal BPs; time zero for O/P = t2 (no immortal time).
+- **Censoring:** end of observation, death, or `max_followup_days` (1825 primary). Death is a competing risk for MACE/CKD (Fine-Gray sensitivity beside cause-specific Cox).
+- **Overlap weighting:** ATO via `WeightIt`/`PSweight`; verify exact mean balance on the PS main-effect covariates (exact only for those moments under a logistic PS); flag residual imbalance on any main-effect covariate as a build failure. Interactions/non-linear terms are not auto-balanced — check them and extend the PS if needed.
+- **IPCW (target trial):** stabilized weights; truncate at the 99th percentile only with a logged justification; report weight distribution.
+- **IV:** report first-stage F, exclusion-restriction argument, tertile-balance falsification, negative-control-outcome check.
+- **Calibration:** every effect family calibrated against the negative controls (OHDSI `EmpiricalCalibration`); report EASE; block reporting if the calibrated null is not centered (|mean log-HR| < 0.1, 95% CI covers 0).
+- **Multiplicity:** Holm-Bonferroni within family + study-wide negative-control-calibrated FDR across the expanded M/N/O–R set.
+- **Sensitivity everywhere:** E-values for headline effects; index-rule/threshold sensitivity (Q); Fine-Gray beside cause-specific; PSM retained as a sensitivity comparator against ATO.
+- **Missing data:** report % missingness per covariate; do NOT impute BPs or labs; overlap weights use complete-covariate PS with a missingness-indicator sensitivity.
+- **Pre-registration:** persist `analysis_plan_v5.0.lock.json` to `study_artifacts` before `run`; reject `run` if the lock is missing or modified.
+
+---
+
+## 7 — Deliverables
+
+```
+docs/research/hypertension-v3/                              ← protocol home (v3 → v5 lineage)
+├── CLAUDE_PROMPT.md                                        ← v4 prompt (retained)
+├── CLAUDE_PROMPT_v5.md                                     ← this file (v5)
+├── CHANGELOG_v3_to_v4.md
+├── CHANGE_REQUEST_v4.1_Bock_2026-05-23.md
+├── CHANGELOG_v4_to_v5.md                                   ← NEW deep diff (write this)
+├── Hypertension_v4_Consolidated_Acumenus.docx
+├── Hypertension_v5_GoForward_Acumenus.docx                ← NEW go-forward (ACUM-PROT-HTN-V5-001)
+├── PROTOCOL.md                                             ← update Part 1 to v5 estimands
+├── README.md                                              ← update run instructions + v5 status
+├── concept-sets/                                          ← + M morbidity sets
+├── cohort-definitions/                                    ← + O/P/Q/R constructs
+├── sql/                                                   ← rendered SQL per cohort & analysis
+├── r/                                                     ← WeightIt/PSweight, CCW+IPCW, 2SRI payloads
+├── results/omop/                                          ← result tables incl. htn_v4_{m,n,o,p,q,r}_*
+├── reports/
+│   ├── htn_v5_report.html                                 ← interactive v5 report
+│   └── htn_v5_report.pdf                                  ← printable
+└── docs/
+    ├── open-questions.md                                  ← all 14 resolved + Protocol-#2 items
+    ├── v5-reuse-manifest.md                               ← v4→v5 asset reuse audit
+    └── irb/                                               ← Part-3 artifacts + v5 amendment note
+```
+
+The **v5 HTML report** MUST:
+- Use the Acumenus palette (Crimson #9B1B30, Dark #0E0E11, Gold #C9A227, Teal #2DD4BF) and Arial.
+- Show the `analysis_plan_v5.0` lock hash prominently in the header.
+- Show negative-control p-value calibration plots (per family) and EASE.
+- Render the **triangulation figure** (O / P / R side-by-side) as the headline.
+- Render ATO-weighted forest plots and love plots (SMD before/after weighting).
+- Render Analysis M heatmap + comparison table, Analysis N ridgelines / violin+box / paired-arrow trellis.
+- Render the Q phenotype-robustness panel (never-diagnosed fraction across the grid) and E-values.
+- Render the "Lu 2025 sensitivity replication" panel with PASS/FAIL/N-A.
+- Carry a **V&V acceptance matrix** panel (see §8) so the report doubles as the platform-validation artifact.
+
+Also write `CHANGELOG_v4_to_v5.md` (deep diff, same style as `CHANGELOG_v3_to_v4.md`).
+
+---
+
+## 8 — Acceptance criteria
+
+1. `app.studies` row `key=htn-v4-bock-2026` has `analysis_plan_version=v5.0`, `status=run_complete`.
+2. New M concept sets verified (`StudyConceptSetDraftVerifier::status=passed`); zero `unresolved_concept` rows.
+3. v4 T/C/S1/S2/O1/O2 reused (or re-materialized) with counts idempotent within ±0.1%; the v5 constructs `htn_v4_{o_weights,p_target_trial,q_phenotype_grid,r_instrument}` populated and non-empty.
+4. Every analysis A–R has `result_summary` populated and a result table under `results.htn_v4_*`.
+5. **Analysis O reports an estimable, negative-control-calibrated timely-vs-delayed effect** with all estimability gates passing — OR, if a gate fails, the effect is explicitly withheld with `estimable=false` and the failing gate logged (either is acceptable; silent reporting of an ungated effect is NOT).
+6. Analyses M and N produce their full tables + figures (heatmap, ridgelines, violin+box, paired-arrow trellis).
+7. Analysis P passes the immortal-time unit test; Analysis R reports first-stage F and the tertile-balance falsification.
+8. `analysis_plan_v5.0.lock.json` exists in `study_artifacts` and hash-matches the rendered v5 report.
+9. Negative-control distribution centered ≈ 0 on log-HR scale across the expanded family; EASE reported per family.
+10. The v4 baseline facts reconcile (T=109,763; never-diagnosed 90%; latency_b median 1,106 d; CKD HR 2.60) — any deviation > 0.1% is investigated and explained in `CHANGELOG_v4_to_v5.md`.
+11. IRB filing stub present with a v5 amendment note; no new IRB filing required.
+12. `make lint` + `make test` pass; `npx vite build` succeeds; PHPStan level 8 clean (no new `phpstan-baseline.neon` entries).
+13. No PHI / `person_id` / MRN in logs.
+
+**V&V acceptance matrix (platform validation — all must be present in the report):** estimand robustness (O/P/R triangulation), positivity handling (O clears gates PSM failed), lock integrity (hash match), negative-control coverage (centered null), reproducibility (stable cohort hashes, ±0.1% idempotent), governance (no PHI in logs, HIGHSEC, IRB artifact pre-egress), external validity (Lu PASS/FAIL/N-A), sensitivity transparency (E-values + QBA).
+
+---
+
+## 9 — Open questions
+
+**Resolved for v5 (baked into §4.0; PI sign-off recorded in the go-forward doc):**
+
+| # | Question | v5 resolution |
+|---|---|---|
+| 1 | Max gap between consecutive elevated BPs | 365 d cap, distinct days; sensitivity 90/180 |
+| 4 | Antihypertensive scope | ATC C02–C09 primary; JNC-8 first-line sensitivity |
+| 5 | Comparator method | **ATO overlap weighting primary; PSM sensitivity** |
+| 6 | Max follow-up | 5 yr primary; all-available sensitivity; 1-yr landmark |
+| 7 | Cost fidelity | **Settled: `omop.cost` = 0 rows (verified 2026-07-03). No cost analysis; utilization proxies only, CAUTION** |
+| 8 | Sample-size justification | positivity-bound, not N-bound; report min detectable HR per contrast |
+| 10 | Renal-denervation code completeness | validate device + procedure codes vs registry |
+| 11 | Index BP rule | run both; default average_of_two_recent; report both |
+| 12 | Lu framing | sensitivity analysis F |
+| 13 | Kidney exclusion | retain dx_ckd exclusion AND capture eGFR covariate |
+| 14 | Drug dose fidelity | RxNorm strength if drug_exposure sparse |
+
+**Protocol #2 (readiness — NOT executable from this prompt):**
+
+| # | Question | Path |
+|---|---|---|
+| 15 | Protocol #2 IRB framing | expedited cat. 7 (QI/human-factors); partner-IRB pre-consult; cluster-randomized characterization |
+| 16 | Protocol #2 EPIC integration | two layers — EPIC-side out-of-platform; Parthenon study `htn-pilot-bp-capture-2026` ingests post-pilot OMOP data and runs comparability + outcome analyses |
+
+Persist the resolutions into `docs/research/hypertension-v3/docs/open-questions.md` and reference the go-forward sign-off doc.
+
+---
+
+## 10 — Style & safety rules (enforced)
+
+- HIGHSEC — no public/unauthenticated endpoint serves cohort/PHI data; new routes pass `auth:sanctum + permission:studies.execute` or stricter.
+- `CdmModel` is read-only. Never INSERT/UPDATE/DELETE against `omop.*` or `vocab.*`. Writes only to `app.*`, `results.htn_v4_*`, `php.*`.
+- Use the `omop` connection (`search_path omop,vocab,php`); `interrogation` connection permitted for read-only Abby analytics.
+- Pint in Docker: `docker compose exec -T php sh -c "cd /var/www/html && vendor/bin/pint"` after every PHP edit.
+- TypeScript strict — `npx vite build` + `tsc --noEmit`. Recharts Tooltip formatter cast `as never`.
+- Branch: `feature/htn-v5-outcomes-study` from `main`. Conventional commits. No `--no-verify` without an emergency note.
+- No PHI, `person_id`, or MRN in logs, reports, or CSV downloads (group-level aggregates only in any egress).
+
+---
+
+## 11 — Done definition
+
+```
+Hypertension v5 study run complete on Acumenus omop CDM @ <commit>.
+Study key: htn-v4-bock-2026  ·  analysis_plan_version: v5.0
+Reused v4 cohorts: T={n} C={n} S1={n} S2={n}  (idempotent ±0.1%: <PASS|FAIL>)
+delay_group distribution: g1=<n> g2=<n> g3=<n> g4=<n> never=<n>  (reconciled to v4: <PASS|FAIL>)
+Analysis M — comorbidity matrix: <17 morbidities> × <6 populations> × 2 epochs rows
+Analysis N — BP distributions: <3 timepoints> × <6 populations> ridgelines
+Analysis O — timely vs delayed (ATO): HR_MACE=<x> (<ci>) HR_CKD=<y> (<ci>)  estimable=<true|false> gates=<pass/fail>
+Analysis P — target trial (grace 90d): HR_MACE=<x> HR_CKD=<y>  immortal-time test=<PASS|FAIL>
+Analysis R — site-IV LATE: first-stage F=<f>  LATE_MACE=<x> LATE_CKD=<y>
+Triangulation (O/P/R): concordance=<concordant|divergent — most-credible: __>
+Anchor (elevated vs normotensive): MACE HR 1.03 (0.94–1.14) · CKD HR 2.60 (2.01–3.38)  [reconciled]
+Phenotype grid: never-diagnosed fraction range across index-rule×threshold×gap = <lo>–<hi>%
+Negative-control EASE (per family): <...>   calibrated null centered: <PASS|FAIL>
+Lu 2025 sensitivity replication (29% CV-risk delta): <PASS|FAIL|N/A>
+Analysis plan lock (v5.0): <sha256>
+IRB filing: <pending|exempt-granted|expedited-granted>  (v5 amendment note appended)
+V&V acceptance matrix: <all-present|missing: __>
+Report: docs/research/hypertension-v3/reports/htn_v5_report.html
+Open questions outstanding: <n>  (Protocol #2: 15, 16 tracked separately)
+```
+
+End of prompt.

--- a/frontend/src/features/studies/components/StudyResultSummary.tsx
+++ b/frontend/src/features/studies/components/StudyResultSummary.tsx
@@ -2,6 +2,13 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { formatNumber } from "@/i18n/format";
 import type { StudyResult } from "../types/study";
+import { OverlapWeightedEffectView } from "./v5/OverlapWeightedEffectView";
+import { TargetTrialView } from "./v5/TargetTrialView";
+import { InstrumentalVariableView } from "./v5/InstrumentalVariableView";
+import { ComorbidityMatrixView } from "./v5/ComorbidityMatrixView";
+import { BpDistributionView } from "./v5/BpDistributionView";
+import { PhenotypeRobustnessView } from "./v5/PhenotypeRobustnessView";
+import { TriangulationView } from "./v5/TriangulationView";
 
 // ---------------------------------------------------------------------------
 // Safe narrowing helpers — summary_data is Record<string, unknown> projected
@@ -49,6 +56,21 @@ export function StudyResultSummary({ result }: { result: StudyResult }) {
     case "characterization":
     case "baseline_characteristics":
       return <CharacterizationView data={data} />;
+    // v5 (Hypertension Outcomes Program) result types
+    case "overlap_weighted_effect":
+      return <OverlapWeightedEffectView data={data} />;
+    case "target_trial":
+      return <TargetTrialView data={data} />;
+    case "instrumental_variable":
+      return <InstrumentalVariableView data={data} />;
+    case "comorbidity_matrix":
+      return <ComorbidityMatrixView data={data} />;
+    case "bp_distribution":
+      return <BpDistributionView data={data} />;
+    case "phenotype_robustness":
+      return <PhenotypeRobustnessView data={data} />;
+    case "triangulation":
+      return <TriangulationView data={data} />;
     default:
       return <GenericView data={data} />;
   }

--- a/frontend/src/features/studies/components/StudyResultsTab.tsx
+++ b/frontend/src/features/studies/components/StudyResultsTab.tsx
@@ -41,6 +41,14 @@ const RESULT_TYPE_LABELS: Record<string, string> = {
   pathway: "Pathway",
   sccs: "SCCS",
   custom: "Custom",
+  // v5 (Hypertension Outcomes Program) result types
+  overlap_weighted_effect: "Overlap-Weighted Effect (ATO)",
+  target_trial: "Target-Trial Emulation",
+  instrumental_variable: "Instrumental Variable",
+  comorbidity_matrix: "Comorbidity Matrix",
+  bp_distribution: "BP Distribution",
+  phenotype_robustness: "Phenotype Robustness",
+  triangulation: "Triangulation",
 };
 
 const SYNTHESIS_TYPE_LABELS: Record<string, string> = {
@@ -277,7 +285,9 @@ export function StudyResultsTab({ slug }: StudyResultsTabProps) {
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
                           <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-info/10 text-info">
-                            {t(`studies.results.resultTypes.${r.result_type}`, { defaultValue: r.result_type })}
+                            {t(`studies.results.resultTypes.${r.result_type}`, {
+                              defaultValue: RESULT_TYPE_LABELS[r.result_type] ?? r.result_type,
+                            })}
                           </span>
                           {r.site?.source && (
                             <span className="text-xs text-text-ghost">

--- a/frontend/src/features/studies/components/StudyV5ReportTab.tsx
+++ b/frontend/src/features/studies/components/StudyV5ReportTab.tsx
@@ -1,0 +1,214 @@
+import type { ReactNode } from "react";
+import { Loader2, FileText, ShieldCheck } from "lucide-react";
+import { useStudyResults } from "../hooks/useStudies";
+import type { StudyResult } from "../types/study";
+import { OverlapWeightedEffectView } from "./v5/OverlapWeightedEffectView";
+import { TargetTrialView } from "./v5/TargetTrialView";
+import { InstrumentalVariableView } from "./v5/InstrumentalVariableView";
+import { ComorbidityMatrixView } from "./v5/ComorbidityMatrixView";
+import { BpDistributionView } from "./v5/BpDistributionView";
+import { PhenotypeRobustnessView } from "./v5/PhenotypeRobustnessView";
+import { TriangulationView } from "./v5/TriangulationView";
+import { VvAcceptanceMatrix, type VvCheck } from "./v5/VvAcceptanceMatrix";
+import { asRecord, isFixture, num, str } from "./v5/narrow";
+
+function ReportSection({ title, subtitle, children }: { title: string; subtitle?: string; children: ReactNode }) {
+  return (
+    <section className="panel p-4 space-y-3">
+      <div>
+        <h3 className="text-sm font-semibold text-text-primary">{title}</h3>
+        {subtitle && <p className="text-[11px] text-text-ghost">{subtitle}</p>}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+/**
+ * Layer 3 — the assembled "v5 Report" surface. Composes the triangulation
+ * headline, the ATO/target-trial/IV effect designs, the descriptive matrices,
+ * and the V&V acceptance matrix into a single native, palette-correct report
+ * that mirrors the standalone HTML report (CLAUDE_PROMPT_v5 §7).
+ */
+export function StudyV5ReportTab({ slug }: { slug: string }) {
+  const { data, isLoading } = useStudyResults(slug, { per_page: 100 });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <Loader2 size={24} className="animate-spin text-text-muted" />
+      </div>
+    );
+  }
+
+  const results = data?.items ?? [];
+  const byType = new Map<string, StudyResult>();
+  for (const r of results) {
+    if (!byType.has(r.result_type)) byType.set(r.result_type, r);
+  }
+
+  const dataFor = (type: string): Record<string, unknown> => asRecord(byType.get(type)?.summary_data ?? {});
+  const has = (type: string): boolean => byType.has(type);
+
+  const triangulation = dataFor("triangulation");
+  const overlap = dataFor("overlap_weighted_effect");
+  const phenotype = dataFor("phenotype_robustness");
+
+  if (!has("triangulation") && !has("overlap_weighted_effect")) {
+    return (
+      <div className="empty-state">
+        <FileText size={24} className="text-text-ghost mb-2" />
+        <h3 className="empty-title">No v5 report available</h3>
+        <p className="empty-message">
+          This study has no v5 (Hypertension Outcomes Program) results yet. Run
+          <code className="mx-1 rounded bg-surface-darkest px-1 py-0.5 text-[11px]">study:seed-htn-v5-fixture</code>
+          or the full v5 executor to populate the report.
+        </p>
+      </div>
+    );
+  }
+
+  const fixture = isFixture(triangulation) || isFixture(overlap);
+  const checks = buildChecks(byType);
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="panel p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-base font-semibold text-text-primary">Hypertension Outcomes Program — v5 Report</h2>
+            <p className="text-[11px] text-text-muted mt-0.5">
+              Triangulated causal estimate of timely vs delayed antihypertensive initiation, with descriptive
+              characterization and full verification &amp; validation.
+            </p>
+          </div>
+          <span className="inline-flex shrink-0 items-center gap-1 rounded bg-info/10 px-2 py-1 text-[10px] font-medium text-info">
+            <ShieldCheck size={12} /> analysis_plan v5.0
+          </span>
+        </div>
+        {fixture && (
+          <p className="mt-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] text-warning">
+            <span className="font-semibold uppercase tracking-wide">Demonstration report · </span>
+            Figures below are rendered from a representative fixture (grounded in v4 baseline facts), not a real v5
+            execution. Provenance is repeated on each figure.
+          </p>
+        )}
+      </div>
+
+      {has("triangulation") && (
+        <ReportSection title="Headline — Cross-Design Triangulation" subtitle="O (ATO) · P (target-trial) · R (IV)">
+          <TriangulationView data={triangulation} />
+        </ReportSection>
+      )}
+
+      {has("overlap_weighted_effect") && (
+        <ReportSection title="Analysis O — Overlap-Weighted (ATO) Effect" subtitle="Primary confounding-adjusted design">
+          <OverlapWeightedEffectView data={overlap} />
+        </ReportSection>
+      )}
+
+      {has("target_trial") && (
+        <ReportSection title="Analysis P — Target-Trial Emulation" subtitle="Clone-censor-weight + IPCW">
+          <TargetTrialView data={dataFor("target_trial")} />
+        </ReportSection>
+      )}
+
+      {has("instrumental_variable") && (
+        <ReportSection title="Analysis R — Instrumental Variable" subtitle="2SRI · triangulation only">
+          <InstrumentalVariableView data={dataFor("instrumental_variable")} />
+        </ReportSection>
+      )}
+
+      {has("comorbidity_matrix") && (
+        <ReportSection title="Analysis M — Comorbidity Matrix" subtitle="Prevalence across populations">
+          <ComorbidityMatrixView data={dataFor("comorbidity_matrix")} />
+        </ReportSection>
+      )}
+
+      {has("bp_distribution") && (
+        <ReportSection title="Analysis N — Blood-Pressure Distribution" subtitle="Baseline → diagnosis trajectory">
+          <BpDistributionView data={dataFor("bp_distribution")} />
+        </ReportSection>
+      )}
+
+      {has("phenotype_robustness") && (
+        <ReportSection title="Analysis Q — Phenotype Robustness" subtitle="Never-diagnosed sensitivity + QBA">
+          <PhenotypeRobustnessView data={phenotype} />
+        </ReportSection>
+      )}
+
+      <ReportSection title="Verification & Validation" subtitle="Acceptance matrix (CLAUDE_PROMPT_v5 §8)">
+        <VvAcceptanceMatrix checks={checks} />
+      </ReportSection>
+    </div>
+  );
+}
+
+function buildChecks(byType: Map<string, StudyResult>): VvCheck[] {
+  const dataFor = (type: string): Record<string, unknown> => asRecord(byType.get(type)?.summary_data ?? {});
+  const has = (type: string): boolean => byType.has(type);
+
+  const overlap = dataFor("overlap_weighted_effect");
+  const gates = asRecord(overlap.gates);
+  const calibration = asRecord(overlap.calibration);
+  const triangulation = dataFor("triangulation");
+  const concordance = str(triangulation.concordance);
+  const fixture = isFixture(triangulation) || isFixture(overlap);
+
+  const designs = has("overlap_weighted_effect") && has("target_trial") && has("instrumental_variable");
+  const nc = num(calibration.informative_negative_controls);
+
+  return [
+    {
+      requirement: "Estimand robustness across weighting & design",
+      status: designs ? "present" : "missing",
+      evidence: designs ? "ATO (O), target-trial (P) and IV (R) all estimated" : "Not all three designs present",
+    },
+    {
+      requirement: "Positivity / equipoise handling",
+      status: Object.keys(gates).length > 0 ? "present" : "missing",
+      evidence: `equipoise ${num(gates.equipoise) ?? "—"} · max |SMD| ${num(gates.max_smd) ?? "—"}`,
+    },
+    {
+      requirement: "Negative-control calibration coverage",
+      status: nc !== null && nc > 0 ? "present" : "missing",
+      evidence: `${nc ?? 0} informative negative controls · EASE ${num(calibration.ease) ?? "—"}`,
+    },
+    {
+      requirement: "Estimability gating (withhold on failure)",
+      status: "pass",
+      evidence: "Non-estimable effects render a withheld state, never a blinded number",
+    },
+    {
+      requirement: "Sensitivity transparency",
+      status: has("phenotype_robustness") && has("target_trial") ? "present" : "missing",
+      evidence: "Phenotype grid (index rule × threshold × gap) + grace-period sensitivity",
+    },
+    {
+      requirement: "External validity across populations",
+      status: has("comorbidity_matrix") ? "present" : "missing",
+      evidence: "17 × 6 comorbidity prevalence matrix",
+    },
+    {
+      requirement: "Triangulation concordance",
+      status: concordance === "concordant" ? "pass" : has("triangulation") ? "present" : "missing",
+      evidence: has("triangulation") ? `${concordance || "—"} · most-credible ${str(triangulation.most_credible) || "—"}` : "No triangulation row",
+    },
+    {
+      requirement: "Quantitative bias analysis",
+      status: has("phenotype_robustness") ? "present" : "missing",
+      evidence: "E-values + QBA-adjusted interval on the never-diagnosed headline",
+    },
+    {
+      requirement: "Reproducibility & provenance",
+      status: fixture ? "na" : "present",
+      evidence: fixture ? "Deterministic demonstration fixture (seeded)" : "Recorded analysis-plan lock",
+    },
+    {
+      requirement: "Analysis-plan lock integrity",
+      status: fixture ? "na" : "pass",
+      evidence: fixture ? "No lock artifact (demonstration data)" : "analysis_plan_v5.0.lock.json verified",
+    },
+  ];
+}

--- a/frontend/src/features/studies/components/v5/BpDistributionView.tsx
+++ b/frontend/src/features/studies/components/v5/BpDistributionView.tsx
@@ -1,0 +1,98 @@
+import { Download } from "lucide-react";
+import { FixtureBanner } from "./FixtureBanner";
+import { SectionTitle, Tile } from "./ui";
+import { RidgelinePlot } from "./charts/RidgelinePlot";
+import { PairedArrowTrellis } from "./charts/PairedArrowTrellis";
+import { toRidgeSeries, toTrellisRows } from "./charts/chartAdapters";
+import { downloadCsv } from "./csv";
+import { fmt, fmtPct, num, records, str } from "./narrow";
+
+/**
+ * Analysis N — Blood-pressure distribution across groups and timepoints.
+ * Ridgeline (KDE) + paired-arrow trellis show the leftward shift from baseline to
+ * diagnosis; the summary table carries the moments, and the below-trigger callout
+ * quantifies regression-to-the-mean / white-coat fraction.
+ */
+export function BpDistributionView({ data }: { data: Record<string, unknown> }) {
+  const summary = records(data.summary);
+  const ridge = toRidgeSeries(data.kde);
+  const trellis = toTrellisRows(data.trellis);
+  const belowTrigger = num(data.below_trigger_fraction);
+
+  const exportCsv = () => {
+    downloadCsv(
+      "htn_v5_bp_distribution",
+      ["group", "timepoint", "measure", "n", "mean", "sd", "median", "q1", "q3", "skew", "kurt"],
+      summary.map((s) => [
+        str(s.group), str(s.timepoint), str(s.measure), num(s.n) ?? 0,
+        num(s.mean) ?? 0, num(s.sd) ?? 0, num(s.median) ?? 0, num(s.q1) ?? 0, num(s.q3) ?? 0,
+        num(s.skew) ?? 0, num(s.kurt) ?? 0,
+      ]),
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <FixtureBanner data={data} />
+
+      {belowTrigger !== null && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <Tile label="Below-trigger fraction" value={fmtPct(belowTrigger)} hint="RTM / white-coat" />
+        </div>
+      )}
+
+      {ridge.length > 0 && (
+        <div>
+          <SectionTitle>SBP distribution (baseline → diagnosis)</SectionTitle>
+          <RidgelinePlot series={ridge} xLabel="SBP (mmHg)" />
+        </div>
+      )}
+
+      {trellis.length > 0 && (
+        <div>
+          <SectionTitle>Mean SBP trajectory (t₁ → t₂ → t_dx)</SectionTitle>
+          <PairedArrowTrellis rows={trellis} />
+        </div>
+      )}
+
+      {summary.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between">
+            <SectionTitle>Summary statistics</SectionTitle>
+            <button type="button" onClick={exportCsv} className="btn btn-ghost btn-sm">
+              <Download size={13} /> CSV
+            </button>
+          </div>
+          <div className="overflow-x-auto max-h-80 overflow-y-auto">
+            <table className="w-full text-xs">
+              <thead className="sticky top-0 bg-surface-raised">
+                <tr className="text-text-ghost text-left">
+                  <th className="py-1 pr-3 font-medium">Group</th>
+                  <th className="py-1 pr-3 font-medium">Timepoint</th>
+                  <th className="py-1 pr-3 font-medium">Measure</th>
+                  <th className="py-1 pr-3 font-medium">Mean ± SD</th>
+                  <th className="py-1 pr-3 font-medium">Median (IQR)</th>
+                  <th className="py-1 pr-3 font-medium">Skew</th>
+                  <th className="py-1 font-medium">Kurt</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.map((s, i) => (
+                  <tr key={i} className="border-t border-border-default">
+                    <td className="py-1 pr-3 text-text-secondary">{str(s.group)}</td>
+                    <td className="py-1 pr-3 text-text-muted">{str(s.timepoint)}</td>
+                    <td className="py-1 pr-3 text-text-muted">{str(s.measure)}</td>
+                    <td className="py-1 pr-3 text-text-primary font-mono">{fmt(s.mean, 1)} ± {fmt(s.sd, 1)}</td>
+                    <td className="py-1 pr-3 text-text-muted font-mono">{fmt(s.median, 1)} ({fmt(s.q1, 1)}–{fmt(s.q3, 1)})</td>
+                    <td className="py-1 pr-3 text-text-muted font-mono">{fmt(s.skew)}</td>
+                    <td className="py-1 text-text-muted font-mono">{fmt(s.kurt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/studies/components/v5/ComorbidityMatrixView.tsx
+++ b/frontend/src/features/studies/components/v5/ComorbidityMatrixView.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { Download, Table2 } from "lucide-react";
+import { HeatmapChart } from "@/features/data-explorer/components/charts/HeatmapChart";
+import { FixtureBanner } from "./FixtureBanner";
+import { SectionTitle } from "./ui";
+import { downloadCsv } from "./csv";
+import { fmt, fmtPct, num, records, str } from "./narrow";
+
+/**
+ * Analysis M — Comorbidity prevalence matrix. Renders the 17×6 prevalence
+ * heatmap and a collapsible full matrix (Wilson CIs + adjusted OR vs control),
+ * exportable to CSV directly from the loaded summary_data.
+ */
+export function ComorbidityMatrixView({ data }: { data: Record<string, unknown> }) {
+  const [showFull, setShowFull] = useState(false);
+  const cells = records(data.heatmap);
+
+  const heatmapData = cells
+    .map((c) => ({ row: str(c.morbidity), col: str(c.population), value: num(c.prevalence) ?? 0 }))
+    .filter((c) => c.row !== "" && c.col !== "");
+
+  const exportCsv = () => {
+    downloadCsv(
+      "htn_v5_comorbidity_matrix",
+      ["morbidity", "population", "prevalence", "wilson_lo", "wilson_hi"],
+      cells.map((c) => [str(c.morbidity), str(c.population), num(c.prevalence) ?? 0, num(c.wilson_lo) ?? 0, num(c.wilson_hi) ?? 0]),
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <FixtureBanner data={data} />
+
+      {heatmapData.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between">
+            <SectionTitle>Prevalence heatmap</SectionTitle>
+            <div className="flex items-center gap-2">
+              <button type="button" onClick={() => setShowFull((v) => !v)} className="btn btn-ghost btn-sm">
+                <Table2 size={13} /> {showFull ? "Hide" : "View full matrix"}
+              </button>
+              <button type="button" onClick={exportCsv} className="btn btn-ghost btn-sm">
+                <Download size={13} /> CSV
+              </button>
+            </div>
+          </div>
+          <HeatmapChart data={heatmapData} rowLabel="Morbidity" colLabel="Population" />
+        </div>
+      )}
+
+      {showFull && cells.length > 0 && (
+        <div className="overflow-x-auto max-h-96 overflow-y-auto">
+          <table className="w-full text-xs">
+            <thead className="sticky top-0 bg-surface-raised">
+              <tr className="text-text-ghost text-left">
+                <th className="py-1 pr-3 font-medium">Morbidity</th>
+                <th className="py-1 pr-3 font-medium">Population</th>
+                <th className="py-1 pr-3 font-medium">Prevalence</th>
+                <th className="py-1 font-medium">Wilson 95% CI</th>
+              </tr>
+            </thead>
+            <tbody>
+              {cells.map((c, i) => (
+                <tr key={i} className="border-t border-border-default">
+                  <td className="py-1 pr-3 text-text-secondary">{str(c.morbidity)}</td>
+                  <td className="py-1 pr-3 text-text-muted">{str(c.population)}</td>
+                  <td className="py-1 pr-3 text-text-primary font-mono">{fmtPct(c.prevalence)}</td>
+                  <td className="py-1 text-text-muted font-mono">{fmt(c.wilson_lo, 3)}–{fmt(c.wilson_hi, 3)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/studies/components/v5/FixtureBanner.tsx
+++ b/frontend/src/features/studies/components/v5/FixtureBanner.tsx
@@ -1,0 +1,28 @@
+import { FlaskConical } from "lucide-react";
+import { str } from "./narrow";
+
+/**
+ * Explicit provenance banner for demonstration-fixture v5 results. The seeder
+ * flags every fixture row with `_fixture: true` and a `_provenance` string; this
+ * renders that provenance so a clinical reviewer can never mistake the
+ * representative numbers for a real v5 execution.
+ */
+export function FixtureBanner({ data }: { data: Record<string, unknown> }) {
+  if (data._fixture !== true) {
+    return null;
+  }
+
+  const provenance =
+    str(data._provenance) ||
+    "Representative demonstration data — not a real v5 execution.";
+
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] text-warning">
+      <FlaskConical size={14} className="mt-0.5 shrink-0" />
+      <span>
+        <span className="font-semibold uppercase tracking-wide">Demonstration data · </span>
+        {provenance}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/features/studies/components/v5/InstrumentalVariableView.tsx
+++ b/frontend/src/features/studies/components/v5/InstrumentalVariableView.tsx
@@ -1,0 +1,97 @@
+import { Info } from "lucide-react";
+import { ForestPlot } from "@/features/estimation/components/ForestPlot";
+import { FixtureBanner } from "./FixtureBanner";
+import { SectionTitle, StatusPill, Tile } from "./ui";
+import { fmt, fmtPct, num, records, str, toForestEstimate } from "./narrow";
+
+/**
+ * Analysis R — Instrumental variable (2SRI). Surfaces first-stage strength (F),
+ * the LATE for each endpoint, the tertile-balance falsification, and the
+ * negative-control-on-instrument check. IV is retained for triangulation only —
+ * the caveat is rendered prominently and can never be the sole basis.
+ */
+export function InstrumentalVariableView({ data }: { data: Record<string, unknown> }) {
+  const firstStageF = num(data.first_stage_f);
+  const interpretable = data.interpretable === true;
+  const late = records(data.late);
+  const tertileBalance = records(data.tertile_balance);
+  const ncNull = data.nc_on_instrument_null === true;
+
+  return (
+    <div className="space-y-4">
+      <FixtureBanner data={data} />
+
+      <div className="flex items-start gap-2 rounded-md border border-info/30 bg-info/10 px-3 py-2 text-[11px] text-info">
+        <Info size={14} className="mt-0.5 shrink-0" />
+        <span>
+          <span className="font-semibold">Triangulation only.</span> The IV estimate corroborates the
+          confounding-adjusted designs (O, P); it is never used as the sole basis for a conclusion.
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Tile
+          label="First-stage F"
+          value={fmt(firstStageF, 1)}
+          hint={firstStageF !== null && firstStageF >= 10 ? "≥ 10 (interpretable)" : "< 10 (weak instrument)"}
+        />
+        <div className="bg-surface-darkest rounded p-2">
+          <p className="text-[9px] text-text-ghost uppercase tracking-wide">Instrument</p>
+          <div className="mt-1">
+            <StatusPill label={interpretable ? "interpretable" : "weak"} tone={interpretable ? "ok" : "warn"} />
+          </div>
+        </div>
+        <Tile label="Sites" value={fmt(data.n_sites, 0)} />
+        <Tile label="Encounter coverage" value={`${fmt(data.coverage_pct, 1)}%`} />
+      </div>
+
+      {late.length > 0 && (
+        <div>
+          <SectionTitle>Local average treatment effect (LATE)</SectionTitle>
+          <ForestPlot estimates={late.map(toForestEstimate)} />
+        </div>
+      )}
+
+      {tertileBalance.length > 0 && (
+        <div>
+          <SectionTitle>Instrument-tertile balance (falsification)</SectionTitle>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-text-ghost text-left">
+                  <th className="py-1 pr-3 font-medium">Covariate</th>
+                  <th className="py-1 pr-3 font-medium">T1</th>
+                  <th className="py-1 pr-3 font-medium">T2</th>
+                  <th className="py-1 pr-3 font-medium">T3</th>
+                  <th className="py-1 font-medium">Balanced</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tertileBalance.map((b, i) => (
+                  <tr key={i} className="border-t border-border-default">
+                    <td className="py-1 pr-3 text-text-secondary">{str(b.covariate)}</td>
+                    <td className="py-1 pr-3 text-text-muted font-mono">{fmt(b.t1)}</td>
+                    <td className="py-1 pr-3 text-text-muted font-mono">{fmt(b.t2)}</td>
+                    <td className="py-1 pr-3 text-text-muted font-mono">{fmt(b.t3)}</td>
+                    <td className="py-1">
+                      <StatusPill label={b.balanced === true ? "yes" : "no"} tone={b.balanced === true ? "ok" : "bad"} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 text-[11px] text-text-muted">
+        <span>Negative-control-on-instrument:</span>
+        <StatusPill label={ncNull ? "null (passes)" : "signal (fails)"} tone={ncNull ? "ok" : "bad"} />
+      </div>
+      <p className="text-[9px] text-text-ghost">
+        Coverage {fmtPct((num(data.coverage_pct) ?? 0) / 100)} reflects the encounter-linked share of the
+        cohort (NEW-17).
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/features/studies/components/v5/OverlapWeightedEffectView.tsx
+++ b/frontend/src/features/studies/components/v5/OverlapWeightedEffectView.tsx
@@ -1,0 +1,93 @@
+import { ForestPlot } from "@/features/estimation/components/ForestPlot";
+import { LovePlot } from "@/features/estimation/components/LovePlot";
+import { FixtureBanner } from "./FixtureBanner";
+import { GateBanner, SectionTitle, Tile } from "./ui";
+import { asRecord, fmt, fmtCount, fmtPct, num, records, str, toBalanceEntry, toForestEstimate } from "./narrow";
+
+/**
+ * Analysis O — Overlap-weighted (ATO) comparative effect. Renders the headline
+ * timely-vs-delayed effect with the estimability gate front and centre; a failed
+ * gate withholds the estimate rather than showing a blinded number.
+ */
+export function OverlapWeightedEffectView({ data }: { data: Record<string, unknown> }) {
+  const estimable = data.estimable !== false;
+  const gates = asRecord(data.gates);
+  const estimates = records(data.estimates);
+  const gradient = records(data.gradient);
+  const balance = records(data.balance);
+  const calibration = asRecord(data.calibration);
+  const riskDiff = asRecord(data.risk_difference_5y);
+
+  return (
+    <div className="space-y-4">
+      <FixtureBanner data={data} />
+      <GateBanner estimable={estimable} gates={gates} />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Tile label="Target (timely)" value={fmtCount(data.target_count)} />
+        <Tile label="Comparator (delayed)" value={fmtCount(data.comparator_count)} />
+        <Tile label="EASE" value={fmt(calibration.ease, 3)} hint="empirical calibration" />
+        <Tile label="Informative NCs" value={fmtCount(calibration.informative_negative_controls)} />
+      </div>
+
+      {estimable && estimates.length > 0 && (
+        <div>
+          <SectionTitle>Primary effect (overlap-weighted HR)</SectionTitle>
+          <ForestPlot estimates={estimates.map(toForestEstimate)} showNNT />
+          <div className="overflow-x-auto mt-2">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-text-ghost text-left">
+                  <th className="py-1 pr-3 font-medium">Outcome</th>
+                  <th className="py-1 pr-3 font-medium">HR</th>
+                  <th className="py-1 pr-3 font-medium">95% CI</th>
+                  <th className="py-1 pr-3 font-medium">Calibrated HR</th>
+                  <th className="py-1 font-medium">E-value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {estimates.map((e, i) => (
+                  <tr key={i} className="border-t border-border-default">
+                    <td className="py-1 pr-3 text-text-secondary">{str(e.outcome_name) || `#${i + 1}`}</td>
+                    <td className="py-1 pr-3 text-text-primary font-mono">{fmt(e.hazard_ratio)}</td>
+                    <td className="py-1 pr-3 text-text-muted font-mono">{fmt(e.ci_95_lower)}–{fmt(e.ci_95_upper)}</td>
+                    <td className="py-1 pr-3 text-text-muted font-mono">
+                      {fmt(e.calibrated_hr)} ({fmt(e.cal_ci_lower)}–{fmt(e.cal_ci_upper)})
+                    </td>
+                    <td className="py-1 text-text-muted font-mono">{fmt(e.e_value)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {estimable && gradient.length > 0 && (
+        <div>
+          <SectionTitle>Dose-response gradient (timeliness quartiles)</SectionTitle>
+          <ForestPlot
+            estimates={gradient.map((g, i) => toForestEstimate({ ...g, outcome_name: str(g.label) || `Q${num(g.group) ?? i + 1}`, hazard_ratio: g.hr }, i))}
+          />
+        </div>
+      )}
+
+      {balance.length > 0 && (
+        <div>
+          <SectionTitle>Covariate balance (before / after ATO weighting)</SectionTitle>
+          <LovePlot data={balance.map(toBalanceEntry)} />
+        </div>
+      )}
+
+      {(num(riskDiff.mace) !== null || num(riskDiff.ckd) !== null) && (
+        <div>
+          <SectionTitle>5-year absolute risk difference</SectionTitle>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <Tile label="MACE" value={fmtPct(riskDiff.mace)} />
+            <Tile label="CKD progression" value={fmtPct(riskDiff.ckd)} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/studies/components/v5/PhenotypeRobustnessView.tsx
+++ b/frontend/src/features/studies/components/v5/PhenotypeRobustnessView.tsx
@@ -1,0 +1,93 @@
+import { FixtureBanner } from "./FixtureBanner";
+import { SectionTitle, Tile } from "./ui";
+import { asRecord, fmt, fmtCount, fmtPct, num, records, str } from "./narrow";
+
+/**
+ * Analysis Q — Phenotype robustness. The 90%-never-diagnosed headline stress
+ * across the index-rule × threshold × max-gap grid, the visit-linked vs
+ * measurement-only split (the 37.9% encounter-coverage finding, NEW-17), the
+ * E-values for the headline effects, and the QBA bias-adjusted interval.
+ */
+export function PhenotypeRobustnessView({ data }: { data: Record<string, unknown> }) {
+  const grid = records(data.grid);
+  const visitSplit = asRecord(data.visit_split);
+  const visitLinked = asRecord(visitSplit.visit_linked);
+  const measurementOnly = asRecord(visitSplit.measurement_only);
+  const eValues = asRecord(data.e_values);
+  const qba = Array.isArray(data.qba_interval) ? data.qba_interval : [];
+
+  return (
+    <div className="space-y-4">
+      <FixtureBanner data={data} />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Tile label="E-value (MACE)" value={fmt(eValues.mace)} />
+        <Tile label="E-value (CKD)" value={fmt(eValues.ckd)} />
+        <Tile
+          label="QBA-adjusted interval"
+          value={qba.length === 2 ? `${fmt(qba[0], 2)}–${fmt(qba[1], 2)}` : "—"}
+          hint="never-dx fraction"
+        />
+      </div>
+
+      {(Object.keys(visitLinked).length > 0 || Object.keys(measurementOnly).length > 0) && (
+        <div>
+          <SectionTitle>Visit-linked vs measurement-only (NEW-17)</SectionTitle>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {[
+              { label: "Visit-linked", rec: visitLinked, tone: "border-success/30" },
+              { label: "Measurement-only", rec: measurementOnly, tone: "border-warning/30" },
+            ].map((col) => (
+              <div key={col.label} className={`rounded-lg border ${col.tone} bg-surface-raised p-3`}>
+                <p className="text-xs font-semibold text-text-secondary mb-2">{col.label}</p>
+                <div className="grid grid-cols-2 gap-2">
+                  <Tile label="Coverage" value={`${fmt(col.rec.coverage_pct, 1)}%`} />
+                  <Tile label="Never-dx" value={fmtPct(col.rec.never_dx)} />
+                  <Tile label="MACE" value={fmtPct(col.rec.mace)} />
+                  <Tile label="CKD" value={fmtPct(col.rec.ckd)} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {grid.length > 0 && (
+        <div>
+          <SectionTitle>Never-diagnosed fraction across the phenotype grid</SectionTitle>
+          <div className="overflow-x-auto max-h-80 overflow-y-auto">
+            <table className="w-full text-xs">
+              <thead className="sticky top-0 bg-surface-raised">
+                <tr className="text-text-ghost text-left">
+                  <th className="py-1 pr-3 font-medium">Index rule</th>
+                  <th className="py-1 pr-3 font-medium">Threshold</th>
+                  <th className="py-1 pr-3 font-medium">Max gap (d)</th>
+                  <th className="py-1 pr-3 font-medium">Never-dx</th>
+                  <th className="py-1 pr-3 font-medium">n</th>
+                  <th className="py-1 font-medium">Median latency (d)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {grid.map((g, i) => {
+                  const frac = num(g.never_dx_fraction) ?? 0;
+                  return (
+                    <tr key={i} className="border-t border-border-default">
+                      <td className="py-1 pr-3 text-text-secondary">{str(g.index_rule)}</td>
+                      <td className="py-1 pr-3 text-text-muted font-mono">{fmt(g.threshold, 0)}</td>
+                      <td className="py-1 pr-3 text-text-muted font-mono">{fmt(g.max_gap, 0)}</td>
+                      <td className="py-1 pr-3 font-mono" style={{ color: `rgba(155,27,48,${0.35 + frac * 0.65})` }}>
+                        {fmtPct(frac)}
+                      </td>
+                      <td className="py-1 pr-3 text-text-muted font-mono">{fmtCount(g.n)}</td>
+                      <td className="py-1 text-text-muted font-mono">{fmtCount(g.median_latency)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/studies/components/v5/TargetTrialView.tsx
+++ b/frontend/src/features/studies/components/v5/TargetTrialView.tsx
@@ -1,0 +1,102 @@
+import type { KaplanMeierPoint } from "@/features/estimation/components/KaplanMeierPlot";
+import { KaplanMeierPlot } from "@/features/estimation/components/KaplanMeierPlot";
+import { FixtureBanner } from "./FixtureBanner";
+import { SectionTitle, StatusPill, Tile } from "./ui";
+import { asRecord, fmt, fmtPct, num, records, str } from "./narrow";
+
+function toKmPoints(value: unknown): KaplanMeierPoint[] {
+  return records(value).map((p) => ({
+    time: num(p.time) ?? 0,
+    surv: num(p.surv) ?? 1,
+    nAtRisk: num(p.nAtRisk) ?? 0,
+    nEvents: num(p.nEvents) ?? 0,
+    nCensored: num(p.nCensored) ?? 0,
+  }));
+}
+
+/**
+ * Analysis P — Target-trial emulation (clone-censor-weight + IPCW). Surfaces the
+ * per-protocol effect, the immortal-time integrity check, the IPCW weight
+ * diagnostic, and cumulative-incidence curves by strategy.
+ */
+export function TargetTrialView({ data }: { data: Record<string, unknown> }) {
+  const estimates = records(data.estimates);
+  const sensitivity = records(data.sensitivity);
+  const km = asRecord(data.km);
+  const ipcw = asRecord(data.ipcw);
+  const immortal = str(data.immortal_time_check);
+  const weightFlagged = ipcw.flag === true;
+
+  return (
+    <div className="space-y-4">
+      <FixtureBanner data={data} />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Tile label="Grace period" value={`${num(data.grace_days) ?? "—"} d`} />
+        <div className="bg-surface-darkest rounded p-2">
+          <p className="text-[9px] text-text-ghost uppercase tracking-wide">Immortal-time check</p>
+          <div className="mt-1">
+            <StatusPill label={immortal || "—"} tone={immortal === "PASS" ? "ok" : "bad"} />
+          </div>
+        </div>
+        <Tile label="Max stabilized weight" value={fmt(ipcw.max_stabilized_weight)} hint={weightFlagged ? "⚠ > 10" : "within range"} />
+        <Tile label="Mean stabilized weight" value={fmt(ipcw.mean_stabilized_weight)} />
+      </div>
+
+      {estimates.length > 0 && (
+        <div>
+          <SectionTitle>Per-protocol effect</SectionTitle>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-text-ghost text-left">
+                  <th className="py-1 pr-3 font-medium">Outcome</th>
+                  <th className="py-1 pr-3 font-medium">HR</th>
+                  <th className="py-1 pr-3 font-medium">95% CI</th>
+                  <th className="py-1 font-medium">5-yr risk diff</th>
+                </tr>
+              </thead>
+              <tbody>
+                {estimates.map((e, i) => (
+                  <tr key={i} className="border-t border-border-default">
+                    <td className="py-1 pr-3 text-text-secondary">{str(e.outcome_name) || `#${i + 1}`}</td>
+                    <td className="py-1 pr-3 text-text-primary font-mono">{fmt(e.hazard_ratio)}</td>
+                    <td className="py-1 pr-3 text-text-muted font-mono">{fmt(e.ci_95_lower)}–{fmt(e.ci_95_upper)}</td>
+                    <td className="py-1 text-text-muted font-mono">{fmtPct(e.risk_diff_5y)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {(toKmPoints(km.timely).length > 0 || toKmPoints(km.delayed).length > 0) && (
+        <div>
+          <SectionTitle>Cumulative incidence by strategy</SectionTitle>
+          <KaplanMeierPlot
+            targetCurve={toKmPoints(km.timely)}
+            comparatorCurve={toKmPoints(km.delayed)}
+            targetLabel="Timely initiation"
+            comparatorLabel="Delayed initiation"
+            timeUnit="months"
+          />
+        </div>
+      )}
+
+      {sensitivity.length > 0 && (
+        <div>
+          <SectionTitle>Grace-period sensitivity</SectionTitle>
+          <div className="flex flex-wrap gap-2">
+            {sensitivity.map((s, i) => (
+              <div key={i} className="bg-surface-darkest rounded px-2 py-1 text-[11px] text-text-muted">
+                <span className="text-text-ghost">{num(s.grace_days) ?? "—"} d · {str(s.outcome_name)}</span>
+                <span className="ml-2 font-mono text-text-primary">HR {fmt(s.hazard_ratio)}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/studies/components/v5/TriangulationView.tsx
+++ b/frontend/src/features/studies/components/v5/TriangulationView.tsx
@@ -1,0 +1,82 @@
+import { GitMerge } from "lucide-react";
+import { ForestPlot } from "@/features/estimation/components/ForestPlot";
+import { FixtureBanner } from "./FixtureBanner";
+import { SectionTitle, StatusPill } from "./ui";
+import { records, str, toForestEstimate } from "./narrow";
+
+function gateTone(status: string): "ok" | "warn" | "bad" | "muted" {
+  if (status === "cleared") return "ok";
+  if (status === "triangulation-only") return "muted";
+  if (status === "withheld") return "bad";
+  return "warn";
+}
+
+/**
+ * Cross-design triangulation — the study's headline causal figure. Aligns the
+ * O (ATO), P (target-trial) and R (IV) estimates for each endpoint so their
+ * concordance is visible, and states the verdict + most-credible design.
+ */
+export function TriangulationView({ data }: { data: Record<string, unknown> }) {
+  const designs = records(data.designs);
+  const concordance = str(data.concordance);
+  const mostCredible = str(data.most_credible);
+  const narrative = str(data.narrative);
+
+  const maceEstimates = designs.map((d, i) =>
+    toForestEstimate({ outcome_name: str(d.name), hazard_ratio: d.hr_mace, ci_95_lower: d.mace_lo, ci_95_upper: d.mace_hi }, i),
+  );
+  const ckdEstimates = designs.map((d, i) =>
+    toForestEstimate({ outcome_name: str(d.name), hazard_ratio: d.hr_ckd, ci_95_lower: d.ckd_lo, ci_95_upper: d.ckd_hi }, i),
+  );
+
+  return (
+    <div className="space-y-4">
+      <FixtureBanner data={data} />
+
+      <div
+        className={`flex items-start gap-2 rounded-md border px-3 py-2 text-xs ${
+          concordance === "concordant"
+            ? "border-success/40 bg-success/10 text-success"
+            : "border-warning/40 bg-warning/10 text-warning"
+        }`}
+      >
+        <GitMerge size={15} className="mt-0.5 shrink-0" />
+        <div>
+          <span className="font-semibold capitalize">{concordance || "—"}</span>
+          {mostCredible && (
+            <>
+              {" · most-credible design: "}
+              <span className="font-mono font-semibold">{mostCredible}</span>
+            </>
+          )}
+          {narrative && <p className="mt-1 font-normal text-text-secondary">{narrative}</p>}
+        </div>
+      </div>
+
+      {designs.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {designs.map((d, i) => (
+            <div key={i} className="inline-flex items-center gap-1.5 rounded bg-surface-darkest px-2 py-1 text-[11px] text-text-muted">
+              <span className="text-text-secondary">{str(d.name)}</span>
+              <StatusPill label={str(d.gate_status) || "—"} tone={gateTone(str(d.gate_status))} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {maceEstimates.length > 0 && (
+        <div>
+          <SectionTitle>MACE — timely vs delayed (by design)</SectionTitle>
+          <ForestPlot estimates={maceEstimates} />
+        </div>
+      )}
+
+      {ckdEstimates.length > 0 && (
+        <div>
+          <SectionTitle>CKD progression — timely vs delayed (by design)</SectionTitle>
+          <ForestPlot estimates={ckdEstimates} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/studies/components/v5/VvAcceptanceMatrix.tsx
+++ b/frontend/src/features/studies/components/v5/VvAcceptanceMatrix.tsx
@@ -1,0 +1,54 @@
+import { CheckCircle2, CircleDashed, XCircle } from "lucide-react";
+
+export type VvStatus = "pass" | "present" | "na" | "missing";
+
+export interface VvCheck {
+  requirement: string;
+  status: VvStatus;
+  evidence: string;
+}
+
+const STATUS_META: Record<VvStatus, { label: string; cls: string; Icon: typeof CheckCircle2 }> = {
+  pass: { label: "PASS", cls: "text-success", Icon: CheckCircle2 },
+  present: { label: "PRESENT", cls: "text-info", Icon: CheckCircle2 },
+  na: { label: "N/A", cls: "text-text-ghost", Icon: CircleDashed },
+  missing: { label: "MISSING", cls: "text-critical", Icon: XCircle },
+};
+
+/**
+ * Verification & Validation acceptance matrix (CLAUDE_PROMPT_v5 §8). Pure
+ * presentation — the report tab derives each row's status from the available
+ * result diagnostics.
+ */
+export function VvAcceptanceMatrix({ checks }: { checks: VvCheck[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="text-text-ghost text-left">
+            <th className="py-1 pr-3 font-medium">Requirement</th>
+            <th className="py-1 pr-3 font-medium">Status</th>
+            <th className="py-1 font-medium">Evidence</th>
+          </tr>
+        </thead>
+        <tbody>
+          {checks.map((c, i) => {
+            const meta = STATUS_META[c.status];
+            const Icon = meta.Icon;
+            return (
+              <tr key={i} className="border-t border-border-default align-top">
+                <td className="py-1.5 pr-3 text-text-secondary">{c.requirement}</td>
+                <td className="py-1.5 pr-3">
+                  <span className={`inline-flex items-center gap-1 font-semibold ${meta.cls}`}>
+                    <Icon size={12} /> {meta.label}
+                  </span>
+                </td>
+                <td className="py-1.5 text-text-muted">{c.evidence}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/features/studies/components/v5/__tests__/chartAdapters.test.ts
+++ b/frontend/src/features/studies/components/v5/__tests__/chartAdapters.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { toRidgeSeries, toTrellisRows } from "../charts/chartAdapters";
+
+describe("toRidgeSeries", () => {
+  it("parses valid KDE series and preserves points", () => {
+    const series = toRidgeSeries([
+      { group: "Timely", timepoint: "t1", points: [[100, 0.1], [150, 0.9]] },
+    ]);
+    expect(series).toHaveLength(1);
+    expect(series[0].group).toBe("Timely");
+    expect(series[0].timepoint).toBe("t1");
+    expect(series[0].points).toEqual([[100, 0.1], [150, 0.9]]);
+  });
+
+  it("drops malformed points and empty series", () => {
+    const series = toRidgeSeries([
+      { group: "A", timepoint: "t1", points: [[100, 0.1], [150], "nope", [null, 0.2]] },
+      { group: "B", timepoint: "t1", points: [] },
+      { group: "C", timepoint: "t1", points: "bad" },
+    ]);
+    // A keeps only its one well-formed point; B and C are dropped entirely
+    expect(series).toHaveLength(1);
+    expect(series[0].group).toBe("A");
+    expect(series[0].points).toEqual([[100, 0.1]]);
+  });
+
+  it("returns an empty array for non-array input", () => {
+    expect(toRidgeSeries(undefined)).toEqual([]);
+    expect(toRidgeSeries({})).toEqual([]);
+  });
+});
+
+describe("toTrellisRows", () => {
+  it("maps the three timepoints", () => {
+    const rows = toTrellisRows([{ group: "Delayed", t1: 151, t2: 147, t_dx: 142 }]);
+    expect(rows).toEqual([{ group: "Delayed", t1: 151, t2: 147, t_dx: 142 }]);
+  });
+
+  it("filters rows without a group and defaults missing timepoints to 0", () => {
+    const rows = toTrellisRows([
+      { t1: 1, t2: 2, t_dx: 3 },
+      { group: "OK" },
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({ group: "OK", t1: 0, t2: 0, t_dx: 0 });
+  });
+});

--- a/frontend/src/features/studies/components/v5/__tests__/narrow.test.ts
+++ b/frontend/src/features/studies/components/v5/__tests__/narrow.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { fmt, fmtPct, isFixture, num, str, toBalanceEntry, toForestEstimate } from "../narrow";
+
+describe("narrow helpers", () => {
+  it("num rejects non-finite and non-number values", () => {
+    expect(num(1.5)).toBe(1.5);
+    expect(num(NaN)).toBeNull();
+    expect(num(Infinity)).toBeNull();
+    expect(num("3")).toBeNull();
+    expect(num(null)).toBeNull();
+  });
+
+  it("str returns strings only", () => {
+    expect(str("MACE")).toBe("MACE");
+    expect(str(42)).toBe("");
+    expect(str(null)).toBe("");
+  });
+
+  it("fmt and fmtPct render em-dash for missing values", () => {
+    expect(fmt(0.741, 2)).toBe("0.74");
+    expect(fmt(undefined)).toBe("—");
+    expect(fmtPct(-0.038)).toBe("-3.8%");
+    expect(fmtPct(null)).toBe("—");
+  });
+
+  it("isFixture only trips on the explicit flag", () => {
+    expect(isFixture({ _fixture: true })).toBe(true);
+    expect(isFixture({ _fixture: "true" })).toBe(false);
+    expect(isFixture({})).toBe(false);
+  });
+});
+
+describe("toForestEstimate", () => {
+  it("derives log HR and SE from the confidence interval", () => {
+    const e = toForestEstimate({ outcome_name: "CKD", hazard_ratio: 0.74, ci_95_lower: 0.66, ci_95_upper: 0.83 }, 0);
+    expect(e.outcome_name).toBe("CKD");
+    expect(e.hazard_ratio).toBe(0.74);
+    expect(e.ci_95_lower).toBe(0.66);
+    expect(e.ci_95_upper).toBe(0.83);
+    expect(e.log_hr).toBeCloseTo(Math.log(0.74), 6);
+    expect(e.se_log_hr).toBeCloseTo((Math.log(0.83) - Math.log(0.66)) / (2 * 1.96), 6);
+    // required EstimateEntry fields are always populated
+    expect(e.outcome_id).toBe(0);
+    expect(e.target_outcomes).toBe(0);
+    expect(e.comparator_outcomes).toBe(0);
+  });
+
+  it("falls back to the `estimate` field (IV LATE payload)", () => {
+    const e = toForestEstimate({ outcome_name: "MACE", estimate: 0.83, ci_95_lower: 0.68, ci_95_upper: 1.01 }, 1);
+    expect(e.hazard_ratio).toBe(0.83);
+  });
+
+  it("stays finite when HR or CI is degenerate", () => {
+    const e = toForestEstimate({ outcome_name: "X", hazard_ratio: 0 }, 2);
+    expect(Number.isFinite(e.log_hr)).toBe(true);
+    expect(Number.isFinite(e.se_log_hr)).toBe(true);
+  });
+});
+
+describe("toBalanceEntry", () => {
+  it("maps the compact balance shape and zero-fills unused means", () => {
+    const b = toBalanceEntry({ covariate: "Age", smd_before: 0.31, smd_after: 0.04 });
+    expect(b.covariate_name).toBe("Age");
+    expect(b.smd_before).toBe(0.31);
+    expect(b.smd_after).toBe(0.04);
+    expect(b.mean_target_before).toBe(0);
+    expect(b.mean_comp_after).toBe(0);
+  });
+
+  it("defaults gracefully on missing fields", () => {
+    const b = toBalanceEntry({});
+    expect(b.covariate_name).toBe("—");
+    expect(b.smd_before).toBe(0);
+  });
+});

--- a/frontend/src/features/studies/components/v5/charts/PairedArrowTrellis.tsx
+++ b/frontend/src/features/studies/components/v5/charts/PairedArrowTrellis.tsx
@@ -1,0 +1,90 @@
+import type { TrellisRow } from "./chartAdapters";
+
+const STOP_COLORS = ["#6B7280", "#C9A227", "#2DD4BF"];
+const STOP_LABELS = ["t₁", "t₂", "t_dx"];
+
+/**
+ * Paired-arrow trellis: one track per group showing the mean value moving
+ * across three timepoints (t₁ → t₂ → t_dx). Makes the direction and magnitude of
+ * the within-group shift explicit. Self-contained SVG.
+ */
+export function PairedArrowTrellis({
+  rows,
+  xLabel = "mean SBP (mmHg)",
+}: {
+  rows: TrellisRow[];
+  xLabel?: string;
+}) {
+  if (rows.length === 0) {
+    return <p className="text-xs text-text-ghost italic">No trajectory data.</p>;
+  }
+
+  const values = rows.flatMap((r) => [r.t1, r.t2, r.t_dx]);
+  const xMin = Math.min(...values) - 3;
+  const xMax = Math.max(...values) + 3;
+
+  const W = 720;
+  const padL = 110;
+  const padR = 24;
+  const rowH = 34;
+  const padT = 10;
+  const padB = 26;
+  const height = padT + rows.length * rowH + padB;
+  const plotW = W - padL - padR;
+  const sx = (x: number) => padL + ((x - xMin) / (xMax - xMin || 1)) * plotW;
+
+  return (
+    <div className="overflow-x-auto">
+      <svg viewBox={`0 0 ${W} ${height}`} className="w-full" role="img" aria-label="Blood-pressure trajectory trellis">
+        {[xMin, (xMin + xMax) / 2, xMax].map((tick) => (
+          <g key={tick}>
+            <line x1={sx(tick)} x2={sx(tick)} y1={padT} y2={height - padB} stroke="currentColor" className="text-border-default" strokeWidth={0.5} />
+            <text x={sx(tick)} y={height - padB + 15} textAnchor="middle" className="fill-text-ghost text-[9px]">
+              {Math.round(tick)}
+            </text>
+          </g>
+        ))}
+        <text x={padL + plotW / 2} y={height - 2} textAnchor="middle" className="fill-text-muted text-[10px]">
+          {xLabel}
+        </text>
+
+        {rows.map((r, ri) => {
+          const y = padT + ri * rowH + rowH / 2;
+          const stops = [r.t1, r.t2, r.t_dx];
+          return (
+            <g key={r.group}>
+              <text x={padL - 10} y={y + 3} textAnchor="end" className="fill-text-secondary text-[10px]">
+                {r.group}
+              </text>
+              <line x1={sx(r.t1)} x2={sx(r.t_dx)} y1={y} y2={y} stroke="currentColor" className="text-border-muted" strokeWidth={1.5} />
+              {stops.map((v, si) => (
+                <g key={si}>
+                  {si < stops.length - 1 && (
+                    <line
+                      x1={sx(stops[si])}
+                      x2={sx(stops[si + 1])}
+                      y1={y}
+                      y2={y}
+                      stroke={STOP_COLORS[si + 1]}
+                      strokeWidth={2}
+                    />
+                  )}
+                  <circle cx={sx(v)} cy={y} r={4} fill={STOP_COLORS[si]} />
+                </g>
+              ))}
+            </g>
+          );
+        })}
+      </svg>
+
+      <div className="mt-1 flex flex-wrap items-center gap-3 pl-28 text-[10px] text-text-muted">
+        {STOP_LABELS.map((label, i) => (
+          <span key={label} className="inline-flex items-center gap-1">
+            <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: STOP_COLORS[i] }} />
+            {label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/studies/components/v5/charts/RidgelinePlot.tsx
+++ b/frontend/src/features/studies/components/v5/charts/RidgelinePlot.tsx
@@ -1,0 +1,104 @@
+import type { RidgeSeries } from "./chartAdapters";
+
+// Two-timepoint palette (Acumenus): baseline muted → diagnosis teal.
+const TIMEPOINT_COLORS: Record<string, string> = {
+  t1: "#6B7280",
+  t2: "#C9A227",
+  t_dx: "#2DD4BF",
+};
+
+/**
+ * Stacked kernel-density ridgeline. Each group gets a band; within it every
+ * timepoint's KDE is drawn as a filled area on a shared x-scale, so the leftward
+ * shift of blood pressure from baseline (t1) to diagnosis (t_dx) reads at a
+ * glance. Self-contained SVG — no chart dependency.
+ */
+export function RidgelinePlot({
+  series,
+  xLabel = "mmHg",
+  height = 260,
+}: {
+  series: RidgeSeries[];
+  xLabel?: string;
+  height?: number;
+}) {
+  const clean = series.filter((s) => s.points.length > 0);
+  if (clean.length === 0) {
+    return <p className="text-xs text-text-ghost italic">No distribution data.</p>;
+  }
+
+  const groups = Array.from(new Set(clean.map((s) => s.group)));
+  const allX = clean.flatMap((s) => s.points.map((p) => p[0]));
+  const xMin = Math.min(...allX);
+  const xMax = Math.max(...allX);
+  const maxDensity = Math.max(...clean.flatMap((s) => s.points.map((p) => p[1])), 1e-9);
+
+  const W = 720;
+  const padL = 96;
+  const padR = 16;
+  const padT = 12;
+  const padB = 28;
+  const plotW = W - padL - padR;
+  const bandH = (height - padT - padB) / groups.length;
+  const ridgeH = bandH * 1.5; // overlap for the classic ridgeline look
+
+  const sx = (x: number) => padL + ((x - xMin) / (xMax - xMin || 1)) * plotW;
+
+  return (
+    <div className="overflow-x-auto">
+      <svg viewBox={`0 0 ${W} ${height}`} className="w-full" role="img" aria-label="Blood-pressure distribution ridgeline">
+        {/* x grid + ticks */}
+        {[xMin, (xMin + xMax) / 2, xMax].map((tick) => (
+          <g key={tick}>
+            <line x1={sx(tick)} x2={sx(tick)} y1={padT} y2={height - padB} stroke="currentColor" className="text-border-default" strokeWidth={0.5} />
+            <text x={sx(tick)} y={height - padB + 16} textAnchor="middle" className="fill-text-ghost text-[9px]">
+              {Math.round(tick)}
+            </text>
+          </g>
+        ))}
+        <text x={padL + plotW / 2} y={height - 2} textAnchor="middle" className="fill-text-muted text-[10px]">
+          {xLabel}
+        </text>
+
+        {groups.map((group, gi) => {
+          const baseY = padT + gi * bandH + bandH;
+          const groupSeries = clean.filter((s) => s.group === group);
+          return (
+            <g key={group}>
+              <text x={padL - 8} y={baseY - 4} textAnchor="end" className="fill-text-secondary text-[10px]">
+                {group}
+              </text>
+              {groupSeries.map((s) => {
+                const color = TIMEPOINT_COLORS[s.timepoint] ?? "#9B1B30";
+                const path = s.points
+                  .map((p, i) => {
+                    const px = sx(p[0]);
+                    const py = baseY - (p[1] / maxDensity) * ridgeH;
+                    return `${i === 0 ? "M" : "L"}${px.toFixed(1)},${py.toFixed(1)}`;
+                  })
+                  .join(" ");
+                const area = `${path} L${sx(s.points[s.points.length - 1][0]).toFixed(1)},${baseY} L${sx(s.points[0][0]).toFixed(1)},${baseY} Z`;
+                return (
+                  <g key={`${s.group}-${s.timepoint}`}>
+                    <path d={area} fill={color} fillOpacity={0.18} />
+                    <path d={path} fill="none" stroke={color} strokeWidth={1.5} />
+                  </g>
+                );
+              })}
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* legend */}
+      <div className="mt-1 flex flex-wrap items-center gap-3 pl-24 text-[10px] text-text-muted">
+        {Array.from(new Set(clean.map((s) => s.timepoint))).map((tp) => (
+          <span key={tp} className="inline-flex items-center gap-1">
+            <span className="inline-block h-2 w-3 rounded-sm" style={{ backgroundColor: TIMEPOINT_COLORS[tp] ?? "#9B1B30" }} />
+            {tp}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/studies/components/v5/charts/chartAdapters.ts
+++ b/frontend/src/features/studies/components/v5/charts/chartAdapters.ts
@@ -1,0 +1,50 @@
+import { num, str } from "../narrow";
+
+export interface RidgeSeries {
+  group: string;
+  timepoint: string;
+  points: Array<[number, number]>;
+}
+
+export interface TrellisRow {
+  group: string;
+  t1: number;
+  t2: number;
+  t_dx: number;
+}
+
+/** Adapt the compact N `kde` payload into ridgeline series. */
+export function toRidgeSeries(kde: unknown): RidgeSeries[] {
+  if (!Array.isArray(kde)) return [];
+  return kde
+    .map((entry) => {
+      const rec = entry as Record<string, unknown>;
+      const rawPoints = Array.isArray(rec.points) ? rec.points : [];
+      const points = rawPoints
+        .map((p): [number, number] | null => {
+          if (!Array.isArray(p) || p.length < 2) return null;
+          const x = num(p[0]);
+          const y = num(p[1]);
+          return x === null || y === null ? null : [x, y];
+        })
+        .filter((p): p is [number, number] => p !== null);
+      return { group: str(rec.group), timepoint: str(rec.timepoint), points };
+    })
+    .filter((s) => s.points.length > 0);
+}
+
+/** Adapt the compact N `trellis` payload into trellis rows. */
+export function toTrellisRows(trellis: unknown): TrellisRow[] {
+  if (!Array.isArray(trellis)) return [];
+  return trellis
+    .map((entry) => {
+      const rec = entry as Record<string, unknown>;
+      return {
+        group: str(rec.group),
+        t1: num(rec.t1) ?? 0,
+        t2: num(rec.t2) ?? 0,
+        t_dx: num(rec.t_dx) ?? 0,
+      };
+    })
+    .filter((r) => r.group !== "");
+}

--- a/frontend/src/features/studies/components/v5/csv.ts
+++ b/frontend/src/features/studies/components/v5/csv.ts
@@ -1,0 +1,23 @@
+/**
+ * Minimal client-side CSV export. The v5 summary_data already carries the full
+ * long-form arrays (matrix cells, BP rows, phenotype grid), so exports render
+ * from what is already loaded — no extra request. Group-level aggregates only;
+ * no PHI is ever present in summary_data.
+ */
+export function downloadCsv(filename: string, headers: string[], rows: Array<Array<string | number>>): void {
+  const escape = (cell: string | number): string => {
+    const s = String(cell ?? "");
+    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+
+  const lines = [headers.map(escape).join(","), ...rows.map((row) => row.map(escape).join(","))];
+  const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename.endsWith(".csv") ? filename : `${filename}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/features/studies/components/v5/narrow.ts
+++ b/frontend/src/features/studies/components/v5/narrow.ts
@@ -1,0 +1,95 @@
+import { formatNumber } from "@/i18n/format";
+import type { CovariateBalanceEntry, EstimateEntry } from "@/features/estimation/types/estimation";
+
+// ---------------------------------------------------------------------------
+// Defensive narrowing for v5 summary_data (projected as Record<string, unknown>).
+// Mirrors the helpers in StudyResultSummary so every field access is safe.
+// ---------------------------------------------------------------------------
+
+export function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+export function records(value: unknown): Record<string, unknown>[] {
+  return asArray(value).map(asRecord);
+}
+
+export function num(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+export function bool(value: unknown): boolean {
+  return value === true;
+}
+
+export function fmt(value: unknown, digits = 2): string {
+  const n = num(value);
+  return n === null ? "—" : n.toFixed(digits);
+}
+
+export function fmtCount(value: unknown): string {
+  const n = num(value);
+  return n === null ? "—" : formatNumber(n);
+}
+
+export function fmtPct(value: unknown, digits = 1): string {
+  const n = num(value);
+  return n === null ? "—" : `${(n * 100).toFixed(digits)}%`;
+}
+
+/** A summary_data row is a fixture when it carries the projector's _fixture flag. */
+export function isFixture(data: Record<string, unknown>): boolean {
+  return data._fixture === true;
+}
+
+// ---------------------------------------------------------------------------
+// Adapters — compact v5 estimate/balance rows → the shapes the reusable
+// estimation charts (ForestPlot, LovePlot) require. Required numeric fields the
+// v5 payload does not carry are derived (log HR / SE from the CI) or zero-filled
+// where the chart does not read them.
+// ---------------------------------------------------------------------------
+
+/** Build a full EstimateEntry (for ForestPlot) from a compact {outcome, HR, CI} row. */
+export function toForestEstimate(row: Record<string, unknown>, index: number): EstimateEntry {
+  const hr = num(row.hazard_ratio) ?? num(row.estimate) ?? 1;
+  const lo = num(row.ci_95_lower) ?? hr;
+  const hi = num(row.ci_95_upper) ?? hr;
+  const safeHr = hr > 0 ? hr : 1;
+  const seLogHr = hi > 0 && lo > 0 && hi > lo ? (Math.log(hi) - Math.log(lo)) / (2 * 1.96) : 0.1;
+
+  return {
+    outcome_id: index,
+    outcome_name: str(row.outcome_name) || `#${index + 1}`,
+    hazard_ratio: hr,
+    ci_95_lower: lo,
+    ci_95_upper: hi,
+    p_value: num(row.p_value) ?? 1,
+    log_hr: Math.log(safeHr),
+    se_log_hr: seLogHr,
+    target_outcomes: num(row.target_outcomes) ?? 0,
+    comparator_outcomes: num(row.comparator_outcomes) ?? 0,
+  };
+}
+
+/** Build a CovariateBalanceEntry (for LovePlot) from a compact {covariate, smd_before, smd_after} row. */
+export function toBalanceEntry(row: Record<string, unknown>): CovariateBalanceEntry {
+  return {
+    covariate_name: str(row.covariate) || str(row.covariate_name) || "—",
+    smd_before: num(row.smd_before) ?? 0,
+    smd_after: num(row.smd_after) ?? 0,
+    mean_target_before: 0,
+    mean_comp_before: 0,
+    mean_target_after: 0,
+    mean_comp_after: 0,
+  };
+}

--- a/frontend/src/features/studies/components/v5/ui.tsx
+++ b/frontend/src/features/studies/components/v5/ui.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from "react";
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
+import { fmt, num } from "./narrow";
+
+/** Compact metric tile. */
+export function Tile({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="bg-surface-darkest rounded p-2">
+      <p className="text-[9px] text-text-ghost uppercase tracking-wide">{label}</p>
+      <p className="text-sm text-text-primary font-mono">{value}</p>
+      {hint && <p className="text-[9px] text-text-ghost mt-0.5">{hint}</p>}
+    </div>
+  );
+}
+
+export function SectionTitle({ children }: { children: ReactNode }) {
+  return (
+    <h5 className="text-[10px] font-semibold text-text-muted uppercase tracking-wider mb-2">{children}</h5>
+  );
+}
+
+/**
+ * Estimability gate banner for comparative designs (O/P/R). A withheld estimate
+ * (failed gate) renders as an explicit withheld state — never a silent number.
+ */
+export function GateBanner({
+  estimable,
+  gates,
+}: {
+  estimable: boolean;
+  gates: Record<string, unknown>;
+}) {
+  const maxSmd = num(gates.max_smd);
+  const equipoise = num(gates.equipoise);
+  const nullCentered = gates.null_centered === true;
+
+  if (!estimable) {
+    return (
+      <div className="flex items-start gap-2 rounded-md border border-critical/40 bg-critical/10 px-3 py-2 text-xs text-critical">
+        <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+        <span>
+          <span className="font-semibold">Estimate withheld.</span> One or more estimability gates
+          failed — no effect estimate is shown. Diagnostics are reported below for transparency.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md border border-success/30 bg-success/10 px-3 py-2 text-[11px] text-success">
+      <span className="inline-flex items-center gap-1 font-semibold">
+        <CheckCircle2 size={13} /> Estimability gates cleared
+      </span>
+      {maxSmd !== null && <span>max |SMD| {fmt(maxSmd, 3)}</span>}
+      {equipoise !== null && <span>equipoise {fmt(equipoise, 2)}</span>}
+      <span>null {nullCentered ? "centered" : "off-center"}</span>
+    </div>
+  );
+}
+
+/** Small badge with a semantic tone. */
+export function StatusPill({ label, tone }: { label: string; tone: "ok" | "warn" | "bad" | "muted" }) {
+  const cls =
+    tone === "ok"
+      ? "bg-success/10 text-success"
+      : tone === "warn"
+        ? "bg-warning/10 text-warning"
+        : tone === "bad"
+          ? "bg-critical/10 text-critical"
+          : "bg-info/10 text-info";
+  return <span className={`px-1.5 py-0.5 rounded text-[9px] font-medium ${cls}`}>{label}</span>;
+}

--- a/frontend/src/features/studies/pages/StudyDetailPage.tsx
+++ b/frontend/src/features/studies/pages/StudyDetailPage.tsx
@@ -42,6 +42,7 @@ import { StudyMilestonesTab } from "../components/StudyMilestonesTab";
 import { StudyArtifactsTab } from "../components/StudyArtifactsTab";
 import { StudyActivityTab } from "../components/StudyActivityTab";
 import { StudyResultsTab } from "../components/StudyResultsTab";
+import { StudyV5ReportTab } from "../components/StudyV5ReportTab";
 import { StudyManuscriptTab } from "../components/StudyManuscriptTab";
 import { FederatedExecutionTab } from "../components/FederatedExecutionTab";
 import { StudyGatesTab } from "../components/StudyGatesTab";
@@ -60,6 +61,7 @@ import {
   useStudyCohorts,
   useStudyMilestones,
   useStudyArtifacts,
+  useStudyResults,
 } from "../hooks/useStudies";
 
 // ---------------------------------------------------------------------------
@@ -81,7 +83,7 @@ const STATUS_COLORS: Record<string, { bg: string; fg: string; dot: string }> = {
   withdrawn: { bg: "#E85A6B15", fg: "var(--critical)", dot: "var(--critical)" },
 };
 
-type TabKey = "overview" | "design" | "analyses" | "results" | "gates" | "manuscript" | "sites" | "team" | "cohorts" | "milestones" | "artifacts" | "activity" | "federated";
+type TabKey = "overview" | "design" | "analyses" | "results" | "report" | "gates" | "manuscript" | "sites" | "team" | "cohorts" | "milestones" | "artifacts" | "activity" | "federated";
 
 interface TabDef {
   key: TabKey;
@@ -118,6 +120,7 @@ const TAB_GROUPS: TabGroup[] = [
     id: "evidence",
     tabs: [
       { key: "results", icon: Layers },
+      { key: "report", icon: FileText },
       { key: "gates", icon: ShieldCheck },
       { key: "manuscript", icon: FileOutput },
     ],
@@ -169,6 +172,18 @@ export default function StudyDetailPage() {
   const { data: cohortsData } = useStudyCohorts(slug || null);
   const { data: milestonesData } = useStudyMilestones(slug || null);
   const { data: artifactsData } = useStudyArtifacts(slug || null);
+
+  // The v5 Report tab only appears for studies that carry a triangulation result
+  // (the Hypertension Outcomes Program v5 headline), so it never clutters
+  // unrelated studies.
+  const { data: v5ReportProbe } = useStudyResults(slug || null, { result_type: "triangulation", per_page: 1 });
+  const hasV5Report = (v5ReportProbe?.items?.length ?? 0) > 0;
+
+  const visibleGroups = TAB_GROUPS.map((group) =>
+    group.id === "evidence" && !hasV5Report
+      ? { ...group, tabs: group.tabs.filter((tab) => tab.key !== "report") }
+      : group,
+  );
 
   const tabCounts: Partial<Record<TabKey, number>> = {
     analyses: analyses?.length,
@@ -454,7 +469,7 @@ export default function StudyDetailPage() {
 
       {/* Tab navigation — grouped by study lifecycle phase */}
       <div className="tab-bar overflow-x-auto" style={{ scrollbarWidth: "none" }}>
-        {TAB_GROUPS.map((group, groupIndex) => (
+        {visibleGroups.map((group, groupIndex) => (
           <div key={group.id} className="flex items-center">
             {groupIndex > 0 && (
               <span className="mx-1.5 h-4 w-px shrink-0 bg-border-default" aria-hidden />
@@ -473,7 +488,7 @@ export default function StudyDetailPage() {
                   className={cn("tab-item flex items-center gap-1.5 whitespace-nowrap", activeTab === tab.key && "active")}
                 >
                   <Icon size={14} />
-                  {t(`studies.detail.tabs.${tab.key}`)}
+                  {t(`studies.detail.tabs.${tab.key}`, { defaultValue: humanizeToken(tab.key) })}
                   {count != null && (
                     <span className="ml-0.5 text-[10px] font-medium text-text-ghost">
                       ({count})
@@ -503,6 +518,7 @@ export default function StudyDetailPage() {
       )}
       {activeTab === "analyses" && <StudyAnalysesTab studyId={study.id} studySlug={study.slug} />}
       {activeTab === "results" && <StudyResultsTab slug={study.slug} />}
+      {activeTab === "report" && <StudyV5ReportTab slug={study.slug} />}
       {activeTab === "gates" && <StudyGatesTab slug={study.slug} canDecide />}
       {activeTab === "manuscript" && <StudyManuscriptTab slug={study.slug} />}
       {activeTab === "sites" && <StudySitesTab slug={study.slug} />}

--- a/scripts/sql/htn-v5-fixture-tables.sql
+++ b/scripts/sql/htn-v5-fixture-tables.sql
@@ -1,0 +1,78 @@
+-- HTN v5 demonstration-fixture long-form tables (Layer 2 table reader + CSV).
+--
+-- The Parthenon runtime role (parthenon_app) has USAGE but NO CREATE on the
+-- `results` schema by design (owner/migrator/runtime split). These tables must
+-- therefore be created by the owner. Run once as parthenon_owner (or a
+-- superuser that SET ROLEs to it):
+--
+--   psql -U claude_dev -h localhost -d parthenon -f scripts/sql/htn-v5-fixture-tables.sql
+--
+-- After creation, `study:seed-htn-v5-fixture` (running as parthenon_app) can
+-- TRUNCATE + INSERT the fixture rows via the granted privileges below.
+-- Additive only; touches nothing in omop / vocab.
+
+SET ROLE parthenon_owner;
+
+CREATE TABLE IF NOT EXISTS results.htn_v4_m_comorbidity_matrix (
+    morbidity   text,
+    population  text,
+    prevalence  numeric,
+    wilson_lo   numeric,
+    wilson_hi   numeric,
+    n_present   integer,
+    n_total     integer,
+    adjusted_or numeric,
+    or_ci_lo    numeric,
+    or_ci_hi    numeric
+);
+
+CREATE TABLE IF NOT EXISTS results.htn_v4_n_bp_distribution (
+    grp       text,
+    timepoint text,
+    measure   text,
+    n         integer,
+    mean      numeric,
+    sd        numeric,
+    median    numeric,
+    q1        numeric,
+    q3        numeric,
+    skew      numeric,
+    kurt      numeric
+);
+
+CREATE TABLE IF NOT EXISTS results.htn_v4_q_phenotype_grid (
+    index_rule        text,
+    threshold         integer,
+    max_gap           integer,
+    never_dx_fraction numeric,
+    n                 integer,
+    median_latency    integer,
+    visit_linked      boolean
+);
+
+CREATE TABLE IF NOT EXISTS results.htn_v4_r_instrument (
+    tertile    integer,
+    covariate  text,
+    mean_value numeric,
+    balanced   boolean
+);
+
+CREATE TABLE IF NOT EXISTS results.htn_v4_triangulation (
+    design      text,
+    outcome     text,
+    estimate    numeric,
+    ci_lo       numeric,
+    ci_hi       numeric,
+    estimable   boolean,
+    gate_status text
+);
+
+GRANT SELECT, INSERT, TRUNCATE, DELETE ON
+    results.htn_v4_m_comorbidity_matrix,
+    results.htn_v4_n_bp_distribution,
+    results.htn_v4_q_phenotype_grid,
+    results.htn_v4_r_instrument,
+    results.htn_v4_triangulation
+TO parthenon_app;
+
+RESET ROLE;


### PR DESCRIPTION
## Summary
Surfaces the Hypertension Outcomes Program **v5** (analyses M–R + triangulation) natively in the React studies module.

**Key context:** v5 had never been executed — study 165 carried only its four v4 results. This builds the full surfacing pipeline and drives it with a representative, clearly-labelled **demonstration fixture** (grounded in real v4 baseline facts: T=109,763; never-dx≈90%; CKD HR≈2.60; 37.9% coverage). Every fixture figure renders a "Demonstration data" provenance banner.

## What's included
**Backend**
- `study:seed-htn-v5-fixture` — idempotent seeder: 7 curated `study_results` rows (compact chart-ready `summary_data`) + long-form `results.htn_v4_*` tables. Estimability gates on O/P/R; IV withheld from publish. `SourceAware` trait; Pint + PHPStan L8 clean.
- `scripts/sql/htn-v5-fixture-tables.sql` — owner DDL + grants (runtime role has no CREATE on results).

**Frontend**
- 7 per-analysis renderers (`components/v5/`) dispatched from `StudyResultSummary` — Results tab now draws charts, not JSON.
- Reuses `ForestPlot`/`LovePlot`/`KaplanMeierPlot`/`HeatmapChart` via adapters; adds `RidgelinePlot` + `PairedArrowTrellis` for Analysis N.
- New **Report tab** (`StudyV5ReportTab`) — triangulation headline + designs + matrices + derived V&V acceptance matrix; gated to studies with a triangulation result.
- Failed gates render an explicit withheld state, never a blinded number. M/N/Q full-table + CSV export client-side from `summary_data` (no PHI egress).

## Test plan
- [x] Pint + PHPStan L8 clean
- [x] `tsc --noEmit` + `vite build` + ESLint clean
- [x] Vitest 14/14 (adapter/narrowing logic)
- [x] Live API returns all 7 v5 rows with correct gating
- [ ] Manual QA on deployed prod: study 165 → Results + Report tabs

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)