### PR TITLE
feat(studies): real Analysis O (withheld) + full 17-morbidity Analysis M

### DIFF
--- a/backend/app/Console/Commands/StudyHtnV4.php
+++ b/backend/app/Console/Commands/StudyHtnV4.php
@@ -4,9 +4,14 @@ namespace App\Console\Commands;
 
 use App\Concerns\SourceAware;
 use App\Context\SourceContext;
+use App\Models\App\EstimationAnalysis;
 use App\Models\App\Source;
 use App\Models\App\Study;
 use App\Models\App\StudyResult;
+use App\Services\Analysis\HadesBridgeService;
+use App\Services\RService;
+use App\Support\EstimationResultNormalizer;
+use App\Support\Studies\EstimationClearance;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 
@@ -39,11 +44,20 @@ class StudyHtnV4 extends Command
     use SourceAware;
 
     protected $signature = 'study:htn-v4
-        {--action=analyses : reuse-audit|analyses|report}
+        {--action=analyses : reuse-audit|analyses|run-o|report}
         {--plan-version=v5 : analysis-plan version (avoids the reserved --version flag)}
         {--study=165 : study id}
         {--source=ACUMENUS : source key whose results schema holds the tables}
         {--dry-run : report without persisting}';
+
+    /** Analysis O cohorts: timely G1, delayed = union(G2,G3,G4) materialised as 5456. */
+    private const O_TIMELY = 5450;
+
+    private const O_DELAYED = 5456;
+
+    private const O_OUTCOMES = [5426 => 'MACE', 5427 => 'CKD progression'];
+
+    private const O_NEG_CONTROLS = [5442, 5443, 5444, 5445, 5446, 5447, 5448, 5449];
 
     protected $description = 'Hypertension v5 executor — runs the CDM-computable analyses (Analysis M comorbidity matrix); R-based causal analyses are skipped when the R runtime is absent';
 
@@ -71,11 +85,27 @@ class StudyHtnV4 extends Command
         'Primary aldosteronism' => 191,
     ];
 
-    /** Spec morbidities with no verified concept set yet (Analysis M coverage gap). */
-    private const PENDING_MORBIDITIES = [
-        'Dyslipidemia', 'Obesity', 'Sleep apnea', 'COPD', 'Depression/anxiety',
-        'Coronary artery disease', 'Peripheral vascular disease', 'Cerebrovascular disease',
-        'Atrial fibrillation', 'Hypertensive retinopathy', 'Cancer', 'Dementia', 'Liver disease',
+    /**
+     * The remaining spec morbidities, each keyed to VERIFIED standard SNOMED
+     * Condition root concept_ids (looked up + confirmed against vocab.concept —
+     * not guessed). Descendants are expanded at query time via concept_ancestor.
+     *
+     * @var array<string, list<int>>
+     */
+    private const MORBIDITY_ROOTS = [
+        'Dyslipidemia' => [432867],
+        'Obesity (dx)' => [433736],
+        'Sleep apnea' => [313459],
+        'COPD' => [255573],
+        'Depression/anxiety' => [440383, 442077],
+        'Coronary artery disease' => [4185932],
+        'Peripheral vascular disease' => [321052],
+        'Cerebrovascular disease' => [381591],
+        'Atrial fibrillation' => [313217],
+        'Hypertensive retinopathy' => [376965],
+        'Cancer' => [443392],
+        'Dementia' => [4182210],
+        'Liver disease' => [4212540],
     ];
 
     public function handle(): int
@@ -92,6 +122,7 @@ class StudyHtnV4 extends Command
         return match ($action) {
             'reuse-audit' => $this->reuseAudit($studyId),
             'analyses' => $this->runAnalyses($studyId),
+            'run-o' => $this->runOverlapWeighted($studyId),
             'report' => $this->report($studyId),
             default => tap(self::FAILURE, fn () => $this->error("Unknown action '{$action}'.")),
         };
@@ -104,8 +135,8 @@ class StudyHtnV4 extends Command
             $n = DB::table('results.cohort')->where('cohort_definition_id', $id)->count();
             $this->line(sprintf('  %-22s cohort %d = %d', $label, $id, $n));
         }
