### PR TITLE
feat(studies): exact ATO overlap weighting for O/P + WeightIt in darkstar

### DIFF
--- a/backend/app/Console/Commands/StudyHtnV4.php
+++ b/backend/app/Console/Commands/StudyHtnV4.php
@@ -243,17 +243,17 @@ class StudyHtnV4 extends Command
      */
     private function runOverlapWeighted(int $studyId): int
     {
-        $this->info("Analysis O — delayed (G2–G4) vs timely (G1) via darkstar CohortMethod · study {$studyId}");
+        $this->info("Analysis O — delayed (G2–G4) vs timely (G1) via darkstar ATO overlap weighting · study {$studyId}");
 
-        $r = $this->runContrast($studyId, self::O_DELAYED, self::O_TIMELY);
+        $r = $this->runContrast($studyId, self::O_DELAYED, self::O_TIMELY, 'ato');
         if ($r === null) {
             return self::FAILURE;
         }
 
         $summaryData = [
             'analysis_code' => 'O',
-            'label' => 'Delay Effect — delayed (G2–G4) vs timely (G1), PS-matched Cox',
-            'method' => 'darkstar CohortMethod: 1:1 PS matching + Cox + EmpiricalCalibration. Exact PSweight ATO pending (WeightIt not in HADES image); PS matching is the spec-named sensitivity.',
+            'label' => 'Delay Effect — delayed (G2–G4) vs timely (G1), ATO overlap-weighted Cox',
+            'method' => 'darkstar overlap weighting: exact ATO overlap weights (w=1-e treated, w=e control; Li–Morgan–Zaslavsky) + weighted Cox + EmpiricalCalibration. ATO balances the PS main-effect covariates by construction.',
         ] + $this->estimationSummaryData($r);
 
         $this->persistEstimationRow($studyId, 'overlap_weighted_effect', $summaryData, $r);
@@ -275,15 +275,15 @@ class StudyHtnV4 extends Command
 
         // Target = not-treated (large), comparator = treated (small) — keeps the
         // Cox/negative-control fits well-conditioned, as for O.
-        $r = $this->runContrast($studyId, self::P_UNTREATED, self::P_TREATED);
+        $r = $this->runContrast($studyId, self::P_UNTREATED, self::P_TREATED, 'ato');
         if ($r === null) {
             return self::FAILURE;
         }
 
         $summaryData = [
             'analysis_code' => 'P',
-            'label' => 'Target-Trial Emulation — treat within 90 d vs not (landmark)',
-            'method' => 'Landmark new-user target-trial emulation (index = t2 + 90 d); PS-matched Cox + EmpiricalCalibration. Full clone-censor-weight + IPCW is a refinement.',
+            'label' => 'Target-Trial Emulation — treat within 90 d vs not (landmark + ATO)',
+            'method' => 'Landmark new-user target-trial emulation (index = t2 + 90 d ⇒ no immortal time) with ATO overlap weighting + weighted Cox + EmpiricalCalibration. Full time-varying clone-censor-weight + IPCW is a further refinement.',
             'grace_days' => 90,
             'immortal_time_check' => 'PASS (landmark design — follow-up starts at the grace landmark)',
         ] + $this->estimationSummaryData($r);
@@ -664,7 +664,7 @@ class StudyHtnV4 extends Command
      *
      * @return array<string, mixed>|null
      */
-    private function runContrast(int $studyId, int $target, int $comparator): ?array
+    private function runContrast(int $studyId, int $target, int $comparator, string $method = 'matching'): ?array
     {
         $source = Source::query()->where('source_key', $this->option('source'))->first();
         if (! $source instanceof Source) {
@@ -694,13 +694,19 @@ class StudyHtnV4 extends Command
         ];
 
         if ($this->option('dry-run')) {
-            $this->line("  [dry-run] would POST estimation to darkstar (target {$target} vs comparator {$comparator}).");
+            $this->line("  [dry-run] would POST {$method} estimation to darkstar (target {$target} vs comparator {$comparator}).");
 
             return null;
         }
 
-        $this->line('  Calling darkstar /analysis/estimation/run (CohortMethod, PS matching + negative-control calibration)…');
-        $raw = app(RService::class)->runEstimation($spec);
+        $rService = app(RService::class);
+        if ($method === 'ato') {
+            $this->line('  Calling darkstar /analysis/overlap-weighting/run (ATO overlap weights + weighted Cox + calibration)…');
+            $raw = $rService->runOverlapWeighting($spec);
+        } else {
+            $this->line('  Calling darkstar /analysis/estimation/run (CohortMethod PS matching + calibration)…');
+            $raw = $rService->runEstimation($spec);
+        }
         if (($raw['status'] ?? null) === 'error') {
             $this->error('  darkstar estimation error: '.($raw['message'] ?? 'unknown'));
 

--- a/backend/app/Services/RService.php
+++ b/backend/app/Services/RService.php
@@ -44,6 +44,25 @@ class RService
     }
 
     /**
+     * Run an overlap-weighted (ATO) population-level estimation. Returns the same
+     * normalized shape as runEstimation (estimates / propensity_score / calibration
+     * / covariate_balance) but with exact ATO overlap weights + a weighted Cox.
+     *
+     * @param  array<string, mixed>  $spec
+     * @return array<string, mixed>
+     */
+    public function runOverlapWeighting(array $spec): array
+    {
+        $response = Http::timeout($this->timeout)
+            ->post("{$this->baseUrl}/analysis/overlap-weighting/run", $spec);
+
+        return $response->json() ?? [
+            'status' => 'error',
+            'message' => 'Darkstar returned a non-JSON or empty response for overlap weighting (HTTP '.$response->status().').',
+        ];
+    }
+
+    /**
      * Empirically calibrate effect estimates against negative controls.
      *
      * @param  array<string, mixed>  $spec

--- a/darkstar/api/overlap_weighting.R
+++ b/darkstar/api/overlap_weighting.R
@@ -1,0 +1,247 @@
+# ──────────────────────────────────────────────────────────────────
+# Overlap Weighting (ATO) — exact overlap-weighted effect estimation
+# POST /analysis/overlap-weighting/run
+#
+# Reuses CohortMethod for data extraction + propensity scoring, then applies
+# ATO overlap weights (w = 1-e for treated, w = e for controls; Li-Morgan-
+# Zaslavsky) and a weighted Cox model. Returns the same normalized shape as
+# /analysis/estimation/run so the caller's mapping is unchanged. Negative-control
+# calibration reuses the shared compute_calibration helper.
+# ──────────────────────────────────────────────────────────────────
+
+library(CohortMethod)
+library(FeatureExtraction)
+library(DatabaseConnector)
+library(survival)
+source("/app/R/connection.R")
+source("/app/R/covariates.R")
+source("/app/R/progress.R")
+source("/app/R/results.R")
+source("/app/R/calibration.R")
+
+# ATO-weighted standardized mean differences, computed directly (CohortMethod's
+# computeCovariateBalance does not apply an arbitrary weights column). Covariates
+# from FeatureExtraction are ~all binary indicators, so SD = sqrt(p(1-p)). Returns
+# the top covariates by pre-weighting imbalance in the caller's balance shape.
+compute_ato_balance <- function(cmData, df) {
+  covs <- tryCatch(as.data.frame(dplyr::collect(cmData$covariates)), error = function(e) NULL)
+  if (is.null(covs) || nrow(covs) == 0) return(list())
+  covs <- covs[covs$rowId %in% df$rowId, , drop = FALSE]
+  if (nrow(covs) == 0) return(list())
+  info <- merge(covs, df[, c("rowId", "treatment", "ato_w")], by = "rowId")
+  # Restrict to binary indicator covariates (value == 1); continuous covariates
+  # (e.g. age) break the p(1-p) SMD formula and are reported as balanced-by-design.
+  info <- info[!is.na(info$covariateValue) & info$covariateValue == 1, , drop = FALSE]
+  if (nrow(info) == 0) return(list())
+  n1 <- sum(df$treatment == 1); n0 <- sum(df$treatment == 0)
+  W1 <- sum(df$ato_w[df$treatment == 1]); W0 <- sum(df$ato_w[df$treatment == 0])
+  if (n1 == 0 || n0 == 0 || W1 == 0 || W0 == 0) return(list())
+  info$wv <- info$ato_w * info$covariateValue
+  # Fast group sums via rowsum (C-level) keyed by "covariateId_treatment".
+  key <- paste0(info$covariateId, "_", info$treatment)
+  sv  <- rowsum(info$covariateValue, key)
+  swv <- rowsum(info$wv, key)
+  get <- function(m, k) if (k %in% rownames(m)) m[k, 1] else 0
+  covRef <- tryCatch(as.data.frame(dplyr::collect(cmData$covariateRef)), error = function(e) NULL)
+  name_of <- function(cid) {
+    if (!is.null(covRef) && "covariateName" %in% names(covRef)) {
+      nm <- covRef$covariateName[covRef$covariateId == cid]
+      if (length(nm) > 0) return(substr(as.character(nm[1]), 1, 120))
+    }
+    paste0("covariate ", cid)
+  }
+  out <- list()
+  for (cid in unique(info$covariateId)) {
+    k1 <- paste0(cid, "_1"); k0 <- paste0(cid, "_0")
+    p1u <- get(sv, k1) / n1;  p0u <- get(sv, k0) / n0
+    p1w <- get(swv, k1) / W1; p0w <- get(swv, k0) / W0
+    sdu <- sqrt((p1u * (1 - p1u) + p0u * (1 - p0u)) / 2)
+    sdw <- sqrt((p1w * (1 - p1w) + p0w * (1 - p0w)) / 2)
+    out[[length(out) + 1]] <- list(
+      covariate_name = name_of(cid),
+      smd_before = round(if (!is.na(sdu) && sdu > 0) (p1u - p0u) / sdu else 0, 4),
+      smd_after  = round(if (!is.na(sdw) && sdw > 0) (p1w - p0w) / sdw else 0, 4),
+      mean_target_before = round(p1u, 4), mean_comp_before = round(p0u, 4),
+      mean_target_after = round(p1w, 4), mean_comp_after = round(p0w, 4)
+    )
+  }
+  ord <- order(sapply(out, function(x) -abs(x$smd_before)))
+  out[ord[seq_len(min(60, length(out)))]]
+}
+
+#* Run overlap-weighted (ATO) population-level estimation
+#* @post /analysis/overlap-weighting/run
+#* @serializer unboxedJSON
+function(body, response) {
+  spec   <- body
+  logger <- create_analysis_logger()
+
+  if (is.null(spec)) {
+    response$status <- 400L
+    return(list(status = "error", message = "No specification provided in request body"))
+  }
+  missing <- setdiff(c("source", "cohorts", "model"), names(spec))
+  if (length(missing) > 0) {
+    response$status <- 400L
+    return(list(status = "error", message = paste("Missing required fields:", paste(missing, collapse = ", "))))
+  }
+
+  safe_execute(response, logger, {
+    connectionDetails <- create_hades_connection(spec$source)
+    connection <- connect_with_retry(connectionDetails)
+    on.exit(safe_disconnect(connection), add = TRUE)
+
+    cdmSchema     <- spec$source$cdm_schema
+    vocabSchema   <- spec$source$vocab_schema   %||% cdmSchema
+    resultsSchema <- spec$source$results_schema
+
+    targetId     <- as.integer(spec$cohorts$target_cohort_id)
+    comparatorId <- as.integer(spec$cohorts$comparator_cohort_id)
+    outcomeIds   <- as.integer(spec$cohorts$outcome_cohort_ids)
+    outcomeNames <- spec$cohorts$outcome_names %||% list()
+    ncOutcomeIds <- as.integer(spec$negative_control_outcomes %||% spec$negativeControlOutcomes %||% list())
+    extractOutcomeIds <- unique(c(outcomeIds, ncOutcomeIds))
+
+    covariateSettings <- build_covariate_settings(spec$covariate_settings)
+    dataArgs <- CohortMethod::createGetDbCohortMethodDataArgs(covariateSettings = covariateSettings)
+    logger$info("Extracting CohortMethod data (ATO)")
+    cmData <- CohortMethod::getDbCohortMethodData(
+      connectionDetails         = connectionDetails,
+      cdmDatabaseSchema         = cdmSchema,
+      targetId                  = targetId,
+      comparatorId              = comparatorId,
+      outcomeIds                = extractOutcomeIds,
+      exposureDatabaseSchema    = resultsSchema,
+      exposureTable             = "cohort",
+      outcomeDatabaseSchema     = resultsSchema,
+      outcomeTable              = "cohort",
+      getDbCohortMethodDataArgs = dataArgs
+    )
+
+    tar_start  <- as.integer(spec$model$time_at_risk_start %||% spec$model$timeAtRiskStart %||% 1)
+    tar_end    <- as.integer(spec$model$time_at_risk_end   %||% spec$model$timeAtRiskEnd   %||% 9999)
+    end_anchor <- spec$model$end_anchor %||% spec$model$endAnchor %||% "cohort end"
+
+    popArgs <- CohortMethod::createCreateStudyPopulationArgs(
+      removeSubjectsWithPriorOutcome = TRUE,
+      riskWindowStart = tar_start, startAnchor = "cohort start",
+      riskWindowEnd = tar_end, endAnchor = end_anchor, minDaysAtRisk = 1
+    )
+    psArgs <- CohortMethod::createCreatePsArgs(
+      maxCohortSizeForFitting = 250000, errorOnHighCorrelation = FALSE, stopOnError = FALSE
+    )
+
+    # Fit one ATO-weighted Cox for a given outcome id; returns the model + the
+    # PS object (for diagnostics) + the weighted population data frame.
+    ato_fit <- function(oid) {
+      pop <- CohortMethod::createStudyPopulation(
+        cohortMethodData = cmData, population = NULL, outcomeId = oid,
+        createStudyPopulationArgs = popArgs
+      )
+      pdf <- as.data.frame(pop)
+      if (sum(pdf$treatment == 1) < 10 || sum(pdf$treatment == 0) < 10) {
+        return(list(ok = FALSE, df = pdf))
+      }
+      ps <- CohortMethod::createPs(cohortMethodData = cmData, population = pop, createPsArgs = psArgs)
+      df <- as.data.frame(ps)
+      e  <- pmin(pmax(df$propensityScore, 1e-6), 1 - 1e-6)
+      df$ato_w <- ifelse(df$treatment == 1, 1 - e, e)
+      df$time  <- if ("survivalTime" %in% names(df)) df$survivalTime else df$timeAtRisk
+      df$event <- as.integer(df$outcomeCount > 0)
+      df <- df[!is.na(df$time) & df$time > 0, , drop = FALSE]
+      m <- tryCatch(
+        survival::coxph(survival::Surv(time, event) ~ treatment, data = df, weights = ato_w, robust = TRUE),
+        error = function(e) NULL
+      )
+      list(ok = TRUE, ps = ps, df = df, model = m)
+    }
+
+    estimates_list <- list()
+    ps_auc <- NA_real_; equipoise_val <- NA_real_; ps_dist_data <- NULL
+    balance_all <- NULL; n_target <- NA_integer_; n_comparator <- NA_integer_
+
+    for (oid in outcomeIds) {
+      logger$info(sprintf("ATO outcome %d", oid))
+      fit <- ato_fit(oid)
+      oname <- outcomeNames[[as.character(oid)]] %||% sprintf("Outcome %d", oid)
+      if (!isTRUE(fit$ok) || is.null(fit$model)) {
+        estimates_list[[length(estimates_list) + 1]] <- list(
+          outcome_id = oid, outcome_name = oname, hazard_ratio = NA, ci_95_lower = NA,
+          ci_95_upper = NA, p_value = NA, log_hr = NA, se_log_hr = NA,
+          target_outcomes = as.integer(sum(fit$df$outcomeCount[fit$df$treatment == 1] > 0)),
+          comparator_outcomes = as.integer(sum(fit$df$outcomeCount[fit$df$treatment == 0] > 0)),
+          warning = "Insufficient subjects or model did not converge"
+        )
+        next
+      }
+      df <- fit$df
+      if (is.na(ps_auc)) {
+        ps_auc        <- tryCatch(CohortMethod::computePsAuc(fit$ps), error = function(e) NA_real_)
+        equipoise_val <- tryCatch(CohortMethod::computeEquipoise(fit$ps), error = function(e) NA_real_)
+        ps_dist_data  <- tryCatch(extract_ps_distribution(fit$ps), error = function(e) NULL)
+        n_target      <- as.integer(sum(df$treatment == 1))
+        n_comparator  <- as.integer(sum(df$treatment == 0))
+        balance_all <- tryCatch(
+          compute_ato_balance(cmData, df),
+          error = function(e) { logger$warn(paste("ATO balance failed:", e$message)); list() }
+        )
+      }
+      cf  <- tryCatch(coef(fit$model)[["treatment"]], error = function(e) NA_real_)
+      se  <- tryCatch(sqrt(diag(vcov(fit$model)))[["treatment"]], error = function(e) NA_real_)
+      hr  <- exp(cf)
+      lo  <- exp(cf - 1.96 * se); hi <- exp(cf + 1.96 * se)
+      pv  <- if (!is.na(cf) && !is.na(se) && se > 0) 2 * pnorm(-abs(cf / se)) else NA_real_
+      estimates_list[[length(estimates_list) + 1]] <- list(
+        outcome_id = oid, outcome_name = oname,
+        hazard_ratio = round(hr, 4), ci_95_lower = round(lo, 4), ci_95_upper = round(hi, 4),
+        p_value = round(pv, 6), log_hr = round(cf, 4), se_log_hr = round(se, 4),
+        target_outcomes = as.integer(sum(df$event[df$treatment == 1])),
+        comparator_outcomes = as.integer(sum(df$event[df$treatment == 0]))
+      )
+      logger$info(sprintf("ATO outcome %d: HR=%.3f [%.3f, %.3f]", oid, hr, lo, hi))
+    }
+
+    # Negative controls (ATO-weighted Cox) for empirical calibration.
+    nc_estimates <- list()
+    for (nc_id in ncOutcomeIds) {
+      tryCatch({
+        fit <- ato_fit(nc_id)
+        if (isTRUE(fit$ok) && !is.null(fit$model)) {
+          cf <- coef(fit$model)[["treatment"]]
+          se <- sqrt(diag(vcov(fit$model)))[["treatment"]]
+          if (is.finite(cf) && is.finite(se)) {
+            nc_estimates[[length(nc_estimates) + 1]] <- list(
+              outcome_id = nc_id, log_rr = round(cf, 4), se_log_rr = round(se, 4)
+            )
+          }
+        }
+      }, error = function(e) logger$warn(sprintf("NC %d failed: %s", nc_id, e$message)))
+    }
+    calibration_data <- if (length(nc_estimates) > 0) {
+      tryCatch(compute_calibration(estimates_list, nc_estimates), error = function(e) NULL)
+    } else NULL
+
+    balance_summary <- if (is.null(balance_all)) list() else balance_all
+    max_smd_after <- if (length(balance_summary) > 0) {
+      round(max(sapply(balance_summary, function(x) abs(x$smd_after)), na.rm = TRUE), 4)
+    } else NA_real_
+    max_smd_before <- if (length(balance_summary) > 0) {
+      round(max(sapply(balance_summary, function(x) abs(x$smd_before)), na.rm = TRUE), 4)
+    } else NA_real_
+
+    list(
+      status  = "completed",
+      method  = "ATO overlap weighting (weighted Cox)",
+      summary = list(target_count = n_target, comparator_count = n_comparator, outcome_counts = list()),
+      estimates = estimates_list,
+      propensity_score = list(
+        auc = round(ps_auc, 4), equipoise = round(equipoise_val, 4),
+        max_smd_after = max_smd_after, max_smd_before = max_smd_before,
+        distribution = ps_dist_data
+      ),
+      calibration = calibration_data,
+      covariate_balance = balance_summary,
+      negative_controls = list(estimates = nc_estimates)
+    )
+  })
+}

--- a/darkstar/plumber_api.R
+++ b/darkstar/plumber_api.R
@@ -12,6 +12,7 @@ pa <- api(
   "/app/api/health.R",
   "/app/api/stubs.R",
   "/app/api/estimation.R",
+  "/app/api/overlap_weighting.R",
   "/app/api/calibration.R",
   "/app/api/prediction.R",
   "/app/api/sccs.R",

--- a/docker/r/Dockerfile
+++ b/docker/r/Dockerfile
@@ -118,6 +118,8 @@ RUN --mount=type=secret,id=github_pat,required=false \
   install.packages('fs'); \
   if (!requireNamespace('fs', quietly = TRUE)) stop('fs failed'); \
   install.packages(c('plumber2', 'mirai', 'nanonext', 'jsonlite', 'DBI', 'RPostgres', 'httr2', 'callr', 'processx', 'digest')); \
+  install.packages(c('sandwich', 'cobalt', 'WeightIt', 'PSweight')); \
+  if (!requireNamespace('WeightIt', quietly = TRUE)) stop('WeightIt failed'); \
   remotes::install_version('ParallelLogger', version = '3.5.1', repos = c('https://ohdsi.r-universe.dev', 'https://cloud.r-project.org')); \
   install.packages('rJava'); \
   Sys.setenv(MAKEFLAGS = '-j8'); \

--- a/docs/devlog/modules/studies/2026-07-05-htn-v5-real-execution-session.md
+++ b/docs/devlog/modules/studies/2026-07-05-htn-v5-real-execution-session.md
@@ -1,0 +1,181 @@
+# Hypertension Outcomes Program v5 — From Frontend Fixtures to a Fully Real, CDM-Executed Study
+
+**Date:** 2026-07-04 → 2026-07-05
+**Study:** `app.studies.id = 165`, slug `hypertension-study-v4`, `analysis_plan_version → v5.0`
+**Protocol:** ACUM-PROT-HTN-V5-001 (PI: Glenn H. Bock, MD · CMIO: Sanjay M. Udoshi, MD)
+**Source docs:** `docs/research/CLAUDE_PROMPT_v5.md`, `docs/research/CHANGELOG_v4_to_v5.md`
+**PRs:** #369, #370, #371, #372, #373, #374 (+ the ATO/WeightIt work in progress)
+
+---
+
+## 1. Executive summary
+
+The session began with a single request — *"surface all the results of V5 in the front end"* — and ended with the **entire Hypertension Outcomes Program v5 running against the live 1M-patient Acumenus OMOP CDM**, with all seven analyses (M, N, O, P, Q, R, triangulation) rendering real data in the React studies module and deployed to production.
+
+The arc had four phases:
+
+1. **Frontend surfacing pipeline** — a complete, reusable rendering layer for the v5 result taxonomy (7 per-analysis renderers, 2 new SVG chart primitives, an assembled "v5 Report" tab, a long-form table substrate), driven initially by a clearly-labelled demonstration fixture because **v5 had never actually been executed**.
+2. **Real descriptive analyses** — M (comorbidity matrix), N (BP distribution), Q (phenotype robustness) computed with careful, index-driven SQL over the CDM.
+3. **Real causal analyses** — O (overlap-weighted delay effect), P (target-trial emulation), R (instrumental variable), and their triangulation, run through the HADES R runtime (`darkstar`), all correctly **withheld** on positivity/overlap/instrument-strength grounds.
+4. **Exact-method refinement** — installing `WeightIt`/`PSweight` into `darkstar` and building a new ATO overlap-weighting endpoint so O uses its spec-primary estimand.
+
+The scientific through-line is honest and consistent: the **descriptive** analyses carry real, clinically-coherent findings; the **causal** delay contrast is **not identifiable** on this CDM, and each design fails independently and concordantly — which is itself the finding.
+
+---
+
+## 2. The pivotal discovery
+
+The v5 prompt reads as an executable spec (analyses A–R, result tables `results.htn_v4_*`, a lock step, a report). The natural assumption was that v5 had run and the job was to surface its rows. **It had not.** Probing the DB showed study 165 carried only its four **v4** results (`characterization`, `effect_estimate`×2, `incidence_rate`), zero `results.htn_v4_*` tables, and no M–R/triangulation rows anywhere.
+
+This reframed the task from *"display existing rows"* to *"build the surfacing pipeline **and** produce the data."* The responsible sequencing was: build the durable frontend capability first (works whenever real data lands), demonstrate it with a clearly-labelled fixture, then progressively replace every fixture with real CDM computation — which is exactly what happened over the session.
+
+---
+
+## 3. Phase 1 — the frontend surfacing pipeline (PR #369)
+
+**Design: three complementary layers, not one.**
+
+- **Layer 1 — extend the generic pipeline.** Taught `StudyResultSummary`'s `switch` seven new `result_type`s (`overlap_weighted_effect`, `target_trial`, `instrumental_variable`, `comorbidity_matrix`, `bp_distribution`, `phenotype_robustness`, `triangulation`), each dispatching to a dedicated renderer under `frontend/src/features/studies/components/v5/`.
+- **Layer 2 — long-form table substrate.** `results.htn_v4_*` tables + client-side CSV export from the already-loaded `summary_data` (the compact payloads carry the full arrays).
+- **Layer 3 — assembled "v5 Report" tab.** `StudyV5ReportTab` composes the triangulation headline + all designs + matrices + a derived **V&V acceptance matrix**, gated into the Evidence tab group and only shown for studies that carry a `triangulation` result.
+
+**Reuse-first.** The existing self-contained SVG chart components did the heavy lifting via small adapters (`v5/narrow.ts`, `v5/charts/chartAdapters.ts`) that fill the exact `EstimateEntry` / `CovariateBalanceEntry` / `KaplanMeierPoint` fields the charts require:
+
+| v5 need | Reused component |
+|---|---|
+| O / triangulation forests | `estimation/components/ForestPlot` |
+| O covariate balance | `estimation/components/LovePlot` |
+| P cumulative incidence | `estimation/components/KaplanMeierPlot` |
+| M prevalence heatmap | `data-explorer/components/charts/HeatmapChart` |
+
+Two net-new primitives were built for Analysis N: **`RidgelinePlot`** (KDE) and **`PairedArrowTrellis`** (t₁→t₂→t_dx), both dependency-free SVG.
+
+**Honesty by construction.** A `FixtureBanner` renders on every `_fixture:true` row; as each analysis became real, its view gained a green "Real CDM" note keyed on `summary_data.data_source === "cdm"`. Failed estimability gates render an explicit **withheld** state — never a blinded number.
+
+The fixture itself (`SeedHtnV5Fixture`, `study:seed-htn-v5-fixture`) was grounded in the real v4 baseline facts (T = 109,763; never-dx ≈ 90%; CKD HR ≈ 2.60; 37.9% coverage) so the demonstration was realistic, and shipped to production so the capability was verifiable end-to-end.
+
+---
+
+## 4. Phase 2 — real descriptive analyses (PRs #370, #374)
+
+### Analysis M — comorbidity comparison matrix
+`study:htn-v4 --action=analyses`. Real prevalence + **Wilson 95% CI** per morbidity × 6 populations (G1–G4, never-diagnosed, comparator C from `results.cohort`) × 2 epochs (pre-existing / newly-occurring vs the index date), from `results.cohort × omop.condition_occurrence`.
+
+- Concepts resolved from **verified** seed roots (4 existing `app.concept_sets` + 13 SNOMED roots confirmed against `vocab.concept`) via `concept_ancestor` descendant expansion — never guessed.
+- **Data-quality finding:** CAD was 0% everywhere under "Coronary arteriosclerosis" (317576) — this CDM codes it as **Ischemic heart disease (4185932)**, which shows the expected gradient (G1 10.1% → G3 16.7%). Morbidities zero across **all** populations are auto-flagged "not captured in this CDM" and excluded rather than shown as misleading zeros (aldosteronism, obesity-as-dx, PVD, hypertensive retinopathy — the CDM has only diabetic retinopathy and models no PVD).
+- Result: **13 reported morbidities × 6 populations × 2 epochs = 78 real rows.** Index-driven (`idx_co_concept_person`), ~5 s.
+
+### Analysis N — index (t2) BP distribution
+`study:htn-v4 --action=run-n` reads `results.htn_v4_n_bp_summary` (built by `scripts/sql/htn-v5-analysis-n-bp.sql` — a **~12-minute bounded scan of the 710M-row `measurement` table**, taking the reading nearest the index per member; SBP 3004249 / DBP 3012888). Real moments + percentiles + skewness/kurtosis per group × measure:
+
+- Diagnosed groups (G1–G4) ≈ **150/106 mmHg**; never-diagnosed ≈ **125/84**; normotensive comparator C ≈ **109/71**. The elevated-BP phenotype is unmistakable and real.
+- Ridgeline KDE is a Gaussian fit to the real mean/SD; t₁/t_dx trajectories are noted refinements (each a further measurement pass).
+
+### Analysis Q — phenotype robustness
+`study:htn-v4 --action=run-q`: real never-diagnosed fraction (**90.0%**, primary phenotype) + the visit-linked vs measurement-only split (`scripts/sql/htn-v5-analysis-q-visit-split.sql`, ~3 min). Two genuine findings:
+
+1. Never-diagnosed is **~90% in both strata** (89.9% measurement-only, 90.1% visit-linked) — the 90% headline is **not** a measurement-only data-feed artifact (disproving the spec's hypothesis).
+2. **MACE ascertainment differs ~3×** (visit-linked 11.7% vs measurement-only 3.8%) — outcomes get coded where there are encounters (the informative-visit signal).
+
+---
+
+## 5. Phase 3 — real causal analyses (PRs #371, #372, #373)
+
+### The `darkstar` correction
+An early conclusion — *"the R/HADES runtime is absent"* — was **wrong**: it was a search for the CLAUDE.md name `r-runtime`, but the actual service is **`darkstar`** (`http://darkstar:8787`, Plumber2, 40 HADES packages incl. CohortMethod / Cyclops / EmpiricalCalibration), and it was already running. `RService`/`EstimationService` already talk to it via `/analysis/estimation/run` (the same CohortMethod path v4 used).
+
+### Analysis O — overlap-weighted delay effect
+`study:htn-v4 --action=run-o`. Reuses the proven v4 delay-contrast design (`EstimationAnalysis` 64: PS + Cox + 8 negative controls) with a materialised **delayed comparator cohort** (`results.cohort` id **5456** = G2∪G3∪G4, additive). **Orientation matters:** the larger delayed group must be the target or CohortMethod throws "non-numeric argument to mathematical function". Result: **withheld** — max |SMD| 0.2434 ≥ 0.10 (equipoise 0.9535, EASE 0.033). This replaced the fixture's fabricated *estimable* HR 0.88 with the truthful withheld result.
+
+### Analysis P — target-trial emulation
+`study:htn-v4 --action=run-p`. Implemented as a **landmark new-user emulation** (index = the t2 + 90-day grace landmark, which structurally eliminates immortal-time bias) rather than a hand-written, error-prone clone-censor-weight + IPCW endpoint. Strategy cohorts (additive, `scripts/sql/htn-v5-estimation-cohorts.sql`): **5457** treated-within-grace (637) vs **5458** not (102,671), landmark-restricted to members alive & observed at the landmark. Run through the same CohortMethod pipeline. Result: **withheld** — PS AUC 0.913 ≥ 0.80 (treated vs untreated are near-perfectly separable → poor overlap).
+
+### Analysis R — site diagnostic-propensity instrumental variable
+`study:htn-v4 --action=run-r`. Built the member-grain instrument (`scripts/sql/htn-v5-analysis-r-instrument.sql`, as `claude_dev` since `parthenon_owner` can't read `omop`): each visit-linked T member assigned their most-recent-visit `care_site`, sites with ≥ 25 T patients get a leave-one-out timely-diagnosis propensity Z (**26,289 members, 521 sites, 37.9% coverage** — matches the spec). The decisive diagnostic is the first-stage F, computed via `regr_r2`: **timely-dx F ≈ 0.1, diagnosed-vs-never F ≈ 3.4 — both ≪ 10.** The instrument is too weak to interpret; the LATE is withheld and no second-stage 2SRI is warranted (it would be uninterpretable).
+
+### Triangulation
+`study:htn-v4 --action=run-triangulation` reads the persisted O/P/R and produces the honest headline: **0/3 designs estimable → "not estimable (concordant non-identifiability)."** The `TriangulationView` renders per-design gate status + reasons and only draws forests for estimable designs.
+
+### Gate-parity fix (critical)
+Mid-phase, a real bug surfaced: the gate **display** omitted the PS-AUC gate and used the covariate-balance SMD instead of `ps.max_smd_after`, so a contrast could read *all-green-but-withheld*. `runContrast` now mirrors `EstimationClearance::isCleared` **exactly**: `auc < 0.80 ∧ max_smd_after < 0.10 ∧ equipoise ≥ 0.30 ∧ calibration status = 'completed'`. The `GateBanner` shows PS AUC; the withheld reason names the actual failing gate (O: max |SMD|; P: PS AUC).
+
+---
+
+## 6. Phase 4 — WeightIt + exact ATO overlap weighting
+
+To honour Analysis O's spec-primary estimand (ATO overlap weighting, not PS matching):
+
+- **Installed `WeightIt` + `PSweight` + `cobalt` + `sandwich`** into the running `darkstar` container and **baked them into `docker/r/Dockerfile`** for durability.
+- **New endpoint `darkstar/api/overlap_weighting.R`** (`POST /analysis/overlap-weighting/run`, registered in `plumber_api.R`): reuses CohortMethod for data extraction + PS, then applies **exact ATO overlap weights** (w = 1−e treated, w = e control; Li–Morgan–Zaslavsky) + a weighted Cox (`survival::coxph`, robust SE) + the same negative-control calibration, returning the identical normalized shape the PHP layer already consumes. `RService::runOverlapWeighting()` + a `--method=ato` path in `runContrast` route O (and P's weighted refinement) through it.
+- **Two real R bugs found and fixed** in the balance computation: (1) the Andromeda-backed covariate table needs `dplyr::collect()`, not `as.data.frame()`; (2) the binary `p(1−p)` SMD formula produces `NaN` on the continuous age covariate — restricted to binary indicators + guarded the NA. `aggregate()` over ~1–2M covariate rows was replaced with C-level `rowsum`.
+
+**Result under exact ATO:** O's ATO-weighted max |SMD| improved from 0.2766 (unadjusted) to **0.2132**, but still did not clear the < 0.10 threshold across all covariates — the timely group (n = 139) is too small and separable for the sparse (Cyclops-regularised) PS to balance the full covariate set, so **O withholds under ATO as well**. **P was also re-run under exact ATO** (22 min — the endpoint ATO-adjusts each negative control, which is more rigorous than the base path's unadjusted NCs): its ATO-weighted balance improved (max |SMD| 0.0991 → 0.0845) but it still **withholds on PS AUC 0.913** — AUC is a property of the groups' separability, not the estimator. R has no valid completion beyond the weak-instrument finding. In short: **the exact methods were applied; the honest verdict is unchanged because the limitation is the data, not the estimator.**
+
+*Note:* the ATO endpoint re-fits the PS per outcome/negative-control (each has a distinct study population after `removeSubjectsWithPriorOutcome`), so large-cohort runs (P, ~100k) are slow but correct; caching the PS where populations coincide is a future optimisation. `WeightIt`/`PSweight` are installed in the running container and in the Dockerfile; the endpoint computes the ATO weights directly (equivalent, and robust against feeding CohortMethod's large-scale covariates through WeightIt).
+
+---
+
+## 7. Architecture & key decisions
+
+- **Data flow:** heavy CDM computations persist to `results.htn_v4_*` tables (built as `claude_dev`, since the runtime role `parthenon_app` has no DDL and `parthenon_owner` cannot read `omop`); the `study:htn-v4` command reads those tables + runs darkstar contrasts and writes curated `app.study_results` rows; the API serves them to the React views. Every heavy computation has a checked-in reproducibility SQL script under `scripts/sql/htn-v5-*.sql`.
+- **Fixture → real, per analysis:** each `study_results` row flips `_fixture` → `data_source: 'cdm'` independently, so the UI honestly shows a mixed state during the transition. No frontend rebuild is needed for data-only changes (the SPA reads the API at runtime).
+- **Non-destructive throughout:** all new cohorts/tables are additive (new `cohort_definition_id`s, new `results.htn_v4_*` tables); nothing in `omop`/`vocab` was modified; no production data was destroyed.
+
+---
+
+## 8. Data-quality & scientific findings (real, from the CDM)
+
+- **Concept coding is CDM-specific:** verified-by-name ≠ captures-this-data. CAD lives under Ischemic heart disease (4185932), not Coronary arteriosclerosis (317576). PVD and hypertensive retinopathy are simply not coded (Synthea-derived). These were surfaced by *running* the analysis, not assumed.
+- **The 90%-undiagnosed is real, not an artifact:** ~90% never-diagnosed in both the visit-linked and measurement-only strata.
+- **Outcome ascertainment is encounter-dependent:** MACE is coded ~3× more often in visit-linked patients.
+- **The delay contrast is not identifiable:** O (residual imbalance, even under ATO), P (poor overlap, AUC 0.913), R (weak instrument, F 3.4) all fail independently and concordantly. The study's calibrated signal rests on the v4 **anchor** (elevated-vs-normotensive) contrast — exactly as the v5 spec anticipated, and empirically confirmed here.
+
+---
+
+## 9. Infrastructure notes / gotchas recorded
+
+- The HADES runtime is **`darkstar`**, not `r-runtime`; it has estimation/calibration/prediction/sccs endpoints; ATO required a net-new endpoint + `WeightIt`.
+- CohortMethod estimation requires the **larger** cohort as target (else "non-numeric argument").
+- `EstimationClearance` gate parity: `auc<0.80 ∧ max_smd_after<0.10 ∧ equipoise≥0.30 ∧ calibrated`.
+- `parthenon_owner` cannot read `omop` — CDM-reading result tables must be built as a superuser (`claude_dev`).
+- The 710M-row `measurement` table: unbounded `count(*)` over a concept times out; **bounded, index-driven, per-member** queries are tractable (~12 min for N).
+- Andromeda covariate tables need `dplyr::collect()`; binary-only SMD math needs guarding against continuous covariates.
+
+---
+
+## 10. Deliverables
+
+**Commands (`study:htn-v4` + fixture seeder):** `--action=analyses` (M), `run-n`, `run-q`, `run-o`, `run-p`, `run-r`, `run-triangulation`; `study:seed-htn-v5-fixture`.
+
+**darkstar:** `api/overlap_weighting.R` (new ATO endpoint) + `WeightIt`/`PSweight`/`cobalt`/`sandwich` in `docker/r/Dockerfile`.
+
+**Backend:** `StudyHtnV4` command, `SeedHtnV5Fixture`, `RService::runOverlapWeighting`, `StudyResultProjector` awareness.
+
+**Frontend (`components/v5/`):** 7 renderers, `StudyV5ReportTab`, `VvAcceptanceMatrix`, `RidgelinePlot`, `PairedArrowTrellis`, adapters, real-CDM notes.
+
+**Reproducibility SQL (`scripts/sql/`):** `htn-v5-fixture-tables.sql`, `htn-v5-estimation-cohorts.sql`, `htn-v5-analysis-r-instrument.sql`, `htn-v5-analysis-n-bp.sql`, `htn-v5-analysis-q-visit-split.sql`.
+
+---
+
+## 11. Final state — all seven analyses real, in production
+
+| # | Analysis | Type | Result |
+|---|---|---|---|
+| M | Comorbidity matrix | descriptive | Real — 13 morbidities × 6 populations (4 not-captured, excluded) |
+| N | BP distribution (index) | descriptive | Real — SBP/DBP moments per group (elevated ≈150/106 vs comparator ≈109/71) |
+| Q | Phenotype robustness | descriptive | Real — never-dx 90.0%; ascertainment 3× by visit-linkage |
+| O | Overlap-weighted delay effect | causal | Real — **withheld** (exact ATO; max\|SMD\| 0.21) |
+| P | Target-trial (landmark) | causal | Real — **withheld** (PS AUC 0.913) |
+| R | Instrumental variable | causal | Real — **weak instrument** (F 3.4) |
+| — | Triangulation | causal | Real — **concordant non-identifiability** |
+
+---
+
+## 12. Remaining refinements (all additive, all clearly labelled in-UI)
+
+- **N:** t₁ and t_dx trajectories (further bounded measurement passes) to populate the paired-arrow trellis with real data.
+- **Q:** the full index-rule × threshold × max-gap grid (phenotype re-materialisation) and E-values (which need an estimable O/P effect — currently withheld).
+- **O/P:** exact ATO balance is computed over all extracted covariates; a PS-model-restricted balance would report the Li–Morgan–Zaslavsky exact-balance property directly. Full time-varying clone-censor-weight + IPCW for P remains the ultimate P refinement.
+- **R:** no valid completion exists on this CDM — the instrument is genuinely too weak (F < 10); the honest ceiling is the weak-instrument report.
+
+The scientific conclusion is stable and would not change with these refinements: **on this CDM the timely-vs-delayed contrast is not identifiable, and that concordant non-identifiability — established across ATO weighting, target-trial emulation, and instrumental variables — is the study's real finding.**


### PR DESCRIPTION
Completes the causal-methods refinement: O now uses its **spec-primary estimand** (ATO overlap weighting) rather than PS matching.

**New darkstar endpoint** `/analysis/overlap-weighting/run` (`darkstar/api/overlap_weighting.R`): CohortMethod data + PS → exact ATO overlap weights (Li–Morgan–Zaslavsky) → weighted Cox + ATO-adjusted negative-control calibration → same normalized shape. `WeightIt`/`PSweight`/`cobalt`/`sandwich` added to the running container + `docker/r/Dockerfile`. Weighted balance computed directly (CohortMethod ignores an arbitrary weights column): `dplyr::collect` the Andromeda covariates + C-level `rowsum` on binary indicators.

**Honest result — verdict unchanged (the limit is the data, not the estimator):**
- O: ATO improves max\|SMD\| 0.2766→0.2132, still ≥0.10 → withheld (timely n=139 too small/separable).
- P: ATO improves max\|SMD\| 0.0991→0.0845, withholds on PS AUC 0.913 (overlap; method-independent).
- R: weak instrument (F 3.4) — no valid completion on this CDM.
- Triangulation: concordant non-identifiability.

Includes the comprehensive session devlog. All 7 v5 analyses now real CDM.

- [x] Pint + PHPStan L8; `docker compose config` valid; darkstar endpoint live + verified. No frontend change.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)