-        $this->line('  Morbidity concept sets available: '.implode(', ', array_keys(self::MORBIDITY_SETS)));
-        $this->warn('  Pending concept-set materialisation: '.implode(', ', self::PENDING_MORBIDITIES));
+        $this->line('  Morbidities (concept sets): '.implode(', ', array_keys(self::MORBIDITY_SETS)));
+        $this->line('  Morbidities (verified SNOMED roots): '.implode(', ', array_keys(self::MORBIDITY_ROOTS)));
 
         return self::SUCCESS;
     }
@@ -118,9 +149,23 @@ class StudyHtnV4 extends Command
         $denoms = $this->populationDenominators();
         $rows = [];
         $heatmap = [];
+        $excluded = [];
 
-        foreach (self::MORBIDITY_SETS as $morbidity => $conceptSetId) {
-            $byPop = $this->morbidityByPopulation($conceptSetId);
+        foreach ($this->morbidityConceptSources() as $morbidity => $src) {
+            $byPop = $this->countByPopulation($src['sql'], $src['bindings']);
+
+            // A morbidity with zero cases across ALL six populations is not
+            // captured by this concept phenotype in this CDM (e.g. Synthea models
+            // no PVD, and only diabetic — not hypertensive — retinopathy). Flag it
+            // for mapping review rather than persist a misleading row of zeros.
+            $totalEver = array_sum(array_map(fn (array $c): int => $c['ever'], $byPop));
+            if ($totalEver === 0) {
+                $excluded[] = $morbidity;
+                $this->warn(sprintf('  %-24s not captured in this CDM — excluded (concept mapping under review)', $morbidity));
+
+                continue;
+            }
+
             foreach (self::POPULATIONS as $popId => $popLabel) {
                 $counts = $byPop[$popId] ?? ['pre' => 0, 'new' => 0, 'ever' => 0];
                 $denom = $denoms[$popId] ?? 0;
@@ -160,7 +205,7 @@ class StudyHtnV4 extends Command
         }
 
         $this->persistLongForm($rows);
-        $this->persistStudyResult($studyId, $heatmap);
+        $this->persistStudyResult($studyId, $heatmap, $excluded);
         $this->info('Analysis M persisted (real CDM data). O/P/R/N/F/G/H require the R runtime — skipped.');
 
         return self::SUCCESS;
@@ -172,6 +217,238 @@ class StudyHtnV4 extends Command
         $this->line('  Standalone HTML/PDF report generation is deferred to the R report step (runtime absent).');
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Analysis O — the study's primary causal contrast (timely vs delayed),
+     * run for real through darkstar's proven CohortMethod estimation endpoint
+     * (PS matching + Cox + empirical calibration). Exact PSweight ATO is not in
+     * the endpoint; PS matching is the spec's named sensitivity and the estimand
+     * differences are noted. A failed estimability gate WITHHOLDS the effect
+     * (required behaviour) rather than reporting a blinded number.
+     */
+    private function runOverlapWeighted(int $studyId): int
+    {
+        $this->info("Analysis O — timely (G1) vs delayed (G2+G3+G4) via darkstar CohortMethod · study {$studyId}");
+
+        $source = Source::query()->where('source_key', $this->option('source'))->first();
+        if (! $source instanceof Source) {
+            $this->error("Source '{$this->option('source')}' not found.");
+
+            return self::FAILURE;
+        }
+
+        // Reuse the proven v4 delay-contrast design (analysis 64): same PS
+        // matching, Cox model, covariate exclusions and negative controls — only
+        // the cohorts change to the collapsed timely-vs-delayed exposure.
+        $base = EstimationAnalysis::query()->whereKey(64)->value('design_json') ?? [];
+
+        $outcomeNames = [];
+        foreach (self::O_OUTCOMES as $id => $name) {
+            $outcomeNames[(string) $id] = $name;
+        }
+
+        $spec = [
+            'source' => HadesBridgeService::buildSourceSpec($source),
+            // Orientation matches the proven v4 delay contrast (analysis 64):
+            // the larger delayed group is the target, timely (G1) the comparator,
+            // so the Cox/negative-control fits stay well-conditioned. The HR is
+            // therefore delayed-relative-to-timely (HR > 1 ⇒ delay is harmful).
+            'cohorts' => [
+                'target_cohort_id' => self::O_DELAYED,
+                'comparator_cohort_id' => self::O_TIMELY,
+                'outcome_cohort_ids' => array_keys(self::O_OUTCOMES),
+                'outcome_names' => $outcomeNames,
+            ],
+            'model' => $base['model'] ?? ['type' => 'cox', 'timeAtRiskStart' => 1, 'timeAtRiskEnd' => 1825, 'endAnchor' => 'cohort_start'],
+            'propensity_score' => $base['propensityScore'] ?? ['enabled' => true, 'method' => 'matching', 'matching' => ['ratio' => 1, 'caliper' => 0.2, 'caliperScale' => 'standardized_logit']],
+            'covariate_settings' => $base['covariateSettings'] ?? ['useDemographicsAge' => true, 'useDemographicsGender' => true, 'useConditionOccurrenceLongTerm' => true],
+            'negative_control_outcomes' => $base['negativeControlOutcomes'] ?? self::O_NEG_CONTROLS,
+        ];
+
+        if ($this->option('dry-run')) {
+            $this->line('  [dry-run] would POST estimation to darkstar (target '.self::O_TIMELY.' vs comparator '.self::O_DELAYED.').');
+
+            return self::SUCCESS;
+        }
+
+        $this->line('  Calling darkstar /analysis/estimation/run (CohortMethod, PS matching + negative-control calibration)…');
+        $raw = app(RService::class)->runEstimation($spec);
+        if (($raw['status'] ?? null) === 'error') {
+            $this->error('  darkstar estimation error: '.($raw['message'] ?? 'unknown'));
+
+            return self::FAILURE;
+        }
+
+        $normalized = EstimationResultNormalizer::normalize($raw);
+        $study = Study::find($studyId);
+        $cleared = $study instanceof Study && EstimationClearance::isCleared($normalized, $study);
+        $calibrated = EstimationClearance::isCalibrated($normalized);
+        $estimable = $cleared && $calibrated;
+
+        $summary = is_array($normalized['summary'] ?? null) ? $normalized['summary'] : [];
+        $ps = is_array($normalized['propensity_score'] ?? null) ? $normalized['propensity_score'] : [];
+        $calibration = is_array($normalized['calibration'] ?? null) ? $normalized['calibration'] : [];
+        $balanceRaw = is_array($normalized['covariate_balance'] ?? null) ? $normalized['covariate_balance'] : [];
+        $maxSmd = $this->maxAbsSmd($balanceRaw);
+        $equipoise = isset($ps['equipoise']) && is_numeric($ps['equipoise']) ? (float) $ps['equipoise'] : null;
+
+        $summaryData = [
+            'analysis_code' => 'O',
+            'label' => 'Delay Effect — delayed (G2–G4) vs timely (G1), PS-matched Cox',
+            'data_source' => 'cdm',
+            'method' => 'darkstar CohortMethod: 1:1 PS matching + Cox + EmpiricalCalibration. Exact PSweight ATO pending (WeightIt not in HADES image); PS matching is the spec-named sensitivity.',
+            'computed_at' => now()->toDateString(),
+            'estimable' => $estimable,
+            'gates' => [
+                'max_smd' => $maxSmd,
+                'equipoise' => $equipoise,
+                'null_centered' => $calibrated,
+            ],
+            'target_count' => isset($summary['target_count']) ? (int) $summary['target_count'] : null,
+            'comparator_count' => isset($summary['comparator_count']) ? (int) $summary['comparator_count'] : null,
+            'estimates' => $estimable ? $this->oEstimates($normalized) : [],
+            'balance' => $this->oBalance($balanceRaw),
+            'calibration' => [
+                'ease' => $calibration['ease'] ?? null,
+                'informative_negative_controls' => $calibration['informative_negative_controls'] ?? null,
+            ],
+            'withheld_reason' => $estimable ? null : $this->withheldReason($maxSmd, $equipoise, $calibrated),
+        ];
+
+        $result = StudyResult::query()
+            ->where('study_id', $studyId)
+            ->where('result_type', 'overlap_weighted_effect')
+            ->first();
+        if ($result instanceof StudyResult) {
+            $result->summary_data = $summaryData;
+            $result->diagnostics = ['data_source' => 'cdm', 'cleared' => $cleared, 'calibrated' => $calibrated];
+            $result->is_publishable = $estimable;
+            $result->save();
+            $this->line('  ✓ study_results overlap_weighted_effect updated to real CDM result');
+        } else {
+            $this->warn('  ⚠ no overlap_weighted_effect row to update (run the fixture seeder first).');
+        }
+
+        $this->info(sprintf(
+            'Analysis O: estimable=%s · max|SMD|=%s · equipoise=%s · target/comparator=%d/%d',
+            $estimable ? 'true' : 'false (withheld)',
+            $maxSmd === null ? '—' : (string) $maxSmd,
+            $equipoise === null ? '—' : (string) $equipoise,
+            $summaryData['target_count'] ?? 0,
+            $summaryData['comparator_count'] ?? 0,
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<mixed>  $balance
+     */
+    private function maxAbsSmd(array $balance): ?float
+    {
+        $max = null;
+        foreach ($balance as $b) {
+            if (is_array($b) && isset($b['smd_after']) && is_numeric($b['smd_after'])) {
+                $abs = abs((float) $b['smd_after']);
+                $max = $max === null ? $abs : max($max, $abs);
+            }
+        }
+
+        return $max === null ? null : round($max, 4);
+    }
+
+    /**
+     * Top covariates by pre-adjustment imbalance, mapped to the love-plot shape.
+     *
+     * @param  array<mixed>  $balance
+     * @return list<array{covariate: string, smd_before: float, smd_after: float}>
+     */
+    private function oBalance(array $balance): array
+    {
+        $rows = [];
+        foreach ($balance as $b) {
+            if (! is_array($b)) {
+                continue;
+            }
+            $rows[] = [
+                'covariate' => is_string($b['covariate_name'] ?? null) ? $b['covariate_name'] : '—',
+                'smd_before' => isset($b['smd_before']) && is_numeric($b['smd_before']) ? round((float) $b['smd_before'], 3) : 0.0,
+                'smd_after' => isset($b['smd_after']) && is_numeric($b['smd_after']) ? round((float) $b['smd_after'], 3) : 0.0,
+            ];
+        }
+        usort($rows, fn (array $a, array $b): int => abs($b['smd_before']) <=> abs($a['smd_before']));
+
+        return array_slice($rows, 0, 15);
+    }
+
+    /**
+     * Effect estimates with E-values (only reached when the gates clear).
+     *
+     * @param  array<string, mixed>  $normalized
+     * @return list<array<string, mixed>>
+     */
+    private function oEstimates(array $normalized): array
+    {
+        $estimates = is_array($normalized['estimates'] ?? null) ? $normalized['estimates'] : [];
+        $calibrated = [];
+        $calib = $normalized['calibration'] ?? [];
+        if (is_array($calib) && is_array($calib['calibrated_estimates'] ?? null)) {
+            foreach ($calib['calibrated_estimates'] as $ce) {
+                if (is_array($ce) && isset($ce['outcome_id'])) {
+                    $calibrated[(int) $ce['outcome_id']] = $ce;
+                }
+            }
+        }
+
+        $out = [];
+        foreach ($estimates as $e) {
+            if (! is_array($e)) {
+                continue;
+            }
+            $hr = isset($e['hazard_ratio']) && is_numeric($e['hazard_ratio']) ? (float) $e['hazard_ratio'] : null;
+            $oid = isset($e['outcome_id']) ? (int) $e['outcome_id'] : null;
+            $ce = $oid !== null ? ($calibrated[$oid] ?? []) : [];
+            $out[] = [
+                'outcome_name' => $e['outcome_name'] ?? "Outcome {$oid}",
+                'hazard_ratio' => $hr,
+                'ci_95_lower' => $e['ci_95_lower'] ?? null,
+                'ci_95_upper' => $e['ci_95_upper'] ?? null,
+                'e_value' => $hr !== null ? $this->eValue($hr) : null,
+                'calibrated_hr' => $ce['calibrated_hr'] ?? null,
+                'cal_ci_lower' => $ce['cal_ci_lower'] ?? null,
+                'cal_ci_upper' => $ce['cal_ci_upper'] ?? null,
+            ];
+        }
+
+        return $out;
+    }
+
+    /** VanderWeele E-value for a hazard ratio. */
+    private function eValue(float $hr): float
+    {
+        if ($hr <= 0) {
+            return 1.0;
+        }
+        $rr = $hr < 1 ? 1 / $hr : $hr;
+
+        return round($rr + sqrt($rr * ($rr - 1)), 2);
+    }
+
+    private function withheldReason(?float $maxSmd, ?float $equipoise, bool $calibrated): string
+    {
+        $fails = [];
+        if ($maxSmd === null || $maxSmd >= 0.1) {
+            $fails[] = 'residual covariate imbalance (max |SMD| '.($maxSmd === null ? 'n/a' : (string) $maxSmd).' ≥ 0.1)';
+        }
+        if ($equipoise !== null && $equipoise < 0.3) {
+            $fails[] = 'insufficient equipoise (< 0.3)';
+        }
+        if (! $calibrated) {
+            $fails[] = 'negative-control null not centered';
+        }
+
+        return $fails === [] ? 'estimability gate failed' : 'Effect withheld — '.implode('; ', $fails).'.';
     }
 
     private function reportRuntimeGaps(): void
@@ -194,41 +471,58 @@ class StudyHtnV4 extends Command
     }
 
     /**
-     * Real per-population comorbidity counts (pre-existing / newly-occurring /
-     * ever) for one morbidity concept set. Concepts resolved from verified seed
-     * roots via vocab.concept_ancestor (standard OMOP descendant expansion —
-     * verified roots, not guessed ids). Fully-qualified schema names read the
-     * omop/vocab/results schemas on the default connection.
+     * All 17 morbidities → the SQL that resolves their eligible standard
+     * concept_ids (+ bindings): the 4 with verified concept sets expand
+     * concept_set_items; the 13 with verified SNOMED roots expand
+     * concept_ancestor. Both are verified inputs, not guessed ids.
      *
+     * @return array<string, array{sql: string, bindings: list<int>}>
+     */
+    private function morbidityConceptSources(): array
+    {
+        $out = [];
+        foreach (self::MORBIDITY_SETS as $name => $setId) {
+            $out[$name] = ['sql' => $this->conceptSetEligibleSql(), 'bindings' => [$setId, $setId, $setId]];
+        }
+        foreach (self::MORBIDITY_ROOTS as $name => $roots) {
+            $placeholders = implode(', ', array_fill(0, count($roots), '?'));
+            $out[$name] = [
+                'sql' => "select descendant_concept_id as concept_id from vocab.concept_ancestor where ancestor_concept_id in ({$placeholders})",
+                'bindings' => $roots,
+            ];
+        }
+
+        return $out;
+    }
+
+    /** Eligible-concept SQL for a concept_set (seeds+descendants minus exclusions); 3 bindings of the set id. */
+    private function conceptSetEligibleSql(): string
+    {
+        return <<<'SQL'
+            select ca.descendant_concept_id as concept_id
+            from app.concept_set_items csi
+            join vocab.concept_ancestor ca on ca.ancestor_concept_id = csi.concept_id
+            where csi.concept_set_id = ? and coalesce(csi.is_excluded, false) = false and coalesce(csi.include_descendants, true) = true
+            union
+            select concept_id from app.concept_set_items
+            where concept_set_id = ? and coalesce(is_excluded, false) = false and coalesce(include_descendants, true) = false
+            except
+            select concept_id from app.concept_set_items where concept_set_id = ? and coalesce(is_excluded, false) = true
+        SQL;
+    }
+
+    /**
+     * Real per-population comorbidity counts (pre-existing / newly-occurring /
+     * ever) for one morbidity's eligible-concept SQL. Fully-qualified schema
+     * names read omop/vocab/results on the default connection.
+     *
+     * @param  list<int>  $bindings
      * @return array<int, array{pre: int, new: int, ever: int}>
      */
-    private function morbidityByPopulation(int $conceptSetId): array
+    private function countByPopulation(string $eligibleSql, array $bindings): array
     {
-        $sql = <<<'SQL'
-            with concepts as (
-                select ca.descendant_concept_id as concept_id
-                from app.concept_set_items csi
-                join vocab.concept_ancestor ca on ca.ancestor_concept_id = csi.concept_id
-                where csi.concept_set_id = ?
-                  and coalesce(csi.is_excluded, false) = false
-                  and coalesce(csi.include_descendants, true) = true
-                union
-                select concept_id
-                from app.concept_set_items
-                where concept_set_id = ?
-                  and coalesce(is_excluded, false) = false
-                  and coalesce(include_descendants, true) = false
-            ),
-            excluded as (
-                select concept_id
-                from app.concept_set_items
-                where concept_set_id = ? and coalesce(is_excluded, false) = true
-            ),
-            eligible as (
-                select concept_id from concepts
-                except
-                select concept_id from excluded
-            ),
+        $sql = <<<SQL
+            with eligible as ({$eligibleSql}),
             pop as (
                 select cohort_definition_id, subject_id, cohort_start_date
                 from results.cohort
@@ -252,7 +546,7 @@ class StudyHtnV4 extends Command
         SQL;
 
         $out = [];
-        foreach (DB::select($sql, [$conceptSetId, $conceptSetId, $conceptSetId]) as $row) {
+        foreach (DB::select($sql, $bindings) as $row) {
             $out[(int) $row->cohort_definition_id] = [
                 'pre' => (int) $row->n_pre,
                 'new' => (int) $row->n_new,
@@ -319,8 +613,9 @@ class StudyHtnV4 extends Command
      * real CDM figures (drops the fixture flag for this analysis).
      *
      * @param  list<array<string, mixed>>  $heatmap
+     * @param  list<string>  $excluded
      */
-    private function persistStudyResult(int $studyId, array $heatmap): void
+    private function persistStudyResult(int $studyId, array $heatmap, array $excluded = []): void
     {
         $result = StudyResult::query()
             ->where('study_id', $studyId)
@@ -333,19 +628,27 @@ class StudyHtnV4 extends Command
             return;
         }
 
+        $allMorbidities = array_merge(array_keys(self::MORBIDITY_SETS), array_keys(self::MORBIDITY_ROOTS));
+        $reported = array_values(array_diff($allMorbidities, $excluded));
+
+        $note = 'Real prevalence + Wilson 95% CI from the Acumenus omop CDM for '.count($reported).' morbidities × 6 populations × 2 epochs. Concepts resolved from verified concept sets / SNOMED roots (descendant-expanded). Covariate-adjusted ORs (R logistic) remain pending.';
+        if ($excluded !== []) {
+            $note .= ' Not captured in this CDM (excluded, mapping under review): '.implode(', ', $excluded).'.';
+        }
+
         $result->summary_data = [
             'analysis_code' => 'M',
             'label' => 'Comorbidity Comparison Matrix (real CDM prevalence)',
             'data_source' => 'cdm',
             'computed_at' => now()->toDateString(),
-            'morbidities' => array_keys(self::MORBIDITY_SETS),
+            'morbidities' => $reported,
             'populations' => array_values(self::POPULATIONS),
             'heatmap' => $heatmap,
-            'pending_morbidities' => self::PENDING_MORBIDITIES,
-            'note' => 'Real prevalence + Wilson 95% CI from the Acumenus omop CDM for '.count(self::MORBIDITY_SETS).' morbidities with verified concept sets. Adjusted ORs and the remaining '.count(self::PENDING_MORBIDITIES).' morbidities are pending (require R runtime / concept-set materialisation).',
+            'pending_morbidities' => $excluded,
+            'note' => $note,
             'result_table' => 'comorbidity-matrix',
         ];
-        $result->diagnostics = ['data_source' => 'cdm', 'r_runtime' => 'absent'];
+        $result->diagnostics = ['data_source' => 'cdm', 'morbidity_count' => count($reported), 'excluded' => $excluded];
         $result->save();
 
         $this->line('  ✓ app.study_results comorbidity_matrix row updated to real CDM data');

--- a/docs/devlog/modules/studies/2026-07-04-htn-v5-frontend-surfacing.md
+++ b/docs/devlog/modules/studies/2026-07-04-htn-v5-frontend-surfacing.md
@@ -86,6 +86,41 @@ matrix), descriptive core**, from the live CDM.
 - Query is index-driven (`idx_co_concept_person`), ~0.2 s per morbidity, no
   `measurement` value-scan, no R. Pint + PHPStan L8 clean.
 
+## Follow-up 2 — real Analysis O + full Analysis M
+
+**Correction to the "R runtime absent" finding:** the HADES runtime is present — it
+is the **`darkstar`** service (`http://darkstar:8787`, Plumber2, 40 HADES packages
+incl. CohortMethod/Cyclops/EmpiricalCalibration), not a service literally named
+`r-runtime`. It was already up.
+
+**Analysis O (primary causal contrast) — now REAL, correctly withheld.** Added
+`study:htn-v4 --action=run-o`. It materialises a delayed comparator cohort
+(`results.cohort` id 5456 = G2∪G3∪G4 = 10,855, additive), reuses the proven v4
+delay-contrast design (analysis 64: 1:1 PS matching, Cox, same covariate
+exclusions + 8 negative controls), and calls darkstar `/analysis/estimation/run`
+via `EstimationService`/`RService`. Orientation matches v4 (delayed as target,
+timely as comparator) so the fits stay well-conditioned. Result: **estimable =
+false** — max |SMD| 0.2434 ≥ 0.1 (equipoise 0.9535, EASE 0.033, 7 informative
+NCs). This **replaces the fixture's fabricated estimable HR 0.88 with the truthful
+withheld result** — the same non-estimability v4 found for G4-vs-G1. Exact PSweight
+ATO is not in the HADES image; PS matching is the spec's named sensitivity (noted
+in `method`).
+
+**Analysis M — expanded from 4 → all 17 morbidities, real CDM.** Added 13 verified
+SNOMED roots (confirmed against `vocab.concept`, descendant-expanded via
+`concept_ancestor`). Two data-quality corrections found by running it: CAD was 0%
+everywhere under "Coronary arteriosclerosis" (317576) — the CDM codes it as
+"Ischemic heart disease" (4185932), which shows the expected gradient (G1 10.1% →
+G3 16.7%). Morbidities that are **zero across all six populations** are flagged
+"not captured in this CDM (mapping under review)" and excluded rather than shown as
+misleading zeros — 4 excluded (primary aldosteronism, obesity-as-dx, PVD,
+hypertensive retinopathy; the CDM has only diabetic retinopathy and models no
+PVD). **13 reported morbidities × 6 populations × 2 epochs = 78 real rows.** Both
+the M and O frontend views show a green "Real CDM" provenance note.
+
+**Provenance now:** M + O = real CDM; N, P, Q, R, triangulation = fixture (need
+custom darkstar R endpoints — darkstar has no target-trial or IV endpoint).
+
 ### Hard environmental blockers (why the rest stays fixture)
 - **The R / HADES runtime is absent from this compose stack** (`r-runtime` = "no
   such service"). That makes **O (ATO), P (target-trial + IPCW), R (site IV /

--- a/frontend/src/features/studies/components/v5/ComorbidityMatrixView.tsx
+++ b/frontend/src/features/studies/components/v5/ComorbidityMatrixView.tsx
@@ -42,7 +42,7 @@ export function ComorbidityMatrixView({ data }: { data: Record<string, unknown> 
             {str(data.note) || "Prevalence + Wilson 95% CI computed from the Acumenus omop CDM."}
             {pending.length > 0 && (
               <span className="mt-1 block text-text-muted">
-                Pending concept-set materialisation ({pending.length}): {pending.join(", ")}.
+                Not captured in this CDM — concept mapping under review ({pending.length}): {pending.join(", ")}.
               </span>
             )}
           </span>

--- a/frontend/src/features/studies/components/v5/OverlapWeightedEffectView.tsx
+++ b/frontend/src/features/studies/components/v5/OverlapWeightedEffectView.tsx
@@ -1,3 +1,4 @@
+import { Database } from "lucide-react";
 import { ForestPlot } from "@/features/estimation/components/ForestPlot";
 import { LovePlot } from "@/features/estimation/components/LovePlot";
 import { FixtureBanner } from "./FixtureBanner";
@@ -18,9 +19,23 @@ export function OverlapWeightedEffectView({ data }: { data: Record<string, unkno
   const calibration = asRecord(data.calibration);
   const riskDiff = asRecord(data.risk_difference_5y);
 
+  const isRealCdm = str(data.data_source) === "cdm";
+
   return (
     <div className="space-y-4">
       <FixtureBanner data={data} />
+      {isRealCdm && (
+        <div className="flex items-start gap-2 rounded-md border border-success/30 bg-success/10 px-3 py-2 text-[11px] text-success">
+          <Database size={14} className="mt-0.5 shrink-0" />
+          <span>
+            <span className="font-semibold uppercase tracking-wide">Real CDM result · </span>
+            {str(data.method) || "Computed via darkstar CohortMethod."}
+            {str(data.withheld_reason) && (
+              <span className="mt-1 block text-warning">{str(data.withheld_reason)}</span>
+            )}
+          </span>
+        </div>
+      )}
       <GateBanner estimable={estimable} gates={gates} />
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">


### PR DESCRIPTION
Runs two more v5 analyses against the live CDM via the real HADES runtime (`darkstar`, which was already up).

**Analysis O** (primary causal contrast) now runs real through darkstar's proven CohortMethod estimation path and **correctly withholds** (max |SMD| 0.2434 ≥ 0.1) — replacing the fixture's fabricated estimable HR 0.88 with the truthful result, backed by real PS diagnostics, covariate balance, and negative-control calibration.

**Analysis M** expands from 4 → all 17 morbidities (13 verified SNOMED roots), with data-quality corrections (CAD → Ischemic heart disease) and honest exclusion of 4 morbidities not captured in this CDM. 78 real rows.

M + O views show a "Real CDM" provenance note. N/P/Q/R/triangulation remain fixtures (need custom darkstar endpoints).

- [x] Pint + PHPStan L8, tsc + vite + eslint clean
- [x] O + M persisted and verified against the live CDM

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